### PR TITLE
fix(table): show visible columns for edit columns option

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -88,7 +88,7 @@ import { TableColumnConfigExtended, TableService } from './table.service';
                 [editable]="!this.isTreeType()"
                 [metadata]="this.metadata"
                 [columnConfig]="columnDef"
-                [availableColumns]="this.columnConfigs$ | async"
+                [availableColumns]="this.visibleColumnConfigs$ | async"
                 [index]="index"
                 [sort]="columnDef.sort"
                 (sortChange)="this.onSortChange($event, columnDef)"


### PR DESCRIPTION
## Description

Edit Columns option on the table used to show the entire set of columns, instead of just the visible columns. Fixed it to use the visible columns config

### Testing
Verified manually by deploying UI locally

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules