### PR TITLE
feat: divide trace data source into trace and api trace

### DIFF
--- a/projects/distributed-tracing/src/public-api.ts
+++ b/projects/distributed-tracing/src/public-api.ts
@@ -96,6 +96,7 @@ export { traceDetailDashboard } from './pages/trace-detail/trace-detail.dashboar
 export { TraceDetailPageComponent } from './pages/trace-detail/trace-detail.page.component';
 
 // Datasources
+export * from './shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model';
 export * from './shared/dashboard/widgets/span-detail/data/span-detail-data-source.model';
 export * from './shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model';
 

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.test.ts
@@ -79,7 +79,6 @@ describe('Trace detail data source model', () => {
         traceProperties: expect.arrayContaining([
           expect.objectContaining({ name: 'tags' }),
           expect.objectContaining({ name: 'traceId' }),
-          expect.objectContaining({ name: 'apiTraceId' }),
           expect.objectContaining({ name: 'statusCode' })
         ])
       })

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
@@ -1,5 +1,5 @@
 import { Model } from '@hypertrace/hyperdash';
-import { Trace } from '../../../../graphql/model/schema/trace';
+import { Trace, traceIdKey } from '../../../../graphql/model/schema/trace';
 
 import { TraceDetailData, TraceDetailDataSourceModel } from './trace-detail-data-source.model';
 
@@ -8,13 +8,14 @@ import { TraceDetailData, TraceDetailDataSourceModel } from './trace-detail-data
 })
 export class ApiTraceDetailDataSourceModel extends TraceDetailDataSourceModel {
   protected getTraceAttributes(): string[] {
-    return [...super.getTraceAttributes(), 'apiTraceId'];
+    return [...super.getTraceAttributes(), 'traceId'];
   }
 
   protected constructTraceDetailData(trace: Trace): ApiTraceDetailData {
     return {
       ...super.constructTraceDetailData(trace),
-      entrySpanId: trace.apiTraceId as string // Symbol('traceId') same as apiTraceId which is actually Entry Span ID
+      traceId: trace.traceId as string,  // For API Trace traceId is real Trace ID. NOT Symbol('traceId').
+      entrySpanId: trace[traceIdKey] // API Trace Symbol('traceId') same as apiTraceId which is actually Entry Span ID
     };
   }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
@@ -14,7 +14,7 @@ export class ApiTraceDetailDataSourceModel extends TraceDetailDataSourceModel {
   protected constructTraceDetailData(trace: Trace): ApiTraceDetailData {
     return {
       ...super.constructTraceDetailData(trace),
-      traceId: trace.traceId as string,  // For API Trace traceId is real Trace ID. NOT Symbol('traceId').
+      traceId: trace.traceId as string, // For API Trace traceId is real Trace ID. NOT Symbol('traceId').
       entrySpanId: trace[traceIdKey] // API Trace Symbol('traceId') same as apiTraceId which is actually Entry Span ID
     };
   }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
@@ -1,74 +1,24 @@
-import { Dictionary } from '@hypertrace/common';
-import { ARRAY_PROPERTY, Model, ModelProperty, PLAIN_OBJECT_PROPERTY } from '@hypertrace/hyperdash';
-import { EMPTY, Observable, of } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
-import { Trace, traceIdKey, traceTypeKey } from '../../../../graphql/model/schema/trace';
-import { SpecificationBuilder } from '../../../../graphql/request/builders/specification/specification-builder';
-import {
-  TraceGraphQlQueryHandlerService,
-  TRACE_GQL_REQUEST
-} from '../../../../graphql/request/handlers/traces/trace-graphql-query-handler.service';
-import { GraphQlDataSourceModel } from '../../../data/graphql/graphql-data-source.model';
+import { Model } from '@hypertrace/hyperdash';
+import { Trace } from '../../../../graphql/model/schema/trace';
+
+import { TraceDetailData, TraceDetailDataSourceModel } from './trace-detail-data-source.model';
 
 @Model({
   type: 'api-trace-detail-data-source'
 })
-export class ApiTraceDetailDataSourceModel extends GraphQlDataSourceModel<TraceDetailData> {
-  @ModelProperty({
-    key: 'trace',
-    required: true,
-    type: PLAIN_OBJECT_PROPERTY.type
-  })
-  public trace!: Trace;
-
-  @ModelProperty({
-    key: 'attributes',
-    type: ARRAY_PROPERTY.type
-  })
-  public attributes: string[] = [];
-
-  private readonly attributeSpecBuilder: SpecificationBuilder = new SpecificationBuilder();
-
-  public getData(): Observable<TraceDetailData> {
-    return this.query<TraceGraphQlQueryHandlerService>({
-      requestType: TRACE_GQL_REQUEST,
-      traceType: this.trace[traceTypeKey],
-      traceId: this.trace[traceIdKey],
-      spanLimit: 0,
-      timeRange: this.getTimeRangeOrThrow(),
-      traceProperties: this.getTraceAttributes().map(attribute =>
-        this.attributeSpecBuilder.attributeSpecificationForKey(attribute)
-      )
-    }).pipe(mergeMap(trace => this.mapResponseObject(trace)));
-  }
-
+export class ApiTraceDetailDataSourceModel extends TraceDetailDataSourceModel {
   protected getTraceAttributes(): string[] {
-    return ['tags', 'statusCode', 'traceId', 'apiTraceId', ...this.attributes];
+    return [...super.getTraceAttributes(), 'apiTraceId'];
   }
 
-  private mapResponseObject(trace: Trace | undefined): Observable<TraceDetailData> {
-    if (trace === undefined) {
-      return EMPTY;
-    }
-
-    return of(this.constructTraceDetailData(trace));
-  }
-
-  protected constructTraceDetailData(trace: Trace): TraceDetailData {
+  protected constructTraceDetailData(trace: Trace): ApiTraceDetailData {
     return {
-      traceId: trace.traceId as string, // The traceId is real Trace ID. NOT Symbol('traceId').
-      entrySpanId: trace.apiTraceId as string, // Symbol('traceId') same as apiTraceId which is actually Entry Span ID
-      statusCode: trace.statusCode as string,
-      tags: trace.tags as Dictionary<unknown>,
-      requestUrl: trace.requestUrl as string
+      ...super.constructTraceDetailData(trace),
+      entrySpanId: trace.apiTraceId as string // Symbol('traceId') same as apiTraceId which is actually Entry Span ID
     };
   }
 }
 
-export interface TraceDetailData {
-  traceId: string;
+export interface ApiTraceDetailData extends TraceDetailData {
   entrySpanId: string;
-  statusCode: string;
-  tags: Dictionary<unknown>;
-  requestUrl: string;
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.test.ts
@@ -78,9 +78,8 @@ describe('API Trace detail data source model', () => {
         timeRange: expect.objectContaining({ from: testTimeRange.startTime, to: testTimeRange.endTime }),
         traceProperties: expect.arrayContaining([
           expect.objectContaining({ name: 'tags' }),
-          expect.objectContaining({ name: 'traceId' }),
           expect.objectContaining({ name: 'statusCode' }),
-          expect.not.objectContaining({ name: 'apiTraceId' })
+          expect.not.objectContaining({ name: 'traceId' }),
         ])
       })
     );

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.test.ts
@@ -1,0 +1,88 @@
+import { ModelApi } from '@hypertrace/hyperdash';
+import { spanIdKey } from '../../../../graphql/model/schema/span';
+import { traceIdKey, traceTypeKey, TRACE_SCOPE } from '../../../../graphql/model/schema/trace';
+import {
+  TraceGraphQlQueryHandlerService,
+  TRACE_GQL_REQUEST
+} from '../../../../graphql/request/handlers/traces/trace-graphql-query-handler.service';
+import { ObservedGraphQlRequest } from '../../../data/graphql/graphql-query-event.service';
+import { ApiTraceDetailDataSourceModel } from './api-trace-detail-data-source.model';
+
+describe('API Trace detail data source model', () => {
+  const testTimeRange = { startTime: new Date(1568907645141), endTime: new Date(1568911245141) };
+  let model!: ApiTraceDetailDataSourceModel;
+  let emittedQueries: unknown;
+
+  beforeEach(() => {
+    const mockApi: Partial<ModelApi> = {
+      getTimeRange: jest.fn(() => testTimeRange)
+    };
+    model = new ApiTraceDetailDataSourceModel();
+    model.trace = {
+      [traceIdKey]: 'test',
+      [traceTypeKey]: TRACE_SCOPE
+    };
+    model.api = mockApi as ModelApi;
+    model.query$.subscribe((query: ObservedGraphQlRequest<TraceGraphQlQueryHandlerService>) => {
+      const request = query.buildRequest([]);
+      emittedQueries = request;
+
+      if (request.requestType === TRACE_GQL_REQUEST && request.traceType === TRACE_SCOPE) {
+        const responseObserver = query.responseObserver;
+        responseObserver.next({
+          test: 'test',
+          [traceIdKey]: 'test',
+          [traceTypeKey]: TRACE_SCOPE,
+          statusCode: '200',
+          tags: {},
+          requestUrl: 'test-url',
+          spans: [
+            {
+              test: 'test',
+              [spanIdKey]: 'test'
+            }
+          ]
+        });
+
+        responseObserver.complete();
+      } else {
+        const responseObserver = query.responseObserver;
+        responseObserver.next({
+          test: 'test',
+          [traceIdKey]: 'test',
+          [traceTypeKey]: TRACE_SCOPE,
+          statusCode: '200',
+          tags: {},
+          spans: [
+            {
+              test: 'test',
+              [spanIdKey]: 'test'
+            }
+          ]
+        });
+
+        responseObserver.complete();
+      }
+    });
+  });
+
+  test('builds expected request', () => {
+    const data$ = model.getData();
+    data$.subscribe();
+
+    expect(emittedQueries).toEqual(
+      expect.objectContaining({
+        requestType: TRACE_GQL_REQUEST,
+        traceId: 'test',
+        spanLimit: 0,
+        timeRange: expect.objectContaining({ from: testTimeRange.startTime, to: testTimeRange.endTime }),
+        traceProperties: expect.arrayContaining([
+          expect.objectContaining({ name: 'tags' }),
+          expect.objectContaining({ name: 'traceId' }),
+          expect.objectContaining({ name: 'statusCode' }),
+          expect.not.objectContaining({ name: 'apiTraceId' })
+        ])
+      })
+    );
+  });
+});

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.test.ts
@@ -79,7 +79,7 @@ describe('API Trace detail data source model', () => {
         traceProperties: expect.arrayContaining([
           expect.objectContaining({ name: 'tags' }),
           expect.objectContaining({ name: 'statusCode' }),
-          expect.not.objectContaining({ name: 'traceId' }),
+          expect.not.objectContaining({ name: 'traceId' })
         ])
       })
     );

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.ts
@@ -1,0 +1,72 @@
+import { Dictionary } from '@hypertrace/common';
+import { ARRAY_PROPERTY, Model, ModelProperty, PLAIN_OBJECT_PROPERTY } from '@hypertrace/hyperdash';
+import { EMPTY, Observable, of } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
+import { Trace, traceIdKey, traceTypeKey } from '../../../../graphql/model/schema/trace';
+import { SpecificationBuilder } from '../../../../graphql/request/builders/specification/specification-builder';
+import {
+  TraceGraphQlQueryHandlerService,
+  TRACE_GQL_REQUEST
+} from '../../../../graphql/request/handlers/traces/trace-graphql-query-handler.service';
+import { GraphQlDataSourceModel } from '../../../data/graphql/graphql-data-source.model';
+
+@Model({
+  type: 'trace-detail-data-source'
+})
+export class TraceDetailDataSourceModel extends GraphQlDataSourceModel<TraceDetailData> {
+  @ModelProperty({
+    key: 'trace',
+    required: true,
+    type: PLAIN_OBJECT_PROPERTY.type
+  })
+  public trace!: Trace;
+
+  @ModelProperty({
+    key: 'attributes',
+    type: ARRAY_PROPERTY.type
+  })
+  public attributes: string[] = [];
+
+  private readonly attributeSpecBuilder: SpecificationBuilder = new SpecificationBuilder();
+
+  public getData(): Observable<TraceDetailData> {
+    return this.query<TraceGraphQlQueryHandlerService>({
+      requestType: TRACE_GQL_REQUEST,
+      traceType: this.trace[traceTypeKey],
+      traceId: this.trace[traceIdKey],
+      spanLimit: 0,
+      timeRange: this.getTimeRangeOrThrow(),
+      traceProperties: this.getTraceAttributes().map(attribute =>
+        this.attributeSpecBuilder.attributeSpecificationForKey(attribute)
+      )
+    }).pipe(mergeMap(trace => this.mapResponseObject(trace)));
+  }
+
+  protected getTraceAttributes(): string[] {
+    return ['tags', 'statusCode', 'traceId', ...this.attributes];
+  }
+
+  private mapResponseObject(trace: Trace | undefined): Observable<TraceDetailData> {
+    if (trace === undefined) {
+      return EMPTY;
+    }
+
+    return of(this.constructTraceDetailData(trace));
+  }
+
+  protected constructTraceDetailData(trace: Trace): TraceDetailData {
+    return {
+      traceId: trace.traceId as string, // The traceId is real Trace ID. NOT Symbol('traceId').
+      statusCode: trace.statusCode as string,
+      tags: trace.tags as Dictionary<unknown>,
+      requestUrl: trace.requestUrl as string
+    };
+  }
+}
+
+export interface TraceDetailData {
+  traceId: string;
+  statusCode: string;
+  tags: Dictionary<unknown>;
+  requestUrl: string;
+}

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.ts
@@ -43,7 +43,7 @@ export class TraceDetailDataSourceModel extends GraphQlDataSourceModel<TraceDeta
   }
 
   protected getTraceAttributes(): string[] {
-    return ['tags', 'statusCode', 'traceId', ...this.attributes];
+    return ['tags', 'statusCode', ...this.attributes];
   }
 
   private mapResponseObject(trace: Trace | undefined): Observable<TraceDetailData> {
@@ -56,7 +56,7 @@ export class TraceDetailDataSourceModel extends GraphQlDataSourceModel<TraceDeta
 
   protected constructTraceDetailData(trace: Trace): TraceDetailData {
     return {
-      traceId: trace.traceId as string, // The traceId is real Trace ID. NOT Symbol('traceId').
+      traceId: trace[traceIdKey],
       statusCode: trace.statusCode as string,
       tags: trace.tags as Dictionary<unknown>,
       requestUrl: trace.requestUrl as string

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget-renderer.component.ts
@@ -3,7 +3,7 @@ import { IconType } from '@hypertrace/assets-library';
 import { WidgetRenderer } from '@hypertrace/dashboards';
 import { Renderer } from '@hypertrace/hyperdash';
 import { Observable } from 'rxjs';
-import { TraceDetailData } from './data/api-trace-detail-data-source.model';
+import { TraceDetailData } from './data/trace-detail-data-source.model';
 import { TraceDetailWidgetModel } from './trace-detail-widget.model';
 
 @Renderer({ modelClass: TraceDetailWidgetModel })

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget.model.ts
@@ -1,11 +1,11 @@
 import { Model, ModelApi, ModelProperty, STRING_PROPERTY } from '@hypertrace/hyperdash';
 import { ModelInject, MODEL_API } from '@hypertrace/hyperdash-angular';
 import { Observable } from 'rxjs';
-import { ApiTraceDetailDataSourceModel, TraceDetailData } from './data/api-trace-detail-data-source.model';
+import { TraceDetailData, TraceDetailDataSourceModel } from './data/trace-detail-data-source.model';
 
 @Model({
   type: 'trace-detail-widget',
-  supportedDataSourceTypes: [ApiTraceDetailDataSourceModel]
+  supportedDataSourceTypes: [TraceDetailDataSourceModel]
 })
 export class TraceDetailWidgetModel {
   @ModelProperty({

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget.model.ts
@@ -1,11 +1,12 @@
 import { Model, ModelApi, ModelProperty, STRING_PROPERTY } from '@hypertrace/hyperdash';
 import { ModelInject, MODEL_API } from '@hypertrace/hyperdash-angular';
 import { Observable } from 'rxjs';
+import { ApiTraceDetailData, ApiTraceDetailDataSourceModel } from './data/api-trace-detail-data-source.model';
 import { TraceDetailData, TraceDetailDataSourceModel } from './data/trace-detail-data-source.model';
 
 @Model({
   type: 'trace-detail-widget',
-  supportedDataSourceTypes: [TraceDetailDataSourceModel]
+  supportedDataSourceTypes: [TraceDetailDataSourceModel, ApiTraceDetailDataSourceModel]
 })
 export class TraceDetailWidgetModel {
   @ModelProperty({
@@ -17,7 +18,7 @@ export class TraceDetailWidgetModel {
   @ModelInject(MODEL_API)
   private readonly api!: ModelApi;
 
-  public getData(): Observable<TraceDetailData> {
-    return this.api.getData<TraceDetailData>();
+  public getData(): Observable<TraceDetailData | ApiTraceDetailData> {
+    return this.api.getData<TraceDetailData | ApiTraceDetailData>();
   }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget.module.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/trace-detail-widget.module.ts
@@ -4,6 +4,7 @@ import { LoadAsyncModule, SummaryValueModule, TitledContentModule } from '@hyper
 import { DashboardCoreModule } from '@hypertrace/hyperdash-angular';
 import { SpanDetailModule } from '../../../components/span-detail/span-detail.module';
 import { ApiTraceDetailDataSourceModel } from './data/api-trace-detail-data-source.model';
+import { TraceDetailDataSourceModel } from './data/trace-detail-data-source.model';
 import { TraceDetailWidgetRendererComponent } from './trace-detail-widget-renderer.component';
 import { TraceDetailWidgetModel } from './trace-detail-widget.model';
 
@@ -11,7 +12,7 @@ import { TraceDetailWidgetModel } from './trace-detail-widget.model';
   declarations: [TraceDetailWidgetRendererComponent],
   imports: [
     DashboardCoreModule.with({
-      models: [TraceDetailWidgetModel, ApiTraceDetailDataSourceModel],
+      models: [TraceDetailWidgetModel, TraceDetailDataSourceModel, ApiTraceDetailDataSourceModel],
       renderers: [TraceDetailWidgetRendererComponent]
     }),
     CommonModule,


### PR DESCRIPTION
## Description
Separate Trace and API Trace detail data sources so that Trace data source can be extended for other trace types.