### PR TITLE
fix: displayMode to control triggerLabel behaviour in multi-select

### DIFF
--- a/projects/components/src/multi-select/multi-select.component.test.ts
+++ b/projects/components/src/multi-select/multi-select.component.test.ts
@@ -6,7 +6,7 @@ import { LabelComponent } from '../label/label.component';
 import { LetAsyncModule } from '../let-async/let-async.module';
 import { SelectJustify } from '../select/select-justify';
 import { SelectOptionComponent } from '../select/select-option.component';
-import { MultiSelectComponent } from './multi-select.component';
+import { MultiSelectComponent, TriggerLabelDisplayMode } from './multi-select.component';
 
 describe('Multi Select Component', () => {
   const hostFactory = createHostFactory<MultiSelectComponent<string>>({
@@ -115,6 +115,38 @@ describe('Multi Select Component', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith([selectionOptions[1].value, selectionOptions[2].value]);
     expect(spectator.query(LabelComponent)?.label).toEqual('second and 1 more');
+    flush();
+  }));
+
+  test('should notify but not change trigger label if triggerLabelDisplayMode is placeholder', fakeAsync(() => {
+    const onChange = jest.fn();
+
+    spectator = hostFactory(
+      `
+    <ht-multi-select [selected]="selected" (selectedChange)="onChange($event)" placeholder="Placeholder" [triggerLabelDisplayMode]="triggerDisplayMode">
+      <ht-select-option *ngFor="let option of options" [label]="option.label" [value]="option.value">
+      </ht-select-option>
+    </ht-multi-select>`,
+      {
+        hostProps: {
+          options: selectionOptions,
+          selected: [selectionOptions[1].value],
+          onChange: onChange,
+          triggerDisplayMode: TriggerLabelDisplayMode.Placeholder
+        }
+      }
+    );
+
+    spectator.tick();
+    expect(spectator.query(LabelComponent)?.label).toEqual('Placeholder');
+    spectator.click('.trigger-content');
+
+    const optionElements = spectator.queryAll('.multi-select-option', { root: true });
+    spectator.click(optionElements[2]);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith([selectionOptions[1].value, selectionOptions[2].value]);
+    expect(spectator.query(LabelComponent)?.label).toEqual('Placeholder');
     flush();
   }));
 

--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -114,7 +114,6 @@ export class MultiSelectComponent<V> implements AfterContentInit, OnChanges {
   }
 
   private setTriggerLabel(): void {
-    console.log(this.triggerLabelDisplayMode);
     if (this.triggerLabelDisplayMode === TriggerLabelDisplayMode.Placeholder) {
       this.triggerLabel = this.placeholder;
 

--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -79,6 +79,9 @@ export class MultiSelectComponent<V> implements AfterContentInit, OnChanges {
   @Input()
   public justify?: SelectJustify;
 
+  @Input()
+  public triggerLabelDisplayMode: TriggerLabelDisplayMode = TriggerLabelDisplayMode.Selection;
+
   @Output()
   public readonly selectedChange: EventEmitter<V[]> = new EventEmitter<V[]>();
 
@@ -111,6 +114,13 @@ export class MultiSelectComponent<V> implements AfterContentInit, OnChanges {
   }
 
   private setTriggerLabel(): void {
+    console.log(this.triggerLabelDisplayMode);
+    if (this.triggerLabelDisplayMode === TriggerLabelDisplayMode.Placeholder) {
+      this.triggerLabel = this.placeholder;
+
+      return;
+    }
+
     const selectedItems: SelectOptionComponent<V>[] | undefined = this.items?.filter(item => this.isSelectedItem(item));
     if (selectedItems === undefined || selectedItems.length === 0) {
       this.triggerLabel = this.placeholder;
@@ -156,4 +166,9 @@ export class MultiSelectComponent<V> implements AfterContentInit, OnChanges {
 
     return this.items.filter(item => this.isSelectedItem(item));
   }
+}
+
+export const enum TriggerLabelDisplayMode {
+  Placeholder = 'placeholder',
+  Selection = 'selection'
 }


### PR DESCRIPTION
Adding a triggerLabelDisplayMode input to multi-select that controls the behaviour of triggerLabel.
If its set to 'Placeholder', the label will always be the placeholder. If not, it'll show the selection summary as label.