### PR TITLE
fix: remove duplicate padding

### DIFF
--- a/src/app/shared/navigation/navigation.component.scss
+++ b/src/app/shared/navigation/navigation.component.scss
@@ -1,7 +1,6 @@
 @import 'mixins';
 
 .navigation {
-  padding: 24px 0px 5px 8px;
   border-right: 1px solid $gray-2;
   height: 100%;
 }


### PR DESCRIPTION
## Description
Remove padding from parent nav since it was added to the component in https://github.com/hypertrace/hypertrace-ui/pull/530

### Testing
Visual verification

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
