### PR TITLE
feat: method to convert duration to ISO8601 duration string

### DIFF
--- a/projects/common/src/time/time-duration.test.ts
+++ b/projects/common/src/time/time-duration.test.ts
@@ -7,6 +7,10 @@ describe('Time duration', () => {
     expect(new TimeDuration(4, TimeUnit.Hour).toMillis()).toBe(4 * 60 * 60 * 1000);
   });
 
+  test('converts to ISO 8601 duration string correctly', () => {
+    expect(new TimeDuration(1, TimeUnit.Hour).toIso8601DurationString()).toBe('PT3600S');
+  });
+
   test('can print a multi unit string', () => {
     expect(
       new TimeDuration(4 * 60 * 60 * 1000 + 3 * 60 * 1000 + 5 * 1000 + 689, TimeUnit.Millisecond).toMultiUnitString(

--- a/projects/common/src/time/time-duration.ts
+++ b/projects/common/src/time/time-duration.ts
@@ -16,6 +16,10 @@ export class TimeDuration {
     return this.toMillis() / this.unitInMillis(unit);
   }
 
+  public toIso8601DurationString(): string {
+    return `PT${this.toMillis() / 1000}S`;
+  }
+
   public toMultiUnitString(
     smallestUnit: ConvertibleTimeUnit = TimeUnit.Second,
     displayZero: boolean = true,


### PR DESCRIPTION
## Description
Method to convert duration to ISO8601 duration string.

### Testing
UT added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules