### PR TITLE
feat: update metric widgets on home dash

### DIFF
--- a/src/app/home/home.dashboard.ts
+++ b/src/app/home/home.dashboard.ts
@@ -153,6 +153,7 @@ export const homeDashboard: DashboardDefaultConfiguration = {
           {
             type: 'metric-display-widget',
             title: 'p99 Latency',
+            subscript: 'ms',
             'title-position': TitlePosition.Footer,
             data: {
               type: 'trace-metric-aggregation-data-source',
@@ -165,7 +166,8 @@ export const homeDashboard: DashboardDefaultConfiguration = {
           },
           {
             type: 'metric-display-widget',
-            title: 'Avg. Latency',
+            title: 'p50 Latency',
+            subscript: 'ms',
             'title-position': TitlePosition.Footer,
             data: {
               type: 'trace-metric-aggregation-data-source',

--- a/src/app/home/home.dashboard.ts
+++ b/src/app/home/home.dashboard.ts
@@ -152,40 +152,27 @@ export const homeDashboard: DashboardDefaultConfiguration = {
         children: [
           {
             type: 'metric-display-widget',
-            title: 'Total Calls',
+            title: 'p99 Latency',
             'title-position': TitlePosition.Footer,
             data: {
               type: 'trace-metric-aggregation-data-source',
               metric: {
                 type: 'explore-selection',
-                metric: 'calls',
-                aggregation: MetricAggregationType.Sum
+                metric: 'duration',
+                aggregation: MetricAggregationType.P99
               }
             }
           },
           {
             type: 'metric-display-widget',
-            title: 'Calls/Second',
+            title: 'Avg. Latency',
             'title-position': TitlePosition.Footer,
             data: {
               type: 'trace-metric-aggregation-data-source',
               metric: {
                 type: 'explore-selection',
-                metric: 'calls',
-                aggregation: MetricAggregationType.AvgrateSecond
-              }
-            }
-          },
-          {
-            type: 'metric-display-widget',
-            title: 'Total Errors',
-            'title-position': TitlePosition.Footer,
-            data: {
-              type: 'trace-metric-aggregation-data-source',
-              metric: {
-                type: 'explore-selection',
-                metric: 'errorCount',
-                aggregation: MetricAggregationType.Sum
+                metric: 'duration',
+                aggregation: MetricAggregationType.P50
               }
             }
           },
@@ -198,6 +185,19 @@ export const homeDashboard: DashboardDefaultConfiguration = {
               metric: {
                 type: 'explore-selection',
                 metric: 'errorCount',
+                aggregation: MetricAggregationType.AvgrateSecond
+              }
+            }
+          },
+          {
+            type: 'metric-display-widget',
+            title: 'Calls/Second',
+            'title-position': TitlePosition.Footer,
+            data: {
+              type: 'trace-metric-aggregation-data-source',
+              metric: {
+                type: 'explore-selection',
+                metric: 'calls',
                 aggregation: MetricAggregationType.AvgrateSecond
               }
             }


### PR DESCRIPTION
Update metric widgets on home dash.

1. Change order of errors/second & calls/second widgets.
2. Add average latency and p99 latency widgets.