### PR TITLE
fix(gauge-list): rows outside container getting squeezed

### DIFF
--- a/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
+++ b/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
@@ -2,7 +2,7 @@
 @import 'font';
 
 .gauge-list {
-  height: 100%;
+  min-height: 100%;
   width: 100%;
   display: grid;
   margin-top: 16px;


### PR DESCRIPTION
The rows in the gauge list were getting squeezed if the rows lie outside the parent container. Scrolling the gauge list displays squeezed rows

Before
<img width="392" alt="Screen Shot 2020-09-04 at 7 28 12 PM" src="https://user-images.githubusercontent.com/48863181/92247379-cb5c4f00-eee4-11ea-971d-fbc22a009792.png">

After
<img width="405" alt="Screen Shot 2020-09-04 at 7 26 47 PM" src="https://user-images.githubusercontent.com/48863181/92247398-d0b99980-eee4-11ea-936c-98bed267a212.png">
