### PR TITLE
feat: email validator and a string formatter

### DIFF
--- a/projects/common/src/public-api.ts
+++ b/projects/common/src/public-api.ts
@@ -106,3 +106,6 @@ export * from './time/time-range.service';
 export * from './time/time-range.type';
 export * from './time/time-unit.type';
 export * from './time/time';
+
+// Validators
+export * from './utilities/validators/email-validator';

--- a/projects/common/src/utilities/formatters/string/string-formatter.test.ts
+++ b/projects/common/src/utilities/formatters/string/string-formatter.test.ts
@@ -1,4 +1,9 @@
-import { displayString, titleCaseFromKebabCase, titleCaseFromSnakeCase } from './string-formatter';
+import {
+  displayString,
+  getStringsFromCommaSeparatedList,
+  titleCaseFromKebabCase,
+  titleCaseFromSnakeCase
+} from './string-formatter';
 
 describe('String formatter', () => {
   test('can convert from kebab case to title case', () => {
@@ -25,5 +30,13 @@ describe('String formatter', () => {
     expect(displayString(() => 'hi')).toBe('Function');
     expect(displayString(Symbol('test symbol'))).toBe('Symbol(test symbol)');
     expect(displayString(false)).toBe('false');
+  });
+
+  test('creates string array correctly from comma separated list', () => {
+    expect(getStringsFromCommaSeparatedList('first,second,   third   ')).toEqual(
+      expect.arrayContaining(['first', 'second', 'third'])
+    );
+    expect(getStringsFromCommaSeparatedList('first,second,   ')).toEqual(expect.arrayContaining(['first', 'second']));
+    expect(getStringsFromCommaSeparatedList('first')).toEqual(expect.arrayContaining(['first']));
   });
 });

--- a/projects/common/src/utilities/formatters/string/string-formatter.ts
+++ b/projects/common/src/utilities/formatters/string/string-formatter.ts
@@ -42,3 +42,10 @@ export const displayString = (provided?: unknown): string => {
 export const collapseWhitespace = (str: string): string =>
   // Replace all whitespace with a single space
   str.replace(/\s\s+/g, ' ');
+
+export const getStringsFromCommaSeparatedList = (text: string): string[] =>
+  text
+    .trim()
+    .split(',')
+    .map(part => part.trim())
+    .filter(part => part !== '');

--- a/projects/common/src/utilities/validators/email-validator.test.ts
+++ b/projects/common/src/utilities/validators/email-validator.test.ts
@@ -2,19 +2,19 @@ import { areEmailAddressesValid, isEmailAddressValid } from '@hypertrace/common'
 
 describe('Email validator', () => {
   test('can validate email correctly', () => {
-    expect(isEmailAddressValid('test@traceable.ai')).toBe(true);
-    expect(isEmailAddressValid('test.email@traceable.ai')).toBe(true);
-    expect(isEmailAddressValid('test+983tonq@traceable.ai')).toBe(true);
-    expect(isEmailAddressValid('test@traceable.')).toBe(false);
+    expect(isEmailAddressValid('test@test.ai')).toBe(true);
+    expect(isEmailAddressValid('test.email@test.ai')).toBe(true);
+    expect(isEmailAddressValid('test+983tonq@test.ai')).toBe(true);
+    expect(isEmailAddressValid('test@test.')).toBe(false);
     expect(isEmailAddressValid('test')).toBe(false);
-    expect(isEmailAddressValid('test@traceable-')).toBe(false);
-    expect(isEmailAddressValid('tes\t@traceable-')).toBe(false);
-    expect(isEmailAddressValid('test@@traceable.ai')).toBe(false);
-    expect(isEmailAddressValid('test@@traceable.ai')).toBe(false);
+    expect(isEmailAddressValid('test@test-')).toBe(false);
+    expect(isEmailAddressValid('tes\t@test-')).toBe(false);
+    expect(isEmailAddressValid('test@@test.ai')).toBe(false);
+    expect(isEmailAddressValid('test@@test.ai')).toBe(false);
   });
 
   test('can validate email lists correctly', () => {
-    expect(areEmailAddressesValid(['test@traceable.ai', 'test.email@traceable.ai'])).toBe(true);
-    expect(areEmailAddressesValid(['test@traceable.ai', 'test.email@@traceable.ai'])).toBe(false);
+    expect(areEmailAddressesValid(['test@test.ai', 'test.email@test.ai'])).toBe(true);
+    expect(areEmailAddressesValid(['test@test.ai', 'test.email@@test.ai'])).toBe(false);
   });
 });

--- a/projects/common/src/utilities/validators/email-validator.test.ts
+++ b/projects/common/src/utilities/validators/email-validator.test.ts
@@ -1,0 +1,20 @@
+import { areEmailAddressesValid, isEmailAddressValid } from '@hypertrace/common';
+
+describe('Email validator', () => {
+  test('can validate email correctly', () => {
+    expect(isEmailAddressValid('test@traceable.ai')).toBe(true);
+    expect(isEmailAddressValid('test.email@traceable.ai')).toBe(true);
+    expect(isEmailAddressValid('test+983tonq@traceable.ai')).toBe(true);
+    expect(isEmailAddressValid('test@traceable.')).toBe(false);
+    expect(isEmailAddressValid('test')).toBe(false);
+    expect(isEmailAddressValid('test@traceable-')).toBe(false);
+    expect(isEmailAddressValid('tes\t@traceable-')).toBe(false);
+    expect(isEmailAddressValid('test@@traceable.ai')).toBe(false);
+    expect(isEmailAddressValid('test@@traceable.ai')).toBe(false);
+  });
+
+  test('can validate email lists correctly', () => {
+    expect(areEmailAddressesValid(['test@traceable.ai', 'test.email@traceable.ai'])).toBe(true);
+    expect(areEmailAddressesValid(['test@traceable.ai', 'test.email@@traceable.ai'])).toBe(false);
+  });
+});

--- a/projects/common/src/utilities/validators/email-validator.ts
+++ b/projects/common/src/utilities/validators/email-validator.ts
@@ -1,0 +1,10 @@
+export const isEmailAddressValid = (emailAddress: string) => {
+  // Regex as per W3C spec for email field
+  // Source: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+  const regex: RegExp = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+  return regex.test(emailAddress);
+};
+
+export const areEmailAddressesValid = (emailAddresses: string[]) =>
+  emailAddresses.filter(emailAddress => !isEmailAddressValid(emailAddress)).length === 0;


### PR DESCRIPTION
## Description
Validator for email.
String formatter to split a comma separated list into a string array.

### Testing
UTs added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules