### PR TITLE
fix(gauge-list): rows outside container getting squeezed

### DIFF
--- a/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
+++ b/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
@@ -7,7 +7,7 @@
   display: grid;
   margin-top: 16px;
   grid-template-columns: minmax(60px, auto) minmax(80px, 160px) max-content;
-  grid-auto-rows: 22px;
+  grid-auto-rows: 20px;
   column-gap: 16px;
   align-items: center;
 

--- a/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
+++ b/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
@@ -2,7 +2,7 @@
 @import 'font';
 
 .gauge-list {
-  height: 100%;
+  min-height: 100%;
   width: 100%;
   display: grid;
   margin-top: 16px;

--- a/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
+++ b/projects/observability/src/shared/components/gauge-list/gauge-list.component.scss
@@ -2,12 +2,12 @@
 @import 'font';
 
 .gauge-list {
-  min-height: 100%;
+  height: 100%;
   width: 100%;
   display: grid;
   margin-top: 16px;
   grid-template-columns: minmax(60px, auto) minmax(80px, 160px) max-content;
-  grid-template-rows: repeat(auto-fill, 1px 40px);
+  grid-auto-rows: 22px;
   column-gap: 16px;
   align-items: center;
 


### PR DESCRIPTION
The rows in the gauge list were getting squeezed if the rows lie outside the parent container. Scrolling the gauge list displays squeezed rows

Before
<img width="392" alt="Screen Shot 2020-09-04 at 7 28 12 PM" src="https://user-images.githubusercontent.com/48863181/92249016-19725200-eee7-11ea-9463-941eefbfd293.png">

After
<img width="405" alt="Screen Shot 2020-09-04 at 7 26 47 PM" src="https://user-images.githubusercontent.com/48863181/92249038-1f683300-eee7-11ea-97f7-e459489f06f6.png">

