### PR TITLE
fix(breadcrumbs): remove  bottom padding

### DIFF
--- a/projects/components/src/breadcrumbs/breadcrumbs.component.scss
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.scss
@@ -3,7 +3,6 @@
 .breadcrumbs {
   .breadcrumb-section {
     display: flex;
-    padding-bottom: 12px;
 
     .breadcrumb {
       @include body-small($blue-5);


### PR DESCRIPTION
- Remove bottom padding which change component position in global layout.
As this padding don't affect position of elements inside component we can add padding to parent component