### PR TITLE
fixes release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,11 @@ workflows:
           context:
             - hypertrace-publishing
             - dockerhub-read
+          requires:
+            - build
+            - test
+            - lint
+            - validate-charts
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Description
While updating release workflow to `release-publish` and `merge-publish` in https://github.com/hypertrace/hypertrace-ui/pull/383 we missed adding this require step in `release-publish` which is blocking release of artifacts. 


### Testing
NA

### Checklist:
- [x] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
