### PR TITLE
feat: adding icon only view mode

### DIFF
--- a/projects/observability/src/shared/components/label-detail/label-detail.component.scss
+++ b/projects/observability/src/shared/components/label-detail/label-detail.component.scss
@@ -33,8 +33,7 @@
 
 .popover-content {
   padding: 16px 16px 16px 4px;
-  min-width: 300px;
-  max-width: 600px;
+  width: 300px;
 
   display: flex;
   flex-direction: column;

--- a/projects/observability/src/shared/components/label-detail/label-detail.component.test.ts
+++ b/projects/observability/src/shared/components/label-detail/label-detail.component.test.ts
@@ -10,7 +10,7 @@ import {
 import { createHostFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { NEVER } from 'rxjs';
-import { LabelDetailComponent } from './label-detail.component';
+import { LabelDetailComponent, LabelDetailView } from './label-detail.component';
 
 describe('Label Detail Component', () => {
   let spectator: Spectator<LabelDetailComponent>;
@@ -27,7 +27,7 @@ describe('Label Detail Component', () => {
     ]
   });
 
-  test('should render all trigger contents', () => {
+  test('should render all trigger contents for default/with-label view mode', () => {
     spectator = createHost(
       `<ht-label-detail [icon]="icon" [label]="label" [description]="description" [additionalDetails]="additionalDetails"></ht-label-detail>`,
       {
@@ -56,6 +56,46 @@ describe('Label Detail Component', () => {
     spectator.detectChanges();
     expect(spectator.query('.detail-button')).not.toExist();
     expect(spectator.query('.label-icon')).toExist();
+
+    // Check if correct options are passed to Popover component
+    const popoverComponent = spectator.query(PopoverComponent);
+    expect(popoverComponent?.closeOnClick).toEqual(false);
+    expect(popoverComponent?.closeOnNavigate).toEqual(true);
+    expect(popoverComponent?.locationPreferences).toEqual(spectator.component.locationPreferences);
+  });
+
+  test('should render all trigger contents for Icon only mode', () => {
+    spectator = createHost(
+      `<ht-label-detail [icon]="icon" [label]="label" [description]="description" [additionalDetails]="additionalDetails" [view]="view"></ht-label-detail>`,
+      {
+        hostProps: {
+          icon: IconType.Add,
+          label: 'Impact',
+          description: 'This is a test description',
+          additionalDetails: ['Additional Detail 1', 'Additional Detail 2'],
+          view: LabelDetailView.IconOnly
+        }
+      }
+    );
+
+    expect(spectator.query('.label-detail-trigger')).toExist();
+    expect(spectator.query('.detail-button')).not.toExist();
+    expect(spectator.query('.label-icon')).toExist();
+    expect(spectator.query(LabelComponent)).not.toExist();
+
+    // On mouse enter, show detail button
+    spectator.dispatchMouseEvent('.label-detail-trigger', 'mouseenter');
+    spectator.detectChanges();
+    expect(spectator.query('.detail-button')).toExist();
+    expect(spectator.query('.label-icon')).not.toExist();
+    expect(spectator.query(LabelComponent)).not.toExist();
+
+    // On mouse leave, hide detail button
+    spectator.dispatchMouseEvent('.label-detail-trigger', 'mouseleave');
+    spectator.detectChanges();
+    expect(spectator.query('.detail-button')).not.toExist();
+    expect(spectator.query('.label-icon')).toExist();
+    expect(spectator.query(LabelComponent)).not.toExist();
 
     // Check if correct options are passed to Popover component
     const popoverComponent = spectator.query(PopoverComponent);

--- a/projects/observability/src/shared/components/label-detail/label-detail.component.ts
+++ b/projects/observability/src/shared/components/label-detail/label-detail.component.ts
@@ -35,6 +35,7 @@ import {
                 size="${ButtonSize.ExtraSmall}"
                 role="${ButtonRole.Tertiary}"
                 display="${ButtonStyle.Text}"
+                htTooltip="Show Details for {{ this.label }}"
               ></ht-button>
               <ht-icon
                 *ngIf="this.icon && !this.showdetailButton"
@@ -42,7 +43,11 @@ import {
                 [icon]="this.icon"
                 size="${IconSize.Small}"
               ></ht-icon>
-              <ht-label [label]="this.label" class="label"></ht-label>
+              <ht-label
+                [label]="this.label"
+                class="label"
+                *ngIf="this.view === '${LabelDetailView.WithLabel}'"
+              ></ht-label>
             </div>
           </ht-popover-trigger>
 
@@ -81,6 +86,9 @@ export class LabelDetailComponent {
   public label?: string;
 
   @Input()
+  public view?: LabelDetailView = LabelDetailView.WithLabel;
+
+  @Input()
   public description?: string;
 
   @Input()
@@ -99,4 +107,9 @@ export class LabelDetailComponent {
     this.popoverRef?.close();
     this.popoverRef = undefined;
   }
+}
+
+export const enum LabelDetailView {
+  IconOnly = 'icon-only',
+  WithLabel = 'with-label'
 }

--- a/projects/observability/src/shared/components/label-detail/label-detail.module.ts
+++ b/projects/observability/src/shared/components/label-detail/label-detail.module.ts
@@ -1,11 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ButtonModule, EventBlockerModule, IconModule, LabelModule, PopoverModule } from '@hypertrace/components';
+import {
+  ButtonModule,
+  EventBlockerModule,
+  IconModule,
+  LabelModule,
+  PopoverModule,
+  TooltipModule
+} from '@hypertrace/components';
 import { LabelDetailComponent } from './label-detail.component';
 
 @NgModule({
   declarations: [LabelDetailComponent],
   exports: [LabelDetailComponent],
-  imports: [CommonModule, EventBlockerModule, IconModule, ButtonModule, PopoverModule, LabelModule]
+  imports: [CommonModule, EventBlockerModule, IconModule, ButtonModule, PopoverModule, LabelModule, TooltipModule]
 })
 export class LabelDetailModule {}


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
Adding icon only view mode.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
