### PR TITLE
fix: reduce default fetch limits for faster loads

### DIFF
--- a/projects/distributed-tracing/src/shared/dashboard/data/graphql/table/spans/spans-table-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/data/graphql/table/spans/spans-table-data-source.model.ts
@@ -26,7 +26,7 @@ export class SpansTableDataSourceModel extends TableDataSourceModel {
     return {
       requestType: SPANS_GQL_REQUEST,
       properties: request.columns.map(column => column.specification),
-      limit: request.position.limit * 10, // Prefetch 10 pages
+      limit: request.position.limit * 2, // Prefetch 2 pages
       offset: request.position.startIndex,
       sort: request.sort && {
         direction: request.sort.direction,

--- a/projects/distributed-tracing/src/shared/dashboard/data/graphql/table/traces/traces-table-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/data/graphql/table/traces/traces-table-data-source.model.ts
@@ -32,7 +32,7 @@ export class TracesTableDataSourceModel extends TableDataSourceModel {
       requestType: TRACES_GQL_REQUEST,
       traceType: this.traceType,
       properties: request.columns.map(column => column.specification),
-      limit: request.position.limit * 10, // Prefetch 10 pages
+      limit: request.position.limit * 2, // Prefetch 2 pages
       offset: request.position.startIndex,
       sort: request.sort && {
         direction: request.sort.direction,

--- a/projects/distributed-tracing/src/shared/dashboard/data/graphql/trace/traces-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/data/graphql/trace/traces-data-source.model.ts
@@ -33,7 +33,7 @@ export class TracesDataSourceModel extends GraphQlDataSourceModel<TracesResponse
       traceType: this.traceType,
       timeRange: this.getTimeRangeOrThrow(),
       properties: this.attributeSpecifications,
-      limit: 1000
+      limit: 100
     });
   }
 }

--- a/projects/observability/src/pages/explorer/explorer.component.test.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.test.ts
@@ -138,7 +138,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: EXPLORE_GQL_REQUEST,
         context: ObservabilityTraceType.Api,
-        limit: 10000,
+        limit: 500,
         interval: new TimeDuration(15, TimeUnit.Second)
       }),
       undefined
@@ -149,7 +149,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: TRACES_GQL_REQUEST,
         filters: [],
-        limit: 500
+        limit: 100
       }),
       undefined
     );
@@ -186,7 +186,7 @@ describe('Explorer component', () => {
         requestType: EXPLORE_GQL_REQUEST,
         context: ObservabilityTraceType.Api,
         filters: [new GraphQlFieldFilter('first', GraphQlOperatorType.Equals, 'foo')],
-        limit: 10000,
+        limit: 500,
         interval: new TimeDuration(15, TimeUnit.Second)
       }),
       undefined
@@ -197,7 +197,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: TRACES_GQL_REQUEST,
         filters: [new GraphQlFieldFilter('first', GraphQlOperatorType.Equals, 'foo')],
-        limit: 500
+        limit: 100
       }),
       undefined
     );
@@ -222,7 +222,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: EXPLORE_GQL_REQUEST,
         context: SPAN_SCOPE,
-        limit: 10000,
+        limit: 500,
         interval: new TimeDuration(15, TimeUnit.Second)
       }),
       undefined
@@ -233,7 +233,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: SPANS_GQL_REQUEST,
         filters: [],
-        limit: 500
+        limit: 100
       }),
       undefined
     );
@@ -274,7 +274,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: EXPLORE_GQL_REQUEST,
         context: SPAN_SCOPE,
-        limit: 10000,
+        limit: 500,
         interval: new TimeDuration(15, TimeUnit.Second),
         filters: [new GraphQlFieldFilter('first', GraphQlOperatorType.Equals, 'foo')]
       }),
@@ -285,7 +285,7 @@ describe('Explorer component', () => {
       2,
       expect.objectContaining({
         requestType: SPANS_GQL_REQUEST,
-        limit: 500,
+        limit: 100,
         filters: [new GraphQlFieldFilter('first', GraphQlOperatorType.Equals, 'foo')]
       }),
       undefined

--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
@@ -31,7 +31,7 @@ import { CartesianSeriesVisualizationType } from '../cartesian/chart';
 @Injectable()
 export class ExploreVisualizationBuilder implements OnDestroy {
   private static readonly DEFAULT_GROUP_LIMIT: number = 5;
-  private static readonly DEFAULT_UNGROUPED_LIMIT: number = 10000;
+  private static readonly DEFAULT_UNGROUPED_LIMIT: number = 500;
 
   public readonly visualizationRequest$: Observable<ExploreVisualizationRequest>;
   private readonly destroyed$: Subject<void> = new Subject();
@@ -193,7 +193,7 @@ export class ExploreVisualizationBuilder implements OnDestroy {
       requestType: TRACES_GQL_REQUEST,
       traceType: traceType,
       properties: specifications,
-      limit: 1000,
+      limit: 100,
       filters: filters && this.graphQlFilterBuilderService.buildGraphQlFilters(filters)
     };
   }
@@ -205,7 +205,7 @@ export class ExploreVisualizationBuilder implements OnDestroy {
     return {
       requestType: SPANS_GQL_REQUEST,
       properties: specifications,
-      limit: 1000,
+      limit: 100,
       filters: filters && this.graphQlFilterBuilderService.buildGraphQlFilters(filters)
     };
   }

--- a/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/entity/entity-table-data-source.model.ts
@@ -61,7 +61,7 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
       tableRequest: request,
       entityType: this.entityType,
       properties: request.columns.map(column => column.specification),
-      limit: this.limit !== undefined ? this.limit : request.position.limit * 10, // Prefetch 10 pages
+      limit: this.limit !== undefined ? this.limit : request.position.limit * 2, // Prefetch 2 pages
       offset: request.position.startIndex,
       sort: request.sort && {
         direction: request.sort.direction,
@@ -93,7 +93,7 @@ export class EntityTableDataSourceModel extends TableDataSourceModel {
       tableRequest: request,
       entityType: this.childEntityType!,
       properties: request.columns.map(column => column.specification).concat(...this.additionalChildSpecifications),
-      limit: 100, // Really no limit, putting one in for sanity
+      limit: 40, // Really no limit, putting one in for sanity
       sort: request.sort && {
         direction: request.sort.direction,
         key: request.sort.column.specification


### PR DESCRIPTION
## Description
Reduce the amount of data fetched. It's rare to page beyond the second page, so we can load it as needed.

### Testing
Updated unit tests to reflect new limits, verified UI locally

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
