### PR TITLE
chore: changed display text to others for explore

### DIFF
--- a/projects/observability/src/shared/dashboard/data/graphql/explore/explore-result.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/explore/explore-result.test.ts
@@ -117,7 +117,7 @@ describe('Explore result', () => {
 
     expect(result.getGroupedSeriesData(['group'], 'foo', MetricAggregationType.Sum)).toEqual([
       { keys: ['first'], value: 10 },
-      { keys: ['Other results'], value: 15 }
+      { keys: ['Others'], value: 15 }
     ]);
   });
 

--- a/projects/observability/src/shared/dashboard/data/graphql/explore/explore-result.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/explore/explore-result.ts
@@ -11,7 +11,7 @@ import {
 
 export class ExploreResult {
   private static readonly OTHER_SERVER_GROUP_NAME: string = '__Other';
-  private static readonly OTHER_UI_GROUP_NAME: string = 'Other results';
+  public static readonly OTHER_UI_GROUP_NAME: string = 'Others';
 
   private readonly specBuilder: ExploreSpecificationBuilder = new ExploreSpecificationBuilder();
 


### PR DESCRIPTION
Made the access modifier as public, so that the "Others" name is accessible publically, to perform a conditional sorting on series based on name

