### PR TITLE
refactor: move knowledge of global params out of nav service

### DIFF
--- a/projects/common/src/navigation/navigation.service.test.ts
+++ b/projects/common/src/navigation/navigation.service.test.ts
@@ -141,8 +141,6 @@ describe('Navigation Service', () => {
     expect(router.navigate).toHaveBeenCalledWith(
       ['root', 'child'],
       expect.objectContaining({
-        // tslint:disable-next-line: no-null-keyword
-        queryParams: { time: null },
         relativeTo: undefined
       })
     );
@@ -155,8 +153,6 @@ describe('Navigation Service', () => {
     expect(router.navigate).toHaveBeenLastCalledWith(
       ['child'],
       expect.objectContaining({
-        // tslint:disable-next-line: no-null-keyword
-        queryParams: { time: null },
         relativeTo: spectator.service.getCurrentActivatedRoute()
       })
     );
@@ -199,8 +195,6 @@ describe('Navigation Service', () => {
     expect(spectator.service.buildNavigationParams('/services')).toEqual({
       path: '/services',
       extras: expect.objectContaining({
-        // tslint:disable-next-line: no-null-keyword
-        queryParams: { time: null },
         relativeTo: undefined
       })
     });
@@ -217,6 +211,21 @@ describe('Navigation Service', () => {
       ['root', 'child'],
       expect.objectContaining({
         replaceUrl: true
+      })
+    );
+  });
+
+  test('propagates global query params', () => {
+    router.navigate = jest.fn().mockResolvedValue(true);
+    spectator.service.registerGlobalQueryParamKey('global');
+    spectator.service.navigateWithinApp('root');
+    expect(router.navigate).toHaveBeenLastCalledWith(
+      ['root'],
+      expect.objectContaining({
+        queryParams: {
+          // tslint:disable-next-line: no-null-keyword
+          global: null
+        }
       })
     );
   });

--- a/projects/common/src/navigation/navigation.service.test.ts
+++ b/projects/common/src/navigation/navigation.service.test.ts
@@ -216,17 +216,22 @@ describe('Navigation Service', () => {
   });
 
   test('propagates global query params', () => {
-    router.navigate = jest.fn().mockResolvedValue(true);
+    spectator.service.navigate({
+      navType: NavigationParamsType.InApp,
+      path: 'root',
+      queryParams: {
+        global: 'foo',
+        other: 'bar'
+      }
+    });
+
     spectator.service.registerGlobalQueryParamKey('global');
-    spectator.service.navigateWithinApp('root');
-    expect(router.navigate).toHaveBeenLastCalledWith(
-      ['root'],
-      expect.objectContaining({
-        queryParams: {
-          // tslint:disable-next-line: no-null-keyword
-          global: null
-        }
-      })
-    );
+
+    spectator.service.navigate('root/child');
+
+    expect(spectator.service.getCurrentActivatedRoute().snapshot.url).toEqual([
+      expect.objectContaining({ path: 'child' })
+    ]);
+    expect(spectator.service.getCurrentActivatedRoute().snapshot.queryParams).toEqual({ global: 'foo' });
   });
 });

--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -27,6 +27,7 @@ export class NavigationService {
   );
 
   private isFirstNavigation: boolean = true;
+  private readonly globalQueryParams: Set<string> = new Set();
 
   public constructor(
     private readonly router: Router,
@@ -55,6 +56,13 @@ export class NavigationService {
       queryParams: newParams,
       replaceCurrentHistory: true
     });
+  }
+
+  /**
+   * Global query params will be preserved by default on navigation
+   */
+  public registerGlobalQueryParamKey(queryParamKey: string): void {
+    this.globalQueryParams.add(queryParamKey);
   }
 
   public getQueryParameter(parameterName: string, defaultValue: string): string {
@@ -116,7 +124,7 @@ export class NavigationService {
   }
 
   private buildQueryParam(preserveParameters: string[] = []): QueryParamObject {
-    return ['time', ...preserveParameters].reduce<Params>(
+    return [...this.globalQueryParams, ...preserveParameters].reduce<Params>(
       (paramObj, param) => ({
         ...paramObj,
         [param]: this.currentParamMap.get(param)

--- a/projects/common/src/time/time-range.service.ts
+++ b/projects/common/src/time/time-range.service.ts
@@ -26,6 +26,7 @@ export class TimeRangeService {
     private readonly timeDurationService: TimeDurationService
   ) {
     this.initializeTimeRange();
+    this.navigationService.registerGlobalQueryParamKey(TimeRangeService.TIME_RANGE_QUERY_PARAM);
   }
 
   public getShareableCurrentUrl(): string {


### PR DESCRIPTION
## Description
This change removes the knowledge of other services from navigation service, allowing them to register global query params (rather than hardcoding them) for a more decoupled design.

### Testing
Updated and added new unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
