### PR TITLE
fix: a number of table layout bugs

### DIFF
--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { SubscriptionLifecycle, TypedSimpleChanges } from '@hypertrace/common';
+import { isEmpty } from 'lodash-es';
 import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { ToggleItem } from '../../toggle-group/toggle-item';
@@ -11,7 +12,7 @@ import { TableMode } from '../table-api';
   providers: [SubscriptionLifecycle],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="table-controls">
+    <div class="table-controls" *ngIf="this.anyControlsEnabled">
       <!-- Filters -->
       <div class="filter-controls">
         <!-- Search -->
@@ -24,7 +25,7 @@ import { TableMode } from '../table-api';
 
         <!-- Filter Toggle -->
         <ht-toggle-group
-          *ngIf="this.filterItems?.length > 1"
+          *ngIf="this.filterItemsEnabled"
           class="control filter-toggle-group"
           [items]="this.filterItems"
           [activeItem]="this.activeFilterItem"
@@ -33,7 +34,7 @@ import { TableMode } from '../table-api';
 
         <!-- Checkbox Filter -->
         <ht-checkbox
-          *ngIf="this.checkboxLabel"
+          *ngIf="this.checkboxEnabled"
           class="control filter-checkbox"
           [label]="this.checkboxLabel"
           [checked]="this.checkboxChecked"
@@ -43,7 +44,7 @@ import { TableMode } from '../table-api';
 
       <!-- Mode Toggle -->
       <ht-toggle-group
-        *ngIf="this.modeItems?.length > 1"
+        *ngIf="this.modeToggleEnabled"
         class="control mode-toggle-group"
         [items]="this.modeItems"
         [activeItem]="this.activeModeItem"
@@ -89,6 +90,22 @@ export class TableControlsComponent implements OnChanges {
 
   @Output()
   public readonly modeChange: EventEmitter<TableMode> = new EventEmitter<TableMode>();
+
+  public get modeToggleEnabled(): boolean {
+    return !!this.modeItems && this.modeItems.length > 0;
+  }
+
+  public get checkboxEnabled(): boolean {
+    return !isEmpty(this.checkboxLabel);
+  }
+
+  public get filterItemsEnabled(): boolean {
+    return !!this.filterItems && this.filterItems.length > 0;
+  }
+
+  public get anyControlsEnabled(): boolean {
+    return this.modeToggleEnabled || this.checkboxEnabled || this.filterItemsEnabled || !!this.searchEnabled;
+  }
 
   private readonly searchDebounceSubject: Subject<string> = new Subject<string>();
 

--- a/projects/components/src/table/data/table-cdk-data-source.ts
+++ b/projects/components/src/table/data/table-cdk-data-source.ts
@@ -67,7 +67,12 @@ export class TableCdkDataSource implements DataSource<TableRow> {
     return this.rowsChange$.pipe(
       tap(rows => this.cacheRows(rows)),
       tap(rows => this.cacheFilterableValues(rows)),
-      tap(rows => this.loadingStateSubject.next({ loading$: of(rows), hide: rows.length > 0 }))
+      tap(rows => this.loadingStateSubject.next({ loading$: of(rows), hide: rows.length > 0 })),
+      catchError(error => {
+        this.loadingStateSubject.next({ loading$: throwError(error) });
+
+        return of([]);
+      })
     );
   }
 
@@ -265,12 +270,7 @@ export class TableCdkDataSource implements DataSource<TableRow> {
         this.rowStateChangeProvider.initialExpandAll && TableCdkRowUtil.isFullyExpandable(rows)
           ? TableCdkRowUtil.expandAllRows(rows)
           : rows
-      ),
-      catchError(error => {
-        this.loadingStateSubject.next({ loading$: throwError(error) });
-
-        return [];
-      })
+      )
     );
   }
 

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
@@ -1,14 +1,14 @@
-.table-widget-container {
-  display: flex;
+@import 'layout';
+
+.table-content-container {
+  @include flex-layout(column);
+}
+
+.table {
+  flex: 1 1;
   width: 100%;
-  height: 100%;
+}
 
-  .table {
-    flex: 1 1;
-    width: 100%;
-  }
-
-  .header-margin {
-    margin-top: 16px;
-  }
+.header-margin {
+  margin-top: 16px;
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -38,38 +38,39 @@ import { TableWidgetModel } from './table-widget.model';
       [title]="this.model.header?.title | htDisplayTitle"
       [link]="this.model.header?.link?.url"
       [linkLabel]="this.model.header?.link?.displayText"
-      class="table-widget-container"
     >
-      <ht-table-controls
-        class="table-controls"
-        [searchEnabled]="!!this.api.model.searchAttribute"
-        [filterItems]="this.filterItems"
-        [modeItems]="this.modeItems"
-        [checkboxLabel]="this.model.getCheckboxFilterOption()?.label"
-        [checkboxChecked]="this.model.getCheckboxFilterOption()?.checked"
-        (checkboxCheckedChange)="this.onCheckboxCheckedChange($event)"
-        (searchChange)="this.onSearchChange($event)"
-        (filterChange)="this.onFilterChange($event)"
-        (modeChange)="this.onModeChange($event)"
-      >
-      </ht-table-controls>
+      <div class="table-content-container">
+        <ht-table-controls
+          class="table-controls"
+          [searchEnabled]="!!this.api.model.searchAttribute"
+          [filterItems]="this.filterItems"
+          [modeItems]="this.modeItems"
+          [checkboxLabel]="this.model.getCheckboxFilterOption()?.label"
+          [checkboxChecked]="this.model.getCheckboxFilterOption()?.checked"
+          (checkboxCheckedChange)="this.onCheckboxCheckedChange($event)"
+          (searchChange)="this.onSearchChange($event)"
+          (filterChange)="this.onFilterChange($event)"
+          (modeChange)="this.onModeChange($event)"
+        >
+        </ht-table-controls>
 
-      <ht-table
-        class="table"
-        [ngClass]="{ 'header-margin': this.model.header?.topMargin }"
-        [columnConfigs]="this.columnConfigs$ | async"
-        [metadata]="this.metadata$ | async"
-        [mode]="this.activeMode"
-        [selectionMode]="this.model.getSelectionMode()"
-        [display]="this.model.style"
-        [data]="this.data$ | async"
-        [filters]="this.combinedFilters$ | async"
-        [pageable]="this.api.model.isPageable()"
-        [detailContent]="childDetail"
-        [syncWithUrl]="this.syncWithUrl"
-        (selectionsChange)="this.onRowSelection($event)"
-      >
-      </ht-table>
+        <ht-table
+          class="table"
+          [ngClass]="{ 'header-margin': this.model.header?.topMargin }"
+          [columnConfigs]="this.columnConfigs$ | async"
+          [metadata]="this.metadata$ | async"
+          [mode]="this.activeMode"
+          [selectionMode]="this.model.getSelectionMode()"
+          [display]="this.model.style"
+          [data]="this.data$ | async"
+          [filters]="this.combinedFilters$ | async"
+          [pageable]="this.api.model.isPageable()"
+          [detailContent]="childDetail"
+          [syncWithUrl]="this.syncWithUrl"
+          (selectionsChange)="this.onRowSelection($event)"
+        >
+        </ht-table>
+      </div>
     </ht-titled-content>
 
     <ng-template #childDetail let-row="row">

--- a/projects/observability/src/pages/explorer/explorer.component.scss
+++ b/projects/observability/src/pages/explorer/explorer.component.scss
@@ -3,7 +3,7 @@
 .explorer-container {
   display: flex;
   flex-direction: column;
-  padding: 24px;
+  padding: 24px 24px 0;
   height: calc(100% - 40px);
 
   .filter-bar {


### PR DESCRIPTION
## Description
This fixes a few different table layout bugs:
- Empty table controls are still using up space due to padding
- Error state doesn't clear previous data
- In full screen mode (entity lists), the last row of data is hidden underneath the footer
- In embedded mode (explorer), the pagination controls are clipped

### Testing
Beyond the unit tests, I visually verified the full and embedded table modes in error, no data and normal states.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
