### PR TITLE
feat: support for includeInactive param in entities gql request

### DIFF
--- a/projects/observability/src/shared/graphql/request/builders/argument/graphql-observability-argument-builder.ts
+++ b/projects/observability/src/shared/graphql/request/builders/argument/graphql-observability-argument-builder.ts
@@ -20,6 +20,9 @@ export class GraphQlObservabilityArgumentBuilder extends GraphQlArgumentBuilder 
     };
   }
 
+  public forIncludeInactive(includeInactive?: boolean): GraphQlArgument[] {
+    return includeInactive !== undefined ? [{ name: 'includeInactive', value: includeInactive }] : [];
+  }
   public forNeighborType(type: EntityType): GraphQlArgument {
     return {
       name: 'neighborType',

--- a/projects/observability/src/shared/graphql/request/handlers/entities/query/entities-graphql-query-builder.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/entities/query/entities-graphql-query-builder.service.ts
@@ -37,7 +37,8 @@ export class EntitiesGraphqlQueryBuilderService {
       this.argBuilder.forTimeRange(request.timeRange),
       ...this.argBuilder.forOffset(request.offset),
       ...this.argBuilder.forOrderBy(request.sort),
-      ...this.buildFilters(request)
+      ...this.buildFilters(request),
+      ...this.argBuilder.forIncludeInactive(request.includeInactive)
     ];
   }
 
@@ -99,6 +100,7 @@ export interface GraphQlEntitiesRequest {
   sort?: GraphQlSortBySpecification;
   filters?: GraphQlFilter[];
   includeTotal?: boolean;
+  includeInactive?: boolean;
 }
 
 export interface EntitiesResponse {


### PR DESCRIPTION
## Description
support for includeInactive param in entities gql request

### Testing
Manually tested. UTs added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules