### PR TITLE
feat: mixin to allow overriding overflow property for table

### DIFF
--- a/projects/assets-library/assets/styles/_layout.scss
+++ b/projects/assets-library/assets/styles/_layout.scss
@@ -51,3 +51,15 @@ $paginator-height: 48px;
   margin: 0 2px;
   border: 1px solid $gray-2;
 }
+
+@mixin override-table-overflow {
+  ::ng-deep {
+    ht-table > div.table {
+      overflow: initial;
+
+      & > .table {
+        overflow: initial;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Mixin to allow overriding overflow property for table.
When the table is used as an independent component with limited height in another component, without this override, the table header row loses its stickiness.

### Testing
Manually tested for the usecases. No impact on existing usages of table.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A)
- [x] Any dependent changes have been merged and published in downstream modules