### PR TITLE
fix: update time duration <-> duration string conversion

### DIFF
--- a/projects/common/src/time/time-duration.test.ts
+++ b/projects/common/src/time/time-duration.test.ts
@@ -8,7 +8,8 @@ describe('Time duration', () => {
   });
 
   test('converts to ISO 8601 duration string correctly', () => {
-    expect(new TimeDuration(1, TimeUnit.Hour).toIso8601DurationString()).toBe('PT3600S');
+    expect(new TimeDuration(1, TimeUnit.Hour).toIso8601DurationString()).toBe('PT1H');
+    expect(new TimeDuration(1, TimeUnit.Day).toIso8601DurationString()).toBe('P1D');
   });
 
   test('can print a multi unit string', () => {
@@ -83,11 +84,11 @@ describe('Time duration', () => {
 
   test('can parse ISO 8601 duration string', () => {
     let duration = TimeDuration.parse('PT1H');
-    expect(duration.value).toBe(3600);
-    expect(duration.unit).toBe(TimeUnit.Second);
+    expect(duration!.value).toBe(1);
+    expect(duration!.unit).toBe(TimeUnit.Hour);
 
-    duration = TimeDuration.parse('PT1H5M');
-    expect(duration.value).toBe(3900);
-    expect(duration.unit).toBe(TimeUnit.Second);
+    duration = TimeDuration.parse('P5D');
+    expect(duration!.value).toBe(5);
+    expect(duration!.unit).toBe(TimeUnit.Day);
   });
 });

--- a/projects/common/src/time/time-duration.ts
+++ b/projects/common/src/time/time-duration.ts
@@ -1,4 +1,4 @@
-import { parse, toSeconds } from 'iso8601-duration';
+import { Duration, parse } from 'iso8601-duration';
 import { assertUnreachable } from '../utilities/lang/lang-utils';
 import { TimeUnit } from './time-unit.type';
 
@@ -14,8 +14,43 @@ export class TimeDuration {
     return this.millis;
   }
 
-  public static parse(durationString: string): TimeDuration {
-    return new TimeDuration(toSeconds(parse(durationString)), TimeUnit.Second);
+  /**
+   * Method to convert a duration string to TimeDuration object
+   * Currently we store the information as a single unit string.
+   * Will need to be updated to handle multiple units when needed.
+   */
+  public static parse(durationString: string): TimeDuration | undefined {
+    const duration: Duration = parse(durationString);
+    const isValid = (durationValue: number | undefined) => durationValue !== undefined && durationValue !== 0;
+    if (isValid(duration.years)) {
+      return new TimeDuration(duration.years!, TimeUnit.Year);
+    }
+
+    if (isValid(duration.months)) {
+      return new TimeDuration(duration.months!, TimeUnit.Month);
+    }
+
+    if (isValid(duration.weeks)) {
+      return new TimeDuration(duration.weeks!, TimeUnit.Week);
+    }
+
+    if (isValid(duration.days)) {
+      return new TimeDuration(duration.days!, TimeUnit.Day);
+    }
+
+    if (isValid(duration.hours)) {
+      return new TimeDuration(duration.hours!, TimeUnit.Hour);
+    }
+
+    if (isValid(duration.minutes)) {
+      return new TimeDuration(duration.minutes!, TimeUnit.Minute);
+    }
+
+    if (isValid(duration.seconds)) {
+      return new TimeDuration(duration.seconds!, TimeUnit.Second);
+    }
+
+    return undefined;
   }
 
   public getAmountForUnit(unit: ConvertibleTimeUnit): number {
@@ -23,7 +58,11 @@ export class TimeDuration {
   }
 
   public toIso8601DurationString(): string {
-    return `PT${this.toMillis() / 1000}S`;
+    if ([TimeUnit.Year, TimeUnit.Month, TimeUnit.Week, TimeUnit.Day].includes(this.unit)) {
+      return `P${this.value}${this.unit.toUpperCase()}`;
+    }
+
+    return `PT${this.value}${this.unit.toUpperCase()}`;
   }
 
   public toMultiUnitString(


### PR DESCRIPTION
## Description
Update time duration <-> iso 8601 duration string conversion logic.
Currently, all duration objects are converted to duration string after converting into seconds. And, all duration strings are converted to TimeDuration objects with seconds as unit.
This results in loss of unit selection and all values are forcefully converted to seconds.
This PR updates this logic.

TImeDuration to durationString conversion will now create a duration string using the unit of the duration object.
DurationString to TimeDuration conversion will now create a time duration object based on the biggest unit value specified in the duration string.

### Testing
UT added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules