### PR TITLE
fix: update layout trigger to emit on first layout

### DIFF
--- a/projects/components/src/layout/layout-change-trigger.directive.ts
+++ b/projects/components/src/layout/layout-change-trigger.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, Input, OnChanges } from '@angular/core';
-import { LayoutChangeService, TypedSimpleChanges } from '@hypertrace/common';
+import { LayoutChangeService } from '@hypertrace/common';
 
 @Directive({
   selector: '[htLayoutChangeTrigger]'
@@ -10,9 +10,7 @@ export class LayoutChangeTriggerDirective implements OnChanges {
   @Input('htLayoutChangeTrigger')
   public changeTrigger?: unknown;
 
-  public ngOnChanges(changeObject: TypedSimpleChanges<this>): void {
-    if (changeObject.changeTrigger && !changeObject.changeTrigger.isFirstChange()) {
-      setTimeout(() => this.layoutChange.publishLayoutChange());
-    }
+  public ngOnChanges(): void {
+    setTimeout(() => this.layoutChange.publishLayoutChange());
   }
 }


### PR DESCRIPTION
## Description
This change to layout triggering means a layout will be triggered on an initial render, in addition to the existing behavior of trigger on a render change. This is important as many visualizations depend on measuring their container to layout, which can't be accurately done until the parent has layed out.

### Testing
Manually verified that the layout sequence produces an accurate measurement. This isn't feasible to automate, as our tests don't run with a layed out dom.

### Checklist:
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
