### PR TITLE
fix table app frame and title content scss to work with safari

### DIFF
--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -19,7 +19,7 @@
 
 .table {
   width: 100%;
-  flex: 1 1 0;
+  flex: 1 1;
   overflow: auto;
 }
 
@@ -65,7 +65,7 @@
 
 .header-cell {
   display: flex;
-  flex: 1 1 0;
+  flex: 1 1;
   overflow: hidden;
 
   .header-cell-renderer {
@@ -95,7 +95,7 @@
 }
 
 .data-cell {
-  flex: 1 1 0;
+  flex: 1 1;
   overflow: hidden;
   border-bottom: 1px solid $gray-1;
 

--- a/projects/components/src/titled-content/titled-content.component.scss
+++ b/projects/components/src/titled-content/titled-content.component.scss
@@ -32,6 +32,8 @@
   }
 
   .content {
+    height: 100%;
+    width: 100%;
     flex: 1 1 auto;
     overflow: hidden;
   }

--- a/src/app/application-frame/application-frame.component.scss
+++ b/src/app/application-frame/application-frame.component.scss
@@ -22,7 +22,7 @@
 }
 
 .app-content-with-header {
-  flex: 1 1 0;
+  flex: 1 1;
   height: 100%;
   width: 100%;
   display: flex;


### PR DESCRIPTION
## Description
Topology, donut, radar, and table were not showing in Safari due to Safari not handling flexbox the same as other browsers.
