### PR TITLE
fix: using startTime for full trace page

### DIFF
--- a/projects/observability/src/pages/api-trace-detail/api-trace-detail.page.component.ts
+++ b/projects/observability/src/pages/api-trace-detail/api-trace-detail.page.component.ts
@@ -48,7 +48,7 @@ import { ApiTraceDetails, ApiTraceDetailService } from './api-trace-detail.servi
             role="${ButtonRole.Tertiary}"
             display="${ButtonStyle.Bordered}"
             label="See Full Trace"
-            (click)="this.navigateToFullTrace(traceDetails.traceId)"
+            (click)="this.navigateToFullTrace(traceDetails.traceId, traceDetails.startTime)"
           ></ht-button>
         </div>
       </div>
@@ -113,7 +113,7 @@ export class ApiTraceDetailPageComponent {
     this.navigationService.navigateBack();
   }
 
-  public navigateToFullTrace(traceId: string): void {
-    this.navigationService.navigateWithinApp(['/trace', traceId]);
+  public navigateToFullTrace(traceId: string, startTime: string): void {
+    this.navigationService.navigateWithinApp(['/trace', traceId, { startTime: startTime }]);
   }
 }


### PR DESCRIPTION
## Description
Using start time while navigating to full trace page.

### Testing
N/A