### PR TITLE
fix: table loader should start with Never

### DIFF
--- a/projects/components/src/table/data/table-cdk-data-source.ts
+++ b/projects/components/src/table/data/table-cdk-data-source.ts
@@ -1,6 +1,6 @@
 import { DataSource } from '@angular/cdk/collections';
 import { forkJoinSafeEmpty, isEqualIgnoreFunctions, RequireBy, sortUnknown } from '@hypertrace/common';
-import { combineLatest, NEVER, Observable, of, Subject, throwError } from 'rxjs';
+import { BehaviorSubject, combineLatest, NEVER, Observable, of, Subject, throwError } from 'rxjs';
 import { catchError, debounceTime, map, mergeMap, startWith, switchMap, tap } from 'rxjs/operators';
 import { PageEvent } from '../../paginator/page.event';
 import { PaginationProvider } from '../../paginator/paginator-api';
@@ -33,7 +33,9 @@ export class TableCdkDataSource implements DataSource<TableRow> {
   private readonly cachedValues: Map<string, unknown[]> = new Map<string, unknown[]>();
   private lastRowChange: StatefulTableRow | undefined;
   private readonly rowsChange$: Subject<StatefulTableRow[]> = new Subject<StatefulTableRow[]>();
-  private readonly loadingStateSubject: Subject<TableLoadingState> = new Subject<TableLoadingState>();
+  private readonly loadingStateSubject: Subject<TableLoadingState> = new BehaviorSubject<TableLoadingState>({
+    loading$: NEVER
+  });
 
   public loadingStateChange$: Observable<TableLoadingState> = this.loadingStateSubject.asObservable();
 


### PR DESCRIPTION
- When we first rebuild the table data source, we need to emit 'Never' on
  the loading subject. This would allow the table to show loader icon
  when a new data source is built due to the addition of a new
  table filter.

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
