### PR TITLE
Add tag based filter to circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,24 +143,49 @@ workflows:
       - npm-install-if-needed:
           context:
             - dockerhub-read
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^release-.*/
       - build:
           context:
             - dockerhub-read
           requires:
             - npm-install-if-needed
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^release-.*/
       - test:
           context:
             - dockerhub-read
           requires:
             - npm-install-if-needed
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^release-.*/
       - lint:
           context:
             - dockerhub-read
           requires:
             - npm-install-if-needed
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^release-.*/
       - validate-charts:
           context:
             - dockerhub-read
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              only: /^release-.*/
       - merge-publish:
           context:
             - hypertrace-publishing


### PR DESCRIPTION
Circleci is building based release tags. According to circleci documentation, we need to add tag based filter on the jobs on which workflow jobs are dependent.
https://circleci.com/docs/2.0/configuration-reference/#tags
