### PR TITLE
fix (service overview): show services as downstream entities in dependency graph

### DIFF
--- a/projects/observability/src/pages/apis/service-detail/overview/service-overview.dashboard.ts
+++ b/projects/observability/src/pages/apis/service-detail/overview/service-overview.dashboard.ts
@@ -527,7 +527,7 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
             title: 'Dependency Graph',
             data: {
               type: 'topology-data-source',
-              'downstream-entities': ['API', 'BACKEND'],
+              'downstream-entities': ['SERVICE', 'BACKEND'],
               entity: 'SERVICE',
               'node-metrics': [
                 {


### PR DESCRIPTION
## Description
Show services as downstream entities instead of APIs in service overview page dependency graph.

### Testing
Manually verified.

### Checklist:
- [x] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] Any dependent changes have been merged and published in downstream modules
