### PR TITLE
fix: filter box input should be full width when no text

### DIFF
--- a/projects/components/src/combo-box/combo-box.component.ts
+++ b/projects/components/src/combo-box/combo-box.component.ts
@@ -297,8 +297,7 @@ export class ComboBoxComponent<TValue = string> implements AfterViewInit, OnChan
     // Calling setTimeout required to get proper measurement after DOM updates
     setTimeout(() => {
       // Add some pixels for input border, padding, etc
-      this.width =
-        this.text !== undefined ? `${(this.invisibleText.nativeElement.offsetWidth as number) + 6}px` : '100%';
+      this.width = !!this.text ? `${(this.invisibleText.nativeElement.offsetWidth as number) + 6}px` : '100%';
       this.changeDetectorRef.markForCheck(); // Yes, required
     });
   }

--- a/projects/components/src/combo-box/combo-box.component.ts
+++ b/projects/components/src/combo-box/combo-box.component.ts
@@ -298,7 +298,7 @@ export class ComboBoxComponent<TValue = string> implements AfterViewInit, OnChan
     setTimeout(() => {
       // Add 6 pixels for input border, padding, etc
       this.width =
-        this.text !== undefined && this.text !== null && this.text !== ''
+        this.text !== undefined && this.text !== ''
           ? `${(this.invisibleText.nativeElement.offsetWidth as number) + 6}px`
           : '100%';
       this.changeDetectorRef.markForCheck(); // Yes, required

--- a/projects/components/src/combo-box/combo-box.component.ts
+++ b/projects/components/src/combo-box/combo-box.component.ts
@@ -296,8 +296,11 @@ export class ComboBoxComponent<TValue = string> implements AfterViewInit, OnChan
 
     // Calling setTimeout required to get proper measurement after DOM updates
     setTimeout(() => {
-      // Add some pixels for input border, padding, etc
-      this.width = !!this.text ? `${(this.invisibleText.nativeElement.offsetWidth as number) + 6}px` : '100%';
+      // Add 6 pixels for input border, padding, etc
+      this.width =
+        this.text === undefined || this.text === null || this.text === ''
+          ? `${(this.invisibleText.nativeElement.offsetWidth as number) + 6}px`
+          : '100%';
       this.changeDetectorRef.markForCheck(); // Yes, required
     });
   }

--- a/projects/components/src/combo-box/combo-box.component.ts
+++ b/projects/components/src/combo-box/combo-box.component.ts
@@ -298,7 +298,7 @@ export class ComboBoxComponent<TValue = string> implements AfterViewInit, OnChan
     setTimeout(() => {
       // Add 6 pixels for input border, padding, etc
       this.width =
-        this.text === undefined || this.text === null || this.text === ''
+        this.text !== undefined && this.text !== null && this.text !== ''
           ? `${(this.invisibleText.nativeElement.offsetWidth as number) + 6}px`
           : '100%';
       this.changeDetectorRef.markForCheck(); // Yes, required


### PR DESCRIPTION
## Description
This fixes the input width for filterbox setting itself to a pixel value instead of 100% to now include when the text is an empty string. Previously we were only checking for undefined. This was causing issues if a user would clear out a filter and then try to repopulate it using the dropdown, but then switch to manual entry instead.