### PR TITLE
Fix expandable rows resetting columns

### DIFF
--- a/projects/components/src/table/cells/expanded-detail/table-expanded-detail-row-cell-renderer.component.ts
+++ b/projects/components/src/table/cells/expanded-detail/table-expanded-detail-row-cell-renderer.component.ts
@@ -14,7 +14,7 @@ import { StatefulTableRow } from '../../table-api';
     ])
   ],
   template: `
-    <div *ngIf="!!this.content" [class.expanded]="this.expanded" class="table-expanded-cell-renderer">
+    <div *ngIf="!!this.content && this.expanded" [class.expanded]="this.expanded" class="table-expanded-cell-renderer">
       <div [@rowExpand]="this.expanded ? 'expanded' : 'collapsed'" class="expandable-column-row">
         <ng-container *ngTemplateOutlet="this.content; context: { row: this.row }"></ng-container>
       </div>

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -22,7 +22,7 @@ import {
   NumberCoercer,
   TypedSimpleChanges
 } from '@hypertrace/common';
-import { without } from 'lodash-es';
+import { isEqual, without } from 'lodash-es';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { FilterAttribute } from '../filtering/filter/filter-attribute';
@@ -126,7 +126,6 @@ import { TableColumnConfigExtended, TableService } from './table.service';
           <ng-container *htLetAsync="this.columnConfigs$ as columnConfig">
             <cdk-cell *cdkCellDef="let row" [attr.colspan]="columnConfig.length" class="expanded-cell">
               <ht-table-expanded-detail-row-cell-renderer
-                *ngIf="this.isRowExpanded(row)"
                 [row]="row"
                 [expanded]="this.isRowExpanded(row)"
                 [content]="this.detailContent"
@@ -354,12 +353,15 @@ export class TableComponent
   }
 
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
+    console.info('ngOnChanges', changes);
     if (changes.display) {
       this.isTableFullPage = this.display === TableStyle.FullPage;
     }
 
-    if (changes.mode || changes.columnConfigs || changes.detailContent || changes.metadata) {
+    if (changes.mode || changes.detailContent || changes.metadata) {
       this.initializeColumns();
+    } else if (changes.columnConfigs) {
+      !isEqualIgnoreFunctions(changes.columnConfigs.previousValue, changes.columnConfigs.currentValue) && this.initializeColumns();
     }
 
     if (
@@ -601,7 +603,7 @@ export class TableComponent
   public toggleRowExpanded(row: StatefulTableRow): void {
     row.$$state.expanded = !row.$$state.expanded;
     this.rowStateSubject.next(row);
-    this.toggleRowChange.emit(row);
+    // this.toggleRowChange.emit(row);
     this.changeDetector.markForCheck();
   }
 

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -353,7 +353,6 @@ export class TableComponent
   }
 
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
-    console.info('ngOnChanges', changes);
     if (changes.display) {
       this.isTableFullPage = this.display === TableStyle.FullPage;
     }
@@ -361,7 +360,8 @@ export class TableComponent
     if (changes.mode || changes.detailContent || changes.metadata) {
       this.initializeColumns();
     } else if (changes.columnConfigs) {
-      !isEqualIgnoreFunctions(changes.columnConfigs.previousValue, changes.columnConfigs.currentValue) && this.initializeColumns();
+      !isEqualIgnoreFunctions(changes.columnConfigs.previousValue, changes.columnConfigs.currentValue) &&
+        this.initializeColumns();
     }
 
     if (
@@ -603,7 +603,7 @@ export class TableComponent
   public toggleRowExpanded(row: StatefulTableRow): void {
     row.$$state.expanded = !row.$$state.expanded;
     this.rowStateSubject.next(row);
-    // this.toggleRowChange.emit(row);
+    this.toggleRowChange.emit(row);
     this.changeDetector.markForCheck();
   }
 

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -22,7 +22,7 @@ import {
   NumberCoercer,
   TypedSimpleChanges
 } from '@hypertrace/common';
-import { isEqual, without } from 'lodash-es';
+import { without } from 'lodash-es';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { FilterAttribute } from '../filtering/filter/filter-attribute';

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -123,8 +123,8 @@ import { TableColumnConfigExtended, TableService } from './table.service';
 
         <!-- Expandable Detail Column -->
         <ng-container [cdkColumnDef]="this.expandedDetailColumnConfig.id" *ngIf="this.isDetailType()">
-          <ng-container *htLetAsync="this.columnConfigs$ as columnConfig">
-            <cdk-cell *cdkCellDef="let row" [attr.colspan]="columnConfig.length" class="expanded-cell">
+          <ng-container *htLetAsync="this.columnConfigs$ as columnConfigs">
+            <cdk-cell *cdkCellDef="let row" [attr.colspan]="columnConfigs.length" class="expanded-cell">
               <ht-table-expanded-detail-row-cell-renderer
                 [row]="row"
                 [expanded]="this.isRowExpanded(row)"
@@ -357,11 +357,8 @@ export class TableComponent
       this.isTableFullPage = this.display === TableStyle.FullPage;
     }
 
-    if (changes.mode || changes.detailContent || changes.metadata) {
+    if (changes.mode || changes.columnConfigs || changes.detailContent || changes.metadata) {
       this.initializeColumns();
-    } else if (changes.columnConfigs) {
-      !isEqualIgnoreFunctions(changes.columnConfigs.previousValue, changes.columnConfigs.currentValue) &&
-        this.initializeColumns();
     }
 
     if (

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -17,7 +17,7 @@ import { Renderer } from '@hypertrace/hyperdash';
 import { RendererApi, RENDERER_API } from '@hypertrace/hyperdash-angular';
 import { capitalize, isEmpty } from 'lodash-es';
 import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
-import { map, startWith, switchMap } from 'rxjs/operators';
+import { map, startWith, switchMap, tap } from 'rxjs/operators';
 import { AttributeMetadata, toFilterAttributeType } from '../../../graphql/model/metadata/attribute-metadata';
 import { MetadataService } from '../../../services/metadata/metadata.service';
 import { InteractionHandler } from '../../interaction/interaction-handler';
@@ -137,7 +137,10 @@ export class TableWidgetRendererComponent
   }
 
   private getColumnConfigs(): Observable<TableColumnConfig[]> {
-    return this.getScope().pipe(switchMap(scope => this.model.getColumns(scope)));
+    return this.getScope().pipe(
+      switchMap(scope => this.model.getColumns(scope)),
+      tap(columns => console.debug('columns', columns))
+    );
   }
 
   private getScopeAttributes(): Observable<FilterAttribute[]> {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -17,7 +17,7 @@ import { Renderer } from '@hypertrace/hyperdash';
 import { RendererApi, RENDERER_API } from '@hypertrace/hyperdash-angular';
 import { capitalize, isEmpty } from 'lodash-es';
 import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
-import { map, startWith, switchMap, tap } from 'rxjs/operators';
+import { map, startWith, switchMap } from 'rxjs/operators';
 import { AttributeMetadata, toFilterAttributeType } from '../../../graphql/model/metadata/attribute-metadata';
 import { MetadataService } from '../../../services/metadata/metadata.service';
 import { InteractionHandler } from '../../interaction/interaction-handler';
@@ -137,10 +137,7 @@ export class TableWidgetRendererComponent
   }
 
   private getColumnConfigs(): Observable<TableColumnConfig[]> {
-    return this.getScope().pipe(
-      switchMap(scope => this.model.getColumns(scope)),
-      tap(columns => console.debug('columns', columns))
-    );
+    return this.getScope().pipe(switchMap(scope => this.model.getColumns(scope)));
   }
 
   private getScopeAttributes(): Observable<FilterAttribute[]> {


### PR DESCRIPTION
## Description
The change to use columnConfig$ as an Observable in table widget renderer caused this. The async pipe passed to columnConfig input on table was causing change detection. Fixed by comparing the values of the array instead of the array reference itself to determine if columnConfigs changed and we should initalizeColumns()

### Testing
Tested against each of the table modes