### PR TITLE
feat: hide sort options in hover menu options if sortable is false

### DIFF
--- a/projects/components/src/table/header/table-header-cell-renderer.component.test.ts
+++ b/projects/components/src/table/header/table-header-cell-renderer.component.test.ts
@@ -77,7 +77,27 @@ describe('Table Header Cell Renderer', () => {
     expect(sortChange).toHaveBeenCalledWith(TableSortDirection.Ascending);
   }));
 
-  test('should show sort hover menu options only if the column is sortable', () => {
+  test('should show sort hover menu options if the column is sortable', () => {
+    const columnConfig: TableColumnConfigExtended = {
+      id: 'test-column',
+      renderer: TextTableCellRendererComponent,
+      parser: new TableCellStringParser(undefined!),
+      filterValues: [],
+      sortable: true
+    };
+
+    const spectator = createHost(undefined, {
+      hostProps: {
+        columnConfig: columnConfig
+      }
+    });
+
+    spectator.click('.options-button');
+    expect(spectator.query('.sort-ascending', { root: true })).toExist();
+    expect(spectator.query('.sort-descending', { root: true })).toExist();
+  });
+
+  test('should not show sort hover menu options if the column is not sortable', () => {
     const columnConfig: TableColumnConfigExtended = {
       id: 'test-column',
       renderer: TextTableCellRendererComponent,
@@ -92,6 +112,8 @@ describe('Table Header Cell Renderer', () => {
       }
     });
 
-    expect(spectator.query('.table-header-cell-renderer')).not.toHaveClass('sortable');
+    spectator.click('.options-button');
+    expect(spectator.query('.sort-ascending', { root: true })).not.toExist();
+    expect(spectator.query('.sort-descending', { root: true })).not.toExist();
   });
 });

--- a/projects/components/src/table/header/table-header-cell-renderer.component.test.ts
+++ b/projects/components/src/table/header/table-header-cell-renderer.component.test.ts
@@ -76,4 +76,22 @@ describe('Table Header Cell Renderer', () => {
     spectator.click(spectator.query('.title')!);
     expect(sortChange).toHaveBeenCalledWith(TableSortDirection.Ascending);
   }));
+
+  test('should show sort hover menu options only if the column is sortable', () => {
+    const columnConfig: TableColumnConfigExtended = {
+      id: 'test-column',
+      renderer: TextTableCellRendererComponent,
+      parser: new TableCellStringParser(undefined!),
+      filterValues: [],
+      sortable: false
+    };
+
+    const spectator = createHost(undefined, {
+      hostProps: {
+        columnConfig: columnConfig
+      }
+    });
+
+    expect(spectator.query('.table-header-cell-renderer')).not.toHaveClass('sortable');
+  });
 });

--- a/projects/components/src/table/header/table-header-cell-renderer.component.ts
+++ b/projects/components/src/table/header/table-header-cell-renderer.component.ts
@@ -42,26 +42,25 @@ import { TableColumnConfigExtended } from '../table.service';
           </ht-popover-trigger>
           <ht-popover-content>
             <div [style.min-width.px]="trigger.offsetWidth" class="popover-content">
-              <div class="popover-item" (click)="this.onFilterValues()" *ngIf="this.isFilterable">Filter Values</div>
-              <div class="popover-item-divider" *ngIf="this.isFilterable"></div>
-              <div
-                class="popover-item sort-ascending"
-                (click)="this.onSortChange(SORT_ASC)"
-                *ngIf="this.columnConfig.sortable"
-              >
-                Sort Ascending
-                <ht-icon class="popover-item-icon" icon="${IconType.ArrowUp}" size="${IconSize.Small}"></ht-icon>
-              </div>
-              <div
-                class="popover-item sort-descending"
-                (click)="this.onSortChange(SORT_DESC)"
-                *ngIf="this.columnConfig.sortable"
-              >
-                Sort Descending
-                <ht-icon class="popover-item-icon" icon="${IconType.ArrowDown}" size="${IconSize.Small}"></ht-icon>
-              </div>
-              <div class="popover-item-divider" *ngIf="this.editable"></div>
-              <div class="popover-item" (click)="this.onEditColumns()" *ngIf="this.editable">Edit Columns</div>
+              <ng-container *ngIf="this.isFilterable">
+                <div class="popover-item" (click)="this.onFilterValues()" *ngIf="this.isFilterable">Filter Values</div>
+                <div class="popover-item-divider"></div>
+              </ng-container>
+              <ng-container *ngIf="this.columnConfig.sortable !== false">
+                <div class="popover-item sort-ascending" (click)="this.onSortChange(SORT_ASC)">
+                  Sort Ascending
+                  <ht-icon class="popover-item-icon" icon="${IconType.ArrowUp}" size="${IconSize.Small}"></ht-icon>
+                </div>
+                <div class="popover-item sort-descending" (click)="this.onSortChange(SORT_DESC)">
+                  Sort Descending
+                  <ht-icon class="popover-item-icon" icon="${IconType.ArrowDown}" size="${IconSize.Small}"></ht-icon>
+                </div>
+                <div class="popover-item-divider"></div>
+              </ng-container>
+
+              <ng-container *ngIf="this.editable">
+                <div class="popover-item" (click)="this.onEditColumns()">Edit Columns</div>
+              </ng-container>
             </div>
           </ht-popover-content>
         </ht-popover>

--- a/projects/components/src/table/header/table-header-cell-renderer.component.ts
+++ b/projects/components/src/table/header/table-header-cell-renderer.component.ts
@@ -44,11 +44,19 @@ import { TableColumnConfigExtended } from '../table.service';
             <div [style.min-width.px]="trigger.offsetWidth" class="popover-content">
               <div class="popover-item" (click)="this.onFilterValues()" *ngIf="this.isFilterable">Filter Values</div>
               <div class="popover-item-divider" *ngIf="this.isFilterable"></div>
-              <div class="popover-item" (click)="this.onSortChange(SORT_ASC)">
+              <div
+                class="popover-item sort-ascending"
+                (click)="this.onSortChange(SORT_ASC)"
+                *ngIf="this.columnConfig.sortable"
+              >
                 Sort Ascending
                 <ht-icon class="popover-item-icon" icon="${IconType.ArrowUp}" size="${IconSize.Small}"></ht-icon>
               </div>
-              <div class="popover-item" (click)="this.onSortChange(SORT_DESC)">
+              <div
+                class="popover-item sort-descending"
+                (click)="this.onSortChange(SORT_DESC)"
+                *ngIf="this.columnConfig.sortable"
+              >
                 Sort Descending
                 <ht-icon class="popover-item-icon" icon="${IconType.ArrowDown}" size="${IconSize.Small}"></ht-icon>
               </div>

--- a/projects/components/src/table/header/table-header-cell-renderer.component.ts
+++ b/projects/components/src/table/header/table-header-cell-renderer.component.ts
@@ -44,7 +44,7 @@ import { TableColumnConfigExtended } from '../table.service';
             <div [style.min-width.px]="trigger.offsetWidth" class="popover-content">
               <ng-container *ngIf="this.isFilterable">
                 <div class="popover-item" (click)="this.onFilterValues()" *ngIf="this.isFilterable">Filter Values</div>
-                <div class="popover-item-divider"></div>
+                <div class="popover-item-divider" *ngIf="this.columnConfig.sortable !== false || this.editable"></div>
               </ng-container>
               <ng-container *ngIf="this.columnConfig.sortable !== false">
                 <div class="popover-item sort-ascending" (click)="this.onSortChange(SORT_ASC)">
@@ -55,7 +55,7 @@ import { TableColumnConfigExtended } from '../table.service';
                   Sort Descending
                   <ht-icon class="popover-item-icon" icon="${IconType.ArrowDown}" size="${IconSize.Small}"></ht-icon>
                 </div>
-                <div class="popover-item-divider"></div>
+                <div class="popover-item-divider" *ngIf="this.editable"></div>
               </ng-container>
 
               <ng-container *ngIf="this.editable">


### PR DESCRIPTION
## Description
Show sort related options in hover options menu only if sortable is true for the column.

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules