### PR TITLE
fix: break-all for json-viewer strings

### DIFF
--- a/projects/components/src/viewer/json-viewer/json-viewer.component.scss
+++ b/projects/components/src/viewer/json-viewer/json-viewer.component.scss
@@ -34,6 +34,7 @@
 
       .string-value {
         color: $green-5;
+        word-break: break-all;
       }
 
       .null-value {


### PR DESCRIPTION
## Description
Fix to prevent long json viewer strings from causing overflow.
