### PR TITLE
fix: remove primary icon

### DIFF
--- a/projects/common/src/navigation/breadcrumb.ts
+++ b/projects/common/src/navigation/breadcrumb.ts
@@ -3,4 +3,5 @@ export interface Breadcrumb {
   icon?: string;
   url?: string[];
   hide?: boolean;
+  alwaysShowIcon?: boolean;
 }

--- a/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
@@ -6,7 +6,7 @@ import { EMPTY } from 'rxjs';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
 import { BreadcrumbsModule } from './breadcrumbs.module';
 
-describe('BreadcrumbsComponent', () => {
+fdescribe('BreadcrumbsComponent', () => {
   let spectator: Spectator<BreadcrumbsComponent>;
   let spy: jest.SpyInstance;
 
@@ -30,16 +30,20 @@ describe('BreadcrumbsComponent', () => {
             label: 'First',
             type: 'First Type',
             icon: 'firstIcon',
-            url: ['first', 'second']
+            url: ['first', 'second'],
+            alwaysShowIcon: false
           },
           {
-            label: 'Second'
+            label: 'Second',
+            icon: 'secondIcon',
+            alwaysShowIcon: true
           },
           {
             label: 'Third',
             type: 'Third Type',
-            icon: 'secondIcon',
-            url: ['first', 'second', 'third']
+            icon: 'thirdIcon',
+            url: ['first', 'second', 'third'],
+            alwaysShowIcon: false
           }
         ]
       }
@@ -53,12 +57,21 @@ describe('BreadcrumbsComponent', () => {
     expect(spectator.queryAll('.breadcrumbs .breadcrumb').length).toBe(3);
   });
 
-  it('should show icon only on the first crumb', () => {
+  it('should show icon on the first crumb if alwaysShowIcon is false', () => {
     const crumbs = spectator.queryAll('.breadcrumbs .breadcrumb');
     expect(crumbs[0].querySelector('ht-icon')).toExist();
+  });
 
+  it('should display the icon on a different crumb than the first one if alwaysShowIcon is true', () => {
+    const crumbs = spectator.queryAll('.breadcrumbs .breadcrumb');
     crumbs.shift();
-    crumbs.forEach(crumb => expect(crumb.querySelector('ht-icon')).toBeNull());
+    crumbs.forEach((crumb, index) => {
+      if (index == 0) {
+        expect(crumb.querySelector('ht-icon')).toExist();
+      } else {
+        expect(crumb.querySelector('ht-icon')).toBeNull();
+      }
+    });
   });
 
   it('should make last crumb inactive', () => {

--- a/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
@@ -6,7 +6,7 @@ import { EMPTY } from 'rxjs';
 import { BreadcrumbsComponent } from './breadcrumbs.component';
 import { BreadcrumbsModule } from './breadcrumbs.module';
 
-fdescribe('BreadcrumbsComponent', () => {
+describe('BreadcrumbsComponent', () => {
   let spectator: Spectator<BreadcrumbsComponent>;
   let spy: jest.SpyInstance;
 

--- a/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
@@ -66,9 +66,9 @@ describe('BreadcrumbsComponent', () => {
     const crumbs = spectator.queryAll('.breadcrumbs .breadcrumb');
     crumbs.forEach((crumb, index) => {
       if (index < crumbs.length - 1) {
-        expect(crumb.querySelector('ht-icon')).toBeNull();
-      } else {
         expect(crumb.querySelector('ht-icon')).toExist();
+      } else {
+        expect(crumb.querySelector('ht-icon')).toBeNull();
       }
     });
   });

--- a/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
@@ -68,7 +68,7 @@ describe('BreadcrumbsComponent', () => {
       if (index < crumbs.length - 1) {
         expect(crumb.querySelector('ht-icon')).toBeNull();
       } else {
-        expect(crumb.querySelector('hwt-icon')).toExist();
+        expect(crumb.querySelector('ht-icon')).toExist();
       }
     });
   });

--- a/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
@@ -57,16 +57,16 @@ fdescribe('BreadcrumbsComponent', () => {
     expect(spectator.queryAll('.breadcrumbs .breadcrumb').length).toBe(3);
   });
 
-  it('should show icon on the first crumb if alwaysShowIcon is false', () => {
+  it('should show icon on the first crumb', () => {
     const crumbs = spectator.queryAll('.breadcrumbs .breadcrumb');
     expect(crumbs[0].querySelector('ht-icon')).toExist();
   });
 
-  it('should display the icon on a different crumb than the first one if alwaysShowIcon is true', () => {
+  it('should display the icon if alwaysShowIcon is true', () => {
     const crumbs = spectator.queryAll('.breadcrumbs .breadcrumb');
     crumbs.shift();
     crumbs.forEach((crumb, index) => {
-      if (index == 0) {
+      if (index === 0) {
         expect(crumb.querySelector('ht-icon')).toExist();
       } else {
         expect(crumb.querySelector('ht-icon')).toBeNull();

--- a/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.test.ts
@@ -62,14 +62,13 @@ describe('BreadcrumbsComponent', () => {
     expect(crumbs[0].querySelector('ht-icon')).toExist();
   });
 
-  it('should display the icon if alwaysShowIcon is true', () => {
+  it('should display the icon', () => {
     const crumbs = spectator.queryAll('.breadcrumbs .breadcrumb');
-    crumbs.shift();
     crumbs.forEach((crumb, index) => {
-      if (index === 0) {
-        expect(crumb.querySelector('ht-icon')).toExist();
-      } else {
+      if (index < crumbs.length - 1) {
         expect(crumb.querySelector('ht-icon')).toBeNull();
+      } else {
+        expect(crumb.querySelector('hwt-icon')).toExist();
       }
     });
   });

--- a/projects/components/src/breadcrumbs/breadcrumbs.component.ts
+++ b/projects/components/src/breadcrumbs/breadcrumbs.component.ts
@@ -18,7 +18,7 @@ import { IconSize } from '../icon/icon-size';
         >
           <ht-icon
             class="icon"
-            *ngIf="isFirst"
+            *ngIf="isFirst || breadcrumb.alwaysShowIcon"
             [icon]="breadcrumb.icon"
             [label]="breadcrumb.label"
             size="${IconSize.Small}"

--- a/projects/components/src/header/page/page-header.component.ts
+++ b/projects/components/src/header/page/page-header.component.ts
@@ -18,7 +18,6 @@ import { NavigableTab } from '../../tabs/navigable/navigable-tab';
     >
       <div class="breadcrumb-container">
         <ht-breadcrumbs [breadcrumbs]="breadcrumbs"></ht-breadcrumbs>
-
         <div class="title" *ngIf="this.titlecrumb$ | async as titlecrumb">
           <ht-icon
             class="icon"

--- a/projects/components/src/header/page/page-header.component.ts
+++ b/projects/components/src/header/page/page-header.component.ts
@@ -22,7 +22,7 @@ import { NavigableTab } from '../../tabs/navigable/navigable-tab';
         <div class="title" *ngIf="this.titlecrumb$ | async as titlecrumb">
           <ht-icon
             class="icon"
-            *ngIf="titlecrumb.icon"
+            *ngIf="titlecrumb.icon && breadcrumbs.length <= 1"
             [icon]="titlecrumb.icon"
             [label]="titlecrumb.label"
             size="${IconSize.Large}"

--- a/projects/observability/src/pages/apis/backend-detail/backend-detail-breadcrumb.resolver.test.ts
+++ b/projects/observability/src/pages/apis/backend-detail/backend-detail-breadcrumb.resolver.test.ts
@@ -29,8 +29,7 @@ describe('Backend detail breadcrumb resolver', () => {
             [entityTypeKey]: ObservabilityEntityType.Backend,
             [entityIdKey]: 'test-id',
             name: 'test backend',
-            type: BackendType.Mysql,
-            alwaysShowIcon: false
+            type: BackendType.Mysql
           })
         )
       }),
@@ -64,7 +63,7 @@ describe('Backend detail breadcrumb resolver', () => {
           x: {
             label: 'test backend',
             icon: ObservabilityIconType.Mysql,
-            alwaysShowIcon: false
+            alwaysShowIcon: true
           }
         });
       });

--- a/projects/observability/src/pages/apis/backend-detail/backend-detail-breadcrumb.resolver.test.ts
+++ b/projects/observability/src/pages/apis/backend-detail/backend-detail-breadcrumb.resolver.test.ts
@@ -29,7 +29,8 @@ describe('Backend detail breadcrumb resolver', () => {
             [entityTypeKey]: ObservabilityEntityType.Backend,
             [entityIdKey]: 'test-id',
             name: 'test backend',
-            type: BackendType.Mysql
+            type: BackendType.Mysql,
+            alwaysShowIcon: false
           })
         )
       }),
@@ -62,7 +63,8 @@ describe('Backend detail breadcrumb resolver', () => {
         expectObservable(breadcrumb$).toBe('(x|)', {
           x: {
             label: 'test backend',
-            icon: ObservabilityIconType.Mysql
+            icon: ObservabilityIconType.Mysql,
+            alwaysShowIcon: false
           }
         });
       });

--- a/projects/observability/src/pages/apis/backend-detail/backend-detail-breadcrumb.resolver.ts
+++ b/projects/observability/src/pages/apis/backend-detail/backend-detail-breadcrumb.resolver.ts
@@ -32,7 +32,8 @@ export class BackendDetailBreadcrumbResolver implements Resolve<Observable<Bread
         take(1),
         map(backend => ({
           label: backend.name,
-          icon: this.iconLookupService.forBackendEntity(backend, this.getBackendTypeAttributeName())
+          icon: this.iconLookupService.forBackendEntity(backend, this.getBackendTypeAttributeName()),
+          alwaysShowIcon: true
         }))
       )
     );


### PR DESCRIPTION
## Description
This PR removes the double icons present in the breadcrumbs and the header, particularly in ht-page-header also to show or not the icons in the crumbs following the first crumb.

### Testing
Visual verification

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
