### PR TITLE
feat: add global filtering that applies aross all queries

### DIFF
--- a/projects/distributed-tracing/src/public-api.ts
+++ b/projects/distributed-tracing/src/public-api.ts
@@ -63,6 +63,7 @@ export * from './shared/graphql/model/schema/filter/field/graphql-field-filter';
 export * from './shared/graphql/model/schema/filter/id/graphql-id-filter';
 
 export * from './shared/graphql/model/schema/filter/graphql-filter';
+export * from './shared/graphql/model/schema/filter/global-graphql-filter.service';
 export {
   GraphQlMetricAggregationType,
   convertToGraphQlMetricAggregationType

--- a/projects/distributed-tracing/src/shared/graphql/model/schema/filter/global-graphql-filter.service.test.ts
+++ b/projects/distributed-tracing/src/shared/graphql/model/schema/filter/global-graphql-filter.service.test.ts
@@ -1,0 +1,58 @@
+import { createServiceFactory } from '@ngneat/spectator/jest';
+import { SPAN_SCOPE } from '../span';
+import { GraphQlFieldFilter } from './field/graphql-field-filter';
+import { GlobalGraphQlFilterService } from './global-graphql-filter.service';
+import { GraphQlOperatorType } from './graphql-filter';
+
+describe('Global graphql filter serivce', () => {
+  const firstFilter = new GraphQlFieldFilter('first', GraphQlOperatorType.Equals, 'first');
+  const secondFilter = new GraphQlFieldFilter('second', GraphQlOperatorType.Equals, 'second');
+  const thirdFilter = new GraphQlFieldFilter('third', GraphQlOperatorType.Equals, 'third');
+  const createService = createServiceFactory({
+    service: GlobalGraphQlFilterService
+  });
+  test('provides no filters by default', () => {
+    const spectator = createService();
+
+    expect(spectator.service.getGlobalFilters(SPAN_SCOPE)).toEqual([]);
+  });
+
+  test('provides filters from multiple matching rules', () => {
+    const spectator = createService();
+    spectator.service.setGlobalFilterRule(Symbol('first'), {
+      filtersForScope: scope => (scope === SPAN_SCOPE ? [firstFilter] : [])
+    });
+    spectator.service.setGlobalFilterRule(Symbol('second'), {
+      filtersForScope: scope => (scope === 'fake' ? [secondFilter] : [])
+    });
+    spectator.service.setGlobalFilterRule(Symbol('third'), {
+      filtersForScope: scope => (scope === SPAN_SCOPE ? [thirdFilter] : [])
+    });
+    expect(spectator.service.getGlobalFilters(SPAN_SCOPE)).toEqual([firstFilter, thirdFilter]);
+  });
+
+  test('allows removing global filter rules', () => {
+    const spectator = createService();
+    const filterRuleKey = Symbol('first');
+    spectator.service.setGlobalFilterRule(filterRuleKey, {
+      filtersForScope: scope => (scope === SPAN_SCOPE ? [firstFilter] : [])
+    });
+
+    expect(spectator.service.getGlobalFilters(SPAN_SCOPE)).toEqual([firstFilter]);
+
+    spectator.service.clearGlobalFilterRule(filterRuleKey);
+    expect(spectator.service.getGlobalFilters(SPAN_SCOPE)).toEqual([]);
+  });
+
+  test('merges with local filters', () => {
+    const spectator = createService();
+    spectator.service.setGlobalFilterRule(Symbol('first'), {
+      filtersForScope: scope => (scope === SPAN_SCOPE ? [firstFilter] : [])
+    });
+
+    expect(spectator.service.mergeGlobalFilters(SPAN_SCOPE)).toEqual([firstFilter]);
+
+    expect(spectator.service.mergeGlobalFilters('fake', [secondFilter])).toEqual([secondFilter]);
+    expect(spectator.service.mergeGlobalFilters(SPAN_SCOPE, [secondFilter])).toEqual([secondFilter, firstFilter]);
+  });
+});

--- a/projects/distributed-tracing/src/shared/graphql/model/schema/filter/global-graphql-filter.service.ts
+++ b/projects/distributed-tracing/src/shared/graphql/model/schema/filter/global-graphql-filter.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { GraphQlFilter } from './graphql-filter';
+
+@Injectable({ providedIn: 'root' })
+export class GlobalGraphQlFilterService {
+  private readonly filterRules: Map<symbol, FilterRule> = new Map();
+
+  public getGlobalFilters(scope: string): GraphQlFilter[] {
+    return Array.from(this.filterRules.values()).flatMap(rule => rule.filtersForScope(scope));
+  }
+
+  public mergeGlobalFilters(scope: string, localFilters: GraphQlFilter[] = []): GraphQlFilter[] {
+    return [...localFilters, ...this.getGlobalFilters(scope)];
+  }
+
+  public setGlobalFilterRule(ruleKey: symbol, rule: FilterRule): void {
+    this.filterRules.set(ruleKey, rule);
+  }
+
+  public clearGlobalFilterRule(ruleKey: symbol): void {
+    this.filterRules.delete(ruleKey);
+  }
+}
+
+interface FilterRule {
+  filtersForScope(scope: string): GraphQlFilter[];
+}

--- a/projects/distributed-tracing/src/shared/graphql/request/handlers/spans/spans-graphql-query-handler.service.ts
+++ b/projects/distributed-tracing/src/shared/graphql/request/handlers/spans/spans-graphql-query-handler.service.ts
@@ -4,6 +4,7 @@ import { GraphQlHandlerType, GraphQlQueryHandler, GraphQlSelection } from '@hype
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { MetadataService } from '../../../../services/metadata/metadata.service';
+import { GlobalGraphQlFilterService } from '../../../model/schema/filter/global-graphql-filter.service';
 import { GraphQlFilter } from '../../../model/schema/filter/graphql-filter';
 import { GraphQlSortBySpecification } from '../../../model/schema/sort/graphql-sort-by-specification';
 import { Span, spanIdKey, SPAN_SCOPE } from '../../../model/schema/span';
@@ -19,7 +20,10 @@ export class SpansGraphQlQueryHandlerService implements GraphQlQueryHandler<Grap
   private readonly argBuilder: GraphQlArgumentBuilder = new GraphQlArgumentBuilder();
   private readonly selectionBuilder: GraphQlSelectionBuilder = new GraphQlSelectionBuilder();
 
-  public constructor(private readonly metadataService: MetadataService) {}
+  public constructor(
+    private readonly metadataService: MetadataService,
+    private readonly globalGraphQlFilterService: GlobalGraphQlFilterService
+  ) {}
 
   public matchesRequest(request: unknown): request is GraphQlSpansRequest {
     return (
@@ -37,7 +41,7 @@ export class SpansGraphQlQueryHandlerService implements GraphQlQueryHandler<Grap
         this.argBuilder.forTimeRange(request.timeRange),
         ...this.argBuilder.forOffset(request.offset),
         ...this.argBuilder.forOrderBy(request.sort),
-        ...this.argBuilder.forFilters(request.filters)
+        ...this.argBuilder.forFilters(this.globalGraphQlFilterService.mergeGlobalFilters(SPAN_SCOPE, request.filters))
       ],
       children: [
         {

--- a/projects/distributed-tracing/src/shared/graphql/request/handlers/traces/traces-graphql-query-handler.service.ts
+++ b/projects/distributed-tracing/src/shared/graphql/request/handlers/traces/traces-graphql-query-handler.service.ts
@@ -4,6 +4,7 @@ import { GraphQlHandlerType, GraphQlQueryHandler, GraphQlSelection } from '@hype
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { MetadataService } from '../../../../services/metadata/metadata.service';
+import { GlobalGraphQlFilterService } from '../../../model/schema/filter/global-graphql-filter.service';
 import { GraphQlFilter } from '../../../model/schema/filter/graphql-filter';
 import { GraphQlSortBySpecification } from '../../../model/schema/sort/graphql-sort-by-specification';
 import { Specification } from '../../../model/schema/specifier/specification';
@@ -18,7 +19,10 @@ export class TracesGraphQlQueryHandlerService implements GraphQlQueryHandler<Gra
   private readonly selectionBuilder: GraphQlSelectionBuilder = new GraphQlSelectionBuilder();
   public readonly type: GraphQlHandlerType.Query = GraphQlHandlerType.Query;
 
-  public constructor(private readonly metadataService: MetadataService) {}
+  public constructor(
+    private readonly metadataService: MetadataService,
+    private readonly globalGraphQlFilterService: GlobalGraphQlFilterService
+  ) {}
 
   public matchesRequest(request: unknown): request is GraphQlTracesRequest {
     return (
@@ -37,7 +41,9 @@ export class TracesGraphQlQueryHandlerService implements GraphQlQueryHandler<Gra
         this.argBuilder.forTimeRange(request.timeRange),
         ...this.argBuilder.forOffset(request.offset),
         ...this.argBuilder.forOrderBy(request.sort),
-        ...this.argBuilder.forFilters(request.filters)
+        ...this.argBuilder.forFilters(
+          this.globalGraphQlFilterService.mergeGlobalFilters(resolveTraceType(request.traceType), request.filters)
+        )
       ],
       children: [
         {

--- a/projects/observability/src/shared/graphql/request/handlers/entities/query/entities-graphql-query-builder.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/entities/query/entities-graphql-query-builder.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@angular/core';
 import { Dictionary, forkJoinSafeEmpty } from '@hypertrace/common';
 import {
+  GlobalGraphQlFilterService,
   GraphQlFilter,
   GraphQlSelectionBuilder,
   GraphQlSortBySpecification,
@@ -27,7 +28,8 @@ export class EntitiesGraphqlQueryBuilderService {
 
   public constructor(
     private readonly metadataService: MetadataService,
-    @Inject(ENTITY_METADATA) private readonly entityMetetadata: EntityMetadataMap
+    private readonly globalGraphQlFilterService: GlobalGraphQlFilterService,
+    @Inject(ENTITY_METADATA) private readonly entityMetadata: EntityMetadataMap
   ) {}
 
   public buildRequestArguments(request: GraphQlEntitiesRequest): GraphQlArgument[] {
@@ -42,7 +44,9 @@ export class EntitiesGraphqlQueryBuilderService {
   }
 
   protected buildFilters(request: GraphQlEntitiesRequest): GraphQlArgument[] {
-    return this.argBuilder.forFilters(request.filters);
+    return this.argBuilder.forFilters(
+      this.globalGraphQlFilterService.mergeGlobalFilters(request.entityType, request.filters)
+    );
   }
 
   public buildRequestSpecifications(request: GraphQlEntitiesRequest): GraphQlSelection[] {
@@ -82,7 +86,7 @@ export class EntitiesGraphqlQueryBuilderService {
   }
 
   public getRequestOptions(request: Pick<GraphQlEntitiesRequest, 'entityType'>): GraphQlRequestOptions {
-    if (this.entityMetetadata.get(request.entityType)?.volatile) {
+    if (this.entityMetadata.get(request.entityType)?.volatile) {
       return { cacheability: GraphQlRequestCacheability.NotCacheable };
     }
 

--- a/projects/observability/src/shared/graphql/request/handlers/entities/query/topology/entity-topology-graphql-query-handler.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/entities/query/topology/entity-topology-graphql-query-handler.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Dictionary } from '@hypertrace/common';
 import {
+  GlobalGraphQlFilterService,
   GraphQlFilter,
   GraphQlSelectionBuilder,
   GraphQlTimeRange,
@@ -22,6 +23,7 @@ export class EntityTopologyGraphQlQueryHandlerService
   private readonly specBuilder: SpecificationBuilder = new SpecificationBuilder();
   private readonly argBuilder: GraphQlObservabilityArgumentBuilder = new GraphQlObservabilityArgumentBuilder();
   private readonly selectionBuilder: GraphQlSelectionBuilder = new GraphQlSelectionBuilder();
+  public constructor(private readonly globalGraphQlFilterService: GlobalGraphQlFilterService) {}
 
   public matchesRequest(request: unknown): request is GraphQlEntityTopologyRequest {
     return (
@@ -38,7 +40,9 @@ export class EntityTopologyGraphQlQueryHandlerService
         this.argBuilder.forEntityType(request.rootNodeType),
         this.argBuilder.forLimit(request.rootNodeLimit),
         this.argBuilder.forTimeRange(request.timeRange),
-        ...this.argBuilder.forFilters(request.rootNodeFilters)
+        ...this.argBuilder.forFilters(
+          this.globalGraphQlFilterService.mergeGlobalFilters(request.rootNodeType, request.rootNodeFilters)
+        )
       ],
       children: [
         {

--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { DateCoercer, Dictionary, TimeDuration } from '@hypertrace/common';
 import {
+  GlobalGraphQlFilterService,
   GraphQlFilter,
   GraphQlSelectionBuilder,
   GraphQlSortBySpecification,
@@ -29,6 +30,8 @@ export class ExploreGraphQlQueryHandlerService
   private readonly specBuilder: ExploreSpecificationBuilder = new ExploreSpecificationBuilder();
   private readonly dateCoercer: DateCoercer = new DateCoercer();
 
+  public constructor(private readonly globalGraphQlFilterService: GlobalGraphQlFilterService) {}
+
   public matchesRequest(request: unknown): request is GraphQlExploreRequest {
     return (
       typeof request === 'object' &&
@@ -51,7 +54,9 @@ export class ExploreGraphQlQueryHandlerService
         this.argBuilder.forTimeRange(request.timeRange),
         ...this.argBuilder.forOffset(request.offset),
         ...this.argBuilder.forInterval(request.interval),
-        ...this.argBuilder.forFilters(request.filters),
+        ...this.argBuilder.forFilters(
+          this.globalGraphQlFilterService.mergeGlobalFilters(request.context, request.filters)
+        ),
         ...this.argBuilder.forGroupBy(request.groupBy),
         ...this.argBuilder.forOrderBys(request.orderBy)
       ],


### PR DESCRIPTION
## Description
This change adds support for registering global filter rules which will be applied to all graphql handlers. This allows rules to be managed independently of the various handlers, a more extensible design.

### Testing
Added and updated unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
