### PR TITLE
fix: explorer table expanding beyond page bounds

### DIFF
--- a/projects/components/src/paginator/paginator.component.scss
+++ b/projects/components/src/paginator/paginator.component.scss
@@ -8,7 +8,7 @@
   align-items: center;
 
   height: $paginator-height;
-  padding-top: 6px;
+  padding: 6px 0;
   border-top: 1px solid $color-border;
 
   .label {

--- a/projects/components/src/panel/panel.component.scss
+++ b/projects/components/src/panel/panel.component.scss
@@ -10,7 +10,7 @@
     border-radius: 2px;
 
     &.expanded {
-      margin-bottom: 8px;
+      padding-bottom: 8px;
     }
 
     .header-content {

--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -2,11 +2,7 @@
 @import 'layout';
 
 .table {
-  display: flex;
-  flex-direction: column;
   height: 100%;
-  width: 100%;
-  position: relative;
 }
 
 .title-row {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
@@ -7,6 +7,7 @@
 .table {
   flex: 1 1;
   width: 100%;
+  overflow: auto;
 }
 
 .header-margin {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
@@ -5,9 +5,8 @@
 }
 
 .table {
-  flex: 1 1;
-  width: 100%;
-  overflow: hidden;
+  flex: 1;
+  min-height: 0;
 }
 
 .header-margin {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.scss
@@ -7,7 +7,7 @@
 .table {
   flex: 1 1;
   width: 100%;
-  overflow: auto;
+  overflow: hidden;
 }
 
 .header-margin {

--- a/projects/observability/src/pages/explorer/explorer.component.scss
+++ b/projects/observability/src/pages/explorer/explorer.component.scss
@@ -1,13 +1,31 @@
 @import 'font';
 
-.explorer-container {
+.explorer {
   display: flex;
   flex-direction: column;
-  padding: 24px 24px 0;
-  height: calc(100% - 40px);
+  overflow: hidden;
+  height: 100%;
 
-  .filter-bar {
-    margin-top: 16px;
+  .explorer-header {
+    flex: 0;
+  }
+
+  .explorer-content {
+    display: flex;
+    flex-direction: column;
+    padding: 24px 24px 0;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .explorer-data-toggle {
+    flex: 0;
+    padding-bottom: 16px;
+  }
+
+  .explorer-filter-bar {
+    flex: 0;
+    padding-bottom: 8px;
   }
 
   .panel-title {
@@ -15,7 +33,8 @@
   }
 
   .visualization-panel {
-    padding-top: 8px;
+    flex: 0;
+
     .label {
       @include body-1-medium;
     }
@@ -29,14 +48,15 @@
   }
 
   .results-panel {
+    flex: 1;
     overflow: hidden;
-    flex: 1 1 auto;
+
     .label {
       @include body-1-medium;
     }
 
     .results-panel-content {
-      margin-top: 12px;
+      padding-top: 12px;
     }
   }
 }

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -19,17 +19,18 @@ import {
   styleUrls: ['./explorer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="vertical-flex-layout">
-      <ht-page-header></ht-page-header>
-      <div class="fill-container explorer-container">
+    <div class="explorer">
+      <ht-page-header class="explorer-header"></ht-page-header>
+      <div class="explorer-content">
         <ht-toggle-group
+          class="explorer-data-toggle"
           [items]="this.contextItems"
           [activeItem]="this.activeContextItem$ | async"
           (activeItemChange)="this.onContextUpdated($event.value)"
         ></ht-toggle-group>
 
         <ht-filter-bar
-          class="filter-bar"
+          class="explorer-filter-bar"
           [attributes]="this.attributes$ | async"
           [syncWithUrl]="true"
           (filtersChange)="this.onFiltersUpdated($event)"


### PR DESCRIPTION
## Description
After fixing the Safari issues with flexbox, the Explorer table was expanding beyond the page limits. This PR fixes that and a few other small styling issues with table in explorer.

## Testing
Manual testing of this table and tables in other parts of the product, including entity lists, events, and api def.
