### PR TITLE
fix: avoid caching for entity requests for breadcrumbs

### DIFF
--- a/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.test.ts
+++ b/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.test.ts
@@ -2,7 +2,7 @@ import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NavigationService } from '@hypertrace/common';
-import { GraphQlRequestService } from '@hypertrace/graphql-client';
+import { GraphQlRequestCacheability, GraphQlRequestService } from '@hypertrace/graphql-client';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 
 import { patchRouterNavigateForTest, runFakeRxjs } from '@hypertrace/test-utils';
@@ -107,7 +107,8 @@ describe('Api detail breadcrumb resolver', () => {
         requestType: ENTITY_GQL_REQUEST,
         entityType: ObservabilityEntityType.Api,
         id: 'test-id'
-      })
+      }),
+      { cacheability: GraphQlRequestCacheability.NotCacheable }
     );
   }));
 
@@ -135,7 +136,8 @@ describe('Api detail breadcrumb resolver', () => {
         requestType: ENTITY_GQL_REQUEST,
         entityType: ObservabilityEntityType.Api,
         id: 'test-id'
-      })
+      }),
+      { cacheability: GraphQlRequestCacheability.NotCacheable }
     );
   }));
 });

--- a/projects/observability/src/pages/apis/service-detail/service-detail-breadcrumb.resolver.test.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail-breadcrumb.resolver.test.ts
@@ -2,7 +2,7 @@ import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NavigationService } from '@hypertrace/common';
-import { GraphQlRequestService } from '@hypertrace/graphql-client';
+import { GraphQlRequestCacheability, GraphQlRequestService } from '@hypertrace/graphql-client';
 import { patchRouterNavigateForTest, runFakeRxjs } from '@hypertrace/test-utils';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
@@ -68,7 +68,8 @@ describe('Service detail breadcrumb resolver', () => {
         requestType: ENTITY_GQL_REQUEST,
         entityType: ObservabilityEntityType.Service,
         id: 'test-id'
-      })
+      }),
+      { cacheability: GraphQlRequestCacheability.NotCacheable }
     );
   }));
 });

--- a/projects/observability/src/pages/apis/service-detail/service-detail-breadcrumb.resolver.ts
+++ b/projects/observability/src/pages/apis/service-detail/service-detail-breadcrumb.resolver.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { Breadcrumb, TimeRangeService } from '@hypertrace/common';
 import { GraphQlTimeRange, SpecificationBuilder } from '@hypertrace/distributed-tracing';
-import { GraphQlRequestService } from '@hypertrace/graphql-client';
+import { GraphQlRequestCacheability, GraphQlRequestService } from '@hypertrace/graphql-client';
 import { Observable } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 import { ObservabilityEntityType } from '../../../shared/graphql/model/schema/entity';
@@ -40,15 +40,18 @@ export class ServiceDetailBreadcrumbResolver implements Resolve<Observable<Bread
   protected fetchEntity(id: string): Observable<ServiceEntity> {
     return this.timeRangeService.getTimeRangeAndChanges().pipe(
       switchMap(timeRange =>
-        this.graphQlQueryService.query<EntityGraphQlQueryHandlerService, ServiceEntity>({
-          requestType: ENTITY_GQL_REQUEST,
-          entityType: ObservabilityEntityType.Service,
-          id: id,
-          properties: this.getAttributeKeys().map(attributeKey =>
-            this.specificationBuilder.attributeSpecificationForKey(attributeKey)
-          ),
-          timeRange: new GraphQlTimeRange(timeRange.startTime, timeRange.endTime)
-        })
+        this.graphQlQueryService.query<EntityGraphQlQueryHandlerService, ServiceEntity>(
+          {
+            requestType: ENTITY_GQL_REQUEST,
+            entityType: ObservabilityEntityType.Service,
+            id: id,
+            properties: this.getAttributeKeys().map(attributeKey =>
+              this.specificationBuilder.attributeSpecificationForKey(attributeKey)
+            ),
+            timeRange: new GraphQlTimeRange(timeRange.startTime, timeRange.endTime)
+          },
+          { cacheability: GraphQlRequestCacheability.NotCacheable }
+        )
       )
     );
   }


### PR DESCRIPTION
## Description
Avoid caching for entity requests for breadcrumbs

### Testing
UTs added

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules