### PR TITLE
fix: adding debounce subscription on component init

### DIFF
--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -1,0 +1,68 @@
+import { Subject } from 'rxjs';
+import { fakeAsync } from '@angular/core/testing';
+import { createHostFactory, Spectator } from '@ngneat/spectator/jest';
+import { SearchBoxComponent } from './search-box.component';
+import { By } from '@angular/platform-browser';
+import { runFakeRxjs } from '@hypertrace/test-utils';
+
+describe('Search box Component', () => {
+  let spectator: Spectator<SearchBoxComponent>;
+
+  const createHost = createHostFactory({
+    component: SearchBoxComponent,
+    shallow: true
+  });
+
+  test('should work with default values', fakeAsync(() => {
+    // const onValueChangeSpy = jest.fn();
+    const valueSubject = new Subject<string>();
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" (valueChange)="onValueChange($event)"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          onValueChange: (value: string) => {
+            valueSubject.next(value);
+          }
+        }
+      }
+    );
+
+    const inputDebugElement = spectator.debugElement.query(By.css('input'));
+    spectator.component.value = 'Test';
+    spectator.triggerEventHandler(inputDebugElement, 'input', spectator.component.value);
+    spectator.tick();
+    // spectator.tick();
+
+    valueSubject.subscribe({
+      next: (value: string) => {
+        console.log(value);
+      }
+    });
+
+    // expect(onValueChangeSpy).toHaveBeenCalledWith('Test');
+
+    runFakeRxjs(({ expectObservable }) => {
+      spectator.triggerEventHandler(inputDebugElement, 'input', spectator.component.value);
+      spectator.tick();
+      expectObservable(spectator.component.valueChange).toBe('(xyz)', {
+        x: 'Test'
+      });
+    });
+  }));
+
+  // test('should pass properties to Mat Slide toggle correctly', fakeAsync(() => {
+  //   const onValueChangeSpy = jest.fn();
+  //   spectator = createHost(
+  //     `<ht-search-box [placeholder]="placeholder" [value]="value" [debounceTime]="debounceTime" (valueChange)="onValueChange($event)"></ht-search-box>`,
+  //     {
+  //       hostProps: {
+  //         placeholder: 'Test Placeholder',
+  //         value: '',
+  //         debounceTime: 10,
+  //         onValueChange: onValueChangeSpy
+  //       }
+  //     }
+  //   );
+  // }));
+});

--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -1,9 +1,8 @@
-import { Subject } from 'rxjs';
 import { fakeAsync } from '@angular/core/testing';
-import { createHostFactory, Spectator } from '@ngneat/spectator/jest';
-import { SearchBoxComponent } from './search-box.component';
 import { By } from '@angular/platform-browser';
 import { runFakeRxjs } from '@hypertrace/test-utils';
+import { createHostFactory, Spectator } from '@ngneat/spectator/jest';
+import { SearchBoxComponent } from './search-box.component';
 
 describe('Search box Component', () => {
   let spectator: Spectator<SearchBoxComponent>;
@@ -14,55 +13,51 @@ describe('Search box Component', () => {
   });
 
   test('should work with default values', fakeAsync(() => {
-    // const onValueChangeSpy = jest.fn();
-    const valueSubject = new Subject<string>();
     spectator = createHost(
       `<ht-search-box [placeholder]="placeholder" (valueChange)="onValueChange($event)"></ht-search-box>`,
       {
         hostProps: {
-          placeholder: 'Test Placeholder',
-          onValueChange: (value: string) => {
-            valueSubject.next(value);
-          }
+          placeholder: 'Test Placeholder'
         }
       }
     );
 
     const inputDebugElement = spectator.debugElement.query(By.css('input'));
+    expect((inputDebugElement.nativeElement as HTMLInputElement)?.placeholder).toEqual('Test Placeholder');
     spectator.component.value = 'Test';
-    spectator.triggerEventHandler(inputDebugElement, 'input', spectator.component.value);
-    spectator.tick();
-    // spectator.tick();
-
-    valueSubject.subscribe({
-      next: (value: string) => {
-        console.log(value);
-      }
-    });
-
-    // expect(onValueChangeSpy).toHaveBeenCalledWith('Test');
 
     runFakeRxjs(({ expectObservable }) => {
-      spectator.triggerEventHandler(inputDebugElement, 'input', spectator.component.value);
-      spectator.tick();
-      expectObservable(spectator.component.valueChange).toBe('(xyz)', {
+      expectObservable(spectator.component.valueChange).toBe('x', {
         x: 'Test'
       });
+
+      spectator.triggerEventHandler(inputDebugElement, 'input', spectator.component.value);
+      spectator.tick();
     });
   }));
 
-  // test('should pass properties to Mat Slide toggle correctly', fakeAsync(() => {
-  //   const onValueChangeSpy = jest.fn();
-  //   spectator = createHost(
-  //     `<ht-search-box [placeholder]="placeholder" [value]="value" [debounceTime]="debounceTime" (valueChange)="onValueChange($event)"></ht-search-box>`,
-  //     {
-  //       hostProps: {
-  //         placeholder: 'Test Placeholder',
-  //         value: '',
-  //         debounceTime: 10,
-  //         onValueChange: onValueChangeSpy
-  //       }
-  //     }
-  //   );
-  // }));
+  test('should work with arbitrary debounce time', fakeAsync(() => {
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" (valueChange)="onValueChange($event)"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          debounceTime: 200
+        }
+      }
+    );
+
+    const inputDebugElement = spectator.debugElement.query(By.css('input'));
+    expect((inputDebugElement.nativeElement as HTMLInputElement)?.placeholder).toEqual('Test Placeholder');
+    spectator.component.value = 'Test2';
+
+    runFakeRxjs(({ expectObservable }) => {
+      expectObservable(spectator.component.valueChange).toBe('200ms x', {
+        x: 'Test2'
+      });
+
+      spectator.triggerEventHandler(inputDebugElement, 'input', spectator.component.value);
+      spectator.tick();
+    });
+  }));
 });

--- a/projects/components/src/search-box/search-box.component.ts
+++ b/projects/components/src/search-box/search-box.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { IconType } from '@hypertrace/assets-library';
 import { SubscriptionLifecycle, TypedSimpleChanges } from '@hypertrace/common';
 import { Subject } from 'rxjs';
@@ -33,7 +33,7 @@ import { IconSize } from '../icon/icon-size';
     </div>
   `
 })
-export class SearchBoxComponent implements OnChanges {
+export class SearchBoxComponent implements OnInit, OnChanges {
   @Input()
   public placeholder: string = 'Search';
 
@@ -41,7 +41,7 @@ export class SearchBoxComponent implements OnChanges {
   public value: string = '';
 
   @Input()
-  public debounceTime: number = 0;
+  public debounceTime?: number;
 
   @Output()
   public readonly valueChange: EventEmitter<string> = new EventEmitter();
@@ -55,14 +55,13 @@ export class SearchBoxComponent implements OnChanges {
   public isFocused: boolean = false;
   private readonly debouncedValueSubject: Subject<string> = new Subject();
 
+  public ngOnInit(): void {
+    this.setDebouncedSubscription();
+  }
+
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
     if (changes.debounceTime) {
-      this.subscriptionLifecycle.unsubscribe();
-      this.subscriptionLifecycle.add(
-        this.debouncedValueSubject
-          .pipe(debounceTime(this.debounceTime))
-          .subscribe(value => this.valueChange.emit(value))
-      );
+      this.setDebouncedSubscription();
     }
   }
 
@@ -81,5 +80,14 @@ export class SearchBoxComponent implements OnChanges {
 
     this.value = '';
     this.onValueChange();
+  }
+
+  private setDebouncedSubscription(): void {
+    this.subscriptionLifecycle.unsubscribe();
+    this.subscriptionLifecycle.add(
+      this.debouncedValueSubject
+        .pipe(debounceTime(this.debounceTime ?? 0))
+        .subscribe(value => this.valueChange.emit(value))
+    );
   }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
fix: adding debounce subscription on component init
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
