### PR TITLE
feat: explorer filter on hover directive

### DIFF
--- a/projects/components/src/popover/popover-position-builder.ts
+++ b/projects/components/src/popover/popover-position-builder.ts
@@ -86,6 +86,11 @@ export class PopoverPositionBuilder {
         );
       case PopoverRelativePositionLocation.InsideTopLeft:
         return new ConnectionPositionPair({ originX: 'start', originY: 'top' }, { overlayX: 'start', overlayY: 'top' });
+      case PopoverRelativePositionLocation.InsideCenterRight:
+        return new ConnectionPositionPair(
+          { originX: 'end', originY: 'center' },
+          { overlayX: 'end', overlayY: 'center' }
+        );
       default:
         return assertUnreachable(location);
     }

--- a/projects/components/src/popover/popover.ts
+++ b/projects/components/src/popover/popover.ts
@@ -58,7 +58,8 @@ export const enum PopoverRelativePositionLocation {
   AboveLeftAligned,
   LeftCentered,
   RightCentered,
-  InsideTopLeft
+  InsideTopLeft,
+  InsideCenterRight
 }
 
 export const enum PopoverFixedPositionLocation {

--- a/projects/observability/src/pages/explorer/explorer-service.ts
+++ b/projects/observability/src/pages/explorer/explorer-service.ts
@@ -48,3 +48,8 @@ export class ExplorerService {
 }
 
 type DrilldownFilter = Omit<Filter, 'metadata' | 'userString' | 'urlString'>;
+
+export interface ExplorerFilterNavParams {
+  scopeQueryParam: ScopeQueryParam;
+  filters: DrilldownFilter[];
+}

--- a/projects/observability/src/public-api.ts
+++ b/projects/observability/src/public-api.ts
@@ -210,3 +210,6 @@ export * from './shared/dashboard/data/graphql/specifiers/entity-specification.m
 
 // Explorer service
 export * from './pages/explorer/explorer-service';
+
+// Explorer filter on hover
+export * from './shared/components/explorer-filter-on-hover/explorer-filter-on-hover.module';

--- a/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.component.scss
+++ b/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.component.scss
@@ -1,0 +1,21 @@
+@import 'color-palette';
+@import 'font';
+@import 'interaction';
+
+.hover-filter-container {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-right: -15px; //extending bounding box for overlay so that filter icon is outside of content
+
+  .filter-icon {
+    @include filter-box-shadow;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+      color: $blue-3;
+      cursor: pointer;
+      transform: scale(1.2);
+    }
+  }
+}

--- a/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.component.ts
+++ b/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { IconType } from '@hypertrace/assets-library';
+import { NavigationService } from '@hypertrace/common';
+import { IconSize, POPOVER_DATA } from '@hypertrace/components';
+import { ExplorerService } from '../../../pages/explorer/explorer-service';
+import { ExplorerFilterOnHoverData } from './explorer-filter-on-hover.directive';
+
+@Component({
+  selector: 'ht-explorer-filter-on-hover',
+  styleUrls: ['./explorer-filter-on-hover.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="hover-filter-container">
+    <ht-icon
+      class="filter-icon"
+      icon="${IconType.Filter}"
+      [size]="this.filterIconSIze"
+      (click)="this.goToExplorerWithFilters()"
+    ></ht-icon>
+  </div>`
+})
+export class ExplorerFilterOnHoverComponent {
+  public readonly filterIconSIze: IconSize;
+
+  public constructor(
+    @Inject(POPOVER_DATA) public readonly data: ExplorerFilterOnHoverData,
+    private readonly explorerService: ExplorerService,
+    private readonly navigationService: NavigationService
+  ) {
+    this.filterIconSIze = this.data.iconSize ?? IconSize.ExtraSmall;
+  }
+
+  public goToExplorerWithFilters(): void {
+    this.explorerService
+      .buildNavParamsWithFilters(this.data.scopeQueryParam, this.data.filters)
+      .subscribe(params => this.navigationService.navigate(params));
+  }
+}
+
+export interface FilterOnHoverData {
+  filterAction(): void;
+}

--- a/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.directive.ts
+++ b/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.directive.ts
@@ -1,0 +1,73 @@
+import { Directive, ElementRef, HostListener, Input } from '@angular/core';
+import {
+  IconSize,
+  PopoverPositionType,
+  PopoverRef,
+  PopoverRelativePositionLocation,
+  PopoverService
+} from '@hypertrace/components';
+import { Subject, Subscription } from 'rxjs';
+import { debounceTime, takeUntil } from 'rxjs/operators';
+import { ExplorerFilterNavParams } from '../../../pages/explorer/explorer-service';
+import { ExplorerFilterOnHoverComponent } from './explorer-filter-on-hover.component';
+
+@Directive({
+  selector: '[htExplorerFilterOnHover]'
+})
+export class ExplorerFilterOnHoverDirective {
+  private readonly mouseEnter$: Subject<MouseEvent> = new Subject();
+  private readonly mouseLeave$: Subject<MouseEvent> = new Subject();
+
+  private readonly subscriptions: Subscription = new Subscription();
+
+  private popover?: PopoverRef;
+
+  public constructor(private readonly popoverService: PopoverService, private readonly host: ElementRef) {
+    this.subscriptions.add(this.mouseLeave$.subscribe(() => this.removeActionableIcon()));
+  }
+
+  @Input('htExplorerFilterOnHover')
+  public filterParams?: ExplorerFilterOnHoverData;
+
+  @HostListener('mouseenter', ['$event'])
+  public onHover(event: MouseEvent): void {
+    this.subscriptions.add(
+      this.mouseEnter$.pipe(debounceTime(200), takeUntil(this.mouseLeave$)).subscribe(() => this.showActionableIcon())
+    );
+
+    this.mouseEnter$.next(event);
+  }
+
+  @HostListener('mouseleave', ['$event'])
+  public onHoverEnd(event: MouseEvent): void {
+    this.mouseLeave$.next(event);
+  }
+
+  public ngOnDestroy(): void {
+    this.removeActionableIcon();
+    this.subscriptions.unsubscribe();
+  }
+
+  private removeActionableIcon(): void {
+    if (this.popover) {
+      this.popover.close();
+      this.popover = undefined;
+    }
+  }
+
+  private showActionableIcon(): void {
+    this.popover = this.popoverService.drawPopover({
+      componentOrTemplate: ExplorerFilterOnHoverComponent,
+      data: this.filterParams,
+      position: {
+        type: PopoverPositionType.Relative,
+        origin: this.host,
+        locationPreferences: [PopoverRelativePositionLocation.InsideCenterRight]
+      }
+    });
+  }
+}
+
+export interface ExplorerFilterOnHoverData extends ExplorerFilterNavParams {
+  iconSize?: IconSize;
+}

--- a/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.module.ts
+++ b/projects/observability/src/shared/components/explorer-filter-on-hover/explorer-filter-on-hover.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { IconModule } from '@hypertrace/components';
+import { ExplorerFilterOnHoverComponent } from './explorer-filter-on-hover.component';
+import { ExplorerFilterOnHoverDirective } from './explorer-filter-on-hover.directive';
+
+@NgModule({
+  declarations: [ExplorerFilterOnHoverDirective, ExplorerFilterOnHoverComponent],
+  imports: [CommonModule, IconModule],
+  exports: [ExplorerFilterOnHoverDirective]
+})
+export class ExplorerFilterOnHoverModule {}


### PR DESCRIPTION
A directive that would show the filter icon on hover on the host element, that can be used to navigate to explorer filtered by that data.