### PR TITLE
fix: adding mock value for getAttributeKeyDisplayName

### DIFF
--- a/projects/dashboards/src/test/dashboard-verification.ts
+++ b/projects/dashboards/src/test/dashboard-verification.ts
@@ -46,7 +46,8 @@ export const mockDashboardProviders = [
     getAllValuesForQueryParameter: () => []
   }),
   mockProvider(MetadataService, {
-    getFilterAttributes: () => of([])
+    getFilterAttributes: () => of([]),
+    getAttributeKeyDisplayName: (_: string, attributeKey: string) => of(attributeKey)
   }),
   mockProvider(LoggerService, {
     warn: jest.fn().mockImplementation(fail),


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Table widget depends on getAttributeKeyDisplayName. When testing for a dashboard page with table, lots of errors are thrown on the table since the dashboardProviders bring a mock version of meta data service which has not implmentation for getAttributeKeyDisplayName. Due to this, the table fails at test run time, leading to errors and test failures

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
