### PR TITLE
fix: synchronize waterfall scrolling

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -100,7 +100,8 @@ import { TableColumnConfigExtended, TableService } from './table.service';
               *cdkCellDef="let row"
               [style.flex-basis]="columnDef.width"
               [style.max-width]="columnDef.width"
-              [style.margin-left]="index === 0 ? this.calcIndentMargin(row) : 0"
+              [style.margin-left]="index === 0 ? this.calcLeftMarginIndent(row) : 0"
+              [style.margin-right]="index === 1 ? this.calcRightMarginIndent(row, columnDef) : 0"
               [ngClass]="{
                 'detail-expanded': this.isDetailExpanded(row)
               }"
@@ -531,8 +532,17 @@ export class TableComponent
     this.hoveredChange.emit(this.hovered);
   }
 
-  public calcIndentMargin(row: StatefulTableRow): string {
+  public calcLeftMarginIndent(row: StatefulTableRow): string {
     return `${row.$$state.depth * 12}px`;
+  }
+
+  public calcRightMarginIndent(row: StatefulTableRow, column: TableColumnConfigExtended): string {
+    // A static width should be shifted over to account for left margin, a dynamic (flex) width does it intrinsically
+    if (column.width !== undefined && typeof column.width === 'string') {
+      return `-${row.$$state.depth * 12}px`;
+    }
+
+    return '0';
   }
 
   public columnIndex(columnConfig: TableColumnConfig, index: number): number {

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -101,10 +101,7 @@ import { TableColumnConfigExtended, TableService } from './table.service';
               [style.flex-basis]="columnDef.width"
               [style.max-width]="columnDef.width"
               [style.margin-left]="index === 0 ? this.calcIndentMargin(row) : 0"
-              [style.margin-right]="index === 1 ? this.calcIndentMargin(row, true) : 0"
               [ngClass]="{
-                'child-row': this.isChildRow(row),
-                'expander-column': this.isExpanderColumn(columnDef),
                 'detail-expanded': this.isDetailExpanded(row)
               }"
               class="data-cell"
@@ -534,8 +531,8 @@ export class TableComponent
     this.hoveredChange.emit(this.hovered);
   }
 
-  public calcIndentMargin(row: StatefulTableRow, negative: boolean = false): string {
-    return `${negative ? '-' : ''}${row.$$state.depth * 12}px`;
+  public calcIndentMargin(row: StatefulTableRow): string {
+    return `${row.$$state.depth * 12}px`;
   }
 
   public columnIndex(columnConfig: TableColumnConfig, index: number): number {
@@ -631,10 +628,6 @@ export class TableComponent
 
   public isHoveredRow(row: StatefulTableRow): boolean {
     return this.hovered !== undefined && TableCdkRowUtil.isEqualExceptState(row, this.hovered);
-  }
-
-  public isChildRow(row: StatefulTableRow): boolean {
-    return !!row.$$state.parent;
   }
 
   public isDetailType(): boolean {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.component.scss
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.component.scss
@@ -3,7 +3,7 @@
 
 :host {
   ::ng-deep {
-    .waterfall-chart .table.full-page {
+    .waterfall-chart .table {
       overflow: unset;
     }
   }


### PR DESCRIPTION
Closes: #411

## Description
Updates the waterfall to correctly synchronize table scrolling after table styling changed. Also fixed another bug around indented columns overlapping later columns

### Testing
Verified waterfall and a few other table screens.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
