### PR TITLE
refactor: setting min dropdown width to be equal to trigger width

### DIFF
--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -29,7 +29,7 @@ import { SelectSize } from '../select/select-size';
       [ngClass]="[this.size, this.showBorder ? 'border' : '', this.disabled ? 'disabled' : '']"
       *htLetAsync="this.selected$ as selected"
     >
-      <ht-popover [disabled]="this.disabled" class="multi-select-container" >
+      <ht-popover [disabled]="this.disabled" class="multi-select-container">
         <ht-popover-trigger>
           <div class="trigger-content" [ngClass]="this.justifyClass" #triggerContainer>
             <ht-icon *ngIf="this.icon" class="trigger-prefix-icon" [icon]="this.icon" size="${IconSize.Small}">
@@ -39,7 +39,7 @@ import { SelectSize } from '../select/select-size';
           </div>
         </ht-popover-trigger>
         <ht-popover-content>
-          <div class="multi-select-content" [ngStyle]="{'min-width.px': triggerContainer.offsetWidth}">
+          <div class="multi-select-content" [ngStyle]="{ 'min-width.px': triggerContainer.offsetWidth }">
             <ng-container *ngIf="this.showAllOptionControl">
               <div class="multi-select-option all-options" (click)="this.onAllSelectionChange()">
                 <input class="checkbox" type="checkbox" [checked]="this.areAllOptionsSelected()" />
@@ -151,7 +151,6 @@ export class MultiSelectComponent<V> implements AfterContentInit, OnChanges {
     this.selected$ = this.buildObservableOfSelected();
     this.selectedChange.emit(this.selected);
   }
-
 
   private setTriggerLabel(): void {
     if (this.triggerLabelDisplayMode === TriggerLabelDisplayMode.Placeholder) {

--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -29,9 +29,9 @@ import { SelectSize } from '../select/select-size';
       [ngClass]="[this.size, this.showBorder ? 'border' : '', this.disabled ? 'disabled' : '']"
       *htLetAsync="this.selected$ as selected"
     >
-      <ht-popover [disabled]="this.disabled" class="multi-select-container">
+      <ht-popover [disabled]="this.disabled" class="multi-select-container" >
         <ht-popover-trigger>
-          <div class="trigger-content" [ngClass]="this.justifyClass">
+          <div class="trigger-content" [ngClass]="this.justifyClass" #triggerContainer>
             <ht-icon *ngIf="this.icon" class="trigger-prefix-icon" [icon]="this.icon" size="${IconSize.Small}">
             </ht-icon>
             <ht-label class="trigger-label" [label]="this.triggerLabel"></ht-label>
@@ -39,7 +39,7 @@ import { SelectSize } from '../select/select-size';
           </div>
         </ht-popover-trigger>
         <ht-popover-content>
-          <div class="multi-select-content">
+          <div class="multi-select-content" [ngStyle]="{'min-width.px': triggerContainer.offsetWidth}">
             <ng-container *ngIf="this.showAllOptionControl">
               <div class="multi-select-option all-options" (click)="this.onAllSelectionChange()">
                 <input class="checkbox" type="checkbox" [checked]="this.areAllOptionsSelected()" />
@@ -151,6 +151,7 @@ export class MultiSelectComponent<V> implements AfterContentInit, OnChanges {
     this.selected$ = this.buildObservableOfSelected();
     this.selectedChange.emit(this.selected);
   }
+
 
   private setTriggerLabel(): void {
     if (this.triggerLabelDisplayMode === TriggerLabelDisplayMode.Placeholder) {


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
refactor: setting min dropdown width to be equal to trigger width
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
