### PR TITLE
feat: adding size option to toggle switch components

### DIFF
--- a/projects/components/src/toggle-switch/toggle-switch-size.ts
+++ b/projects/components/src/toggle-switch/toggle-switch-size.ts
@@ -1,0 +1,5 @@
+export const enum ToggleSwitchSize {
+    Small = 'small',
+    Medium = 'medium',
+  }
+  

--- a/projects/components/src/toggle-switch/toggle-switch-size.ts
+++ b/projects/components/src/toggle-switch/toggle-switch-size.ts
@@ -1,4 +1,4 @@
 export const enum ToggleSwitchSize {
-    Small = 'small',
-    Medium = 'medium',
+  Small = 'small',
+  Medium = 'medium'
 }

--- a/projects/components/src/toggle-switch/toggle-switch-size.ts
+++ b/projects/components/src/toggle-switch/toggle-switch-size.ts
@@ -1,5 +1,4 @@
 export const enum ToggleSwitchSize {
     Small = 'small',
     Medium = 'medium',
-  }
-  
+}

--- a/projects/components/src/toggle-switch/toggle-switch.component.scss
+++ b/projects/components/src/toggle-switch/toggle-switch.component.scss
@@ -4,13 +4,42 @@
 :host {
   ::ng-deep {
     .mat-slide-toggle {
-      height: 20px;
-      line-height: 20px;
+      &.small-slide-toogle {
+        height: 20px;
+        line-height: 20px;
+
+        &.mat-checked .mat-slide-toggle-thumb-container {
+          transform: translate3d(7px, 0, 0) !important;
+        }
+
+        .mat-slide-toggle-label {
+          .mat-slide-toggle-bar .mat-slide-toggle-thumb-container {
+            width: 12px;
+            height: 12px;
+
+            .mat-slide-toggle-ripple {
+              top: calc(50% - 7px);
+              left: calc(50% - 7px);
+              height: 14px;
+              width: 14px;
+            }
+          }
+
+          .mat-slide-toggle-thumb {
+            height: 12px;
+            width: 12px;
+          }
+
+          .mat-slide-toggle-bar {
+            width: 18px;
+            height: 6px;
+          }
+        }
+      }
     }
 
     .mat-checked {
       .mat-slide-toggle-thumb-container {
-        transform: translate3d(7px, 0, 0) !important;
         margin-left: 1px;
       }
 
@@ -25,27 +54,14 @@
 
     .mat-slide-toggle-thumb-container {
       margin-left: -1px;
-      width: 12px;
-      height: 12px;
-
-      .mat-slide-toggle-ripple {
-        top: calc(50% - 7px);
-        left: calc(50% - 7px);
-        height: 20px;
-        width: 20px;
-      }
     }
 
     .mat-slide-toggle-thumb {
       background-color: $gray-2;
-      height: 12px;
-      width: 12px;
     }
 
     .mat-slide-toggle-bar {
       background-color: $gray-5;
-      width: 18px;
-      height: 6px;
     }
   }
 }

--- a/projects/components/src/toggle-switch/toggle-switch.component.test.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.test.ts
@@ -3,8 +3,8 @@ import { fakeAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatSlideToggle, MatSlideToggleChange, MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { createHostFactory, Spectator } from '@ngneat/spectator/jest';
-import { ToggleSwitchComponent } from './toggle-switch.component';
 import { ToggleSwitchSize } from './toggle-switch-size';
+import { ToggleSwitchComponent } from './toggle-switch.component';
 
 describe('Toggle Switch Component', () => {
   let spectator: Spectator<ToggleSwitchComponent>;

--- a/projects/components/src/toggle-switch/toggle-switch.component.test.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.test.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { MatSlideToggle, MatSlideToggleChange, MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { createHostFactory, Spectator } from '@ngneat/spectator/jest';
 import { ToggleSwitchComponent } from './toggle-switch.component';
+import { ToggleSwitchSize } from './toggle-switch-size';
 
 describe('Toggle Switch Component', () => {
   let spectator: Spectator<ToggleSwitchComponent>;
@@ -17,13 +18,13 @@ describe('Toggle Switch Component', () => {
   test('should pass properties to Mat Slide toggle correctly', fakeAsync(() => {
     const onCheckedChangeSpy = jest.fn();
     spectator = createHost(
-      `<ht-toggle-switch [checked]="checked" [label]="label" [disabled]="disabled" [size]="small" (checkedChange)="onCheckedChange($event)"></ht-toggle-switch>`,
+      `<ht-toggle-switch [checked]="checked" [label]="label" [disabled]="disabled" [size]="size" (checkedChange)="onCheckedChange($event)"></ht-toggle-switch>`,
       {
         hostProps: {
           checked: true,
           label: 'label',
           disabled: false,
-          size: 'small',
+          size: ToggleSwitchSize.Small,
           onCheckedChange: onCheckedChangeSpy
         }
       }

--- a/projects/components/src/toggle-switch/toggle-switch.component.test.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.test.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { fakeAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatSlideToggle, MatSlideToggleChange, MatSlideToggleModule } from '@angular/material/slide-toggle';
@@ -10,18 +11,19 @@ describe('Toggle Switch Component', () => {
   const createHost = createHostFactory({
     component: ToggleSwitchComponent,
     shallow: true,
-    imports: [MatSlideToggleModule, FormsModule]
+    imports: [MatSlideToggleModule, FormsModule, CommonModule]
   });
 
   test('should pass properties to Mat Slide toggle correctly', fakeAsync(() => {
     const onCheckedChangeSpy = jest.fn();
     spectator = createHost(
-      `<ht-toggle-switch [checked]="checked" [label]="label" [disabled]="disabled" (checkedChange)="onCheckedChange($event)"></ht-toggle-switch>`,
+      `<ht-toggle-switch [checked]="checked" [label]="label" [disabled]="disabled" [size]="small" (checkedChange)="onCheckedChange($event)"></ht-toggle-switch>`,
       {
         hostProps: {
           checked: true,
           label: 'label',
           disabled: false,
+          size: 'small',
           onCheckedChange: onCheckedChangeSpy
         }
       }
@@ -33,6 +35,7 @@ describe('Toggle Switch Component', () => {
     expect(matToggleComponent?.checked).toBeTruthy();
     expect(matToggleComponent?.disabled).toBeFalsy();
     expect(spectator.query('.label')).toHaveText('label');
+    expect(spectator.query('mat-slide-toggle')).toHaveClass('small-slide-toogle');
 
     spectator.triggerEventHandler(MatSlideToggle, 'change', new MatSlideToggleChange(matToggleComponent!, false));
     expect(onCheckedChangeSpy).toHaveBeenCalledWith(false);

--- a/projects/components/src/toggle-switch/toggle-switch.component.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.ts
@@ -10,7 +10,7 @@ import { ToggleSwitchSize } from './toggle-switch-size';
     <mat-slide-toggle
       color="primary"
       [(ngModel)]="this.checked"
-      [ngClass]="{ 'small-slide-toogle': this.size === '${ToggleSwitchSize.Small}' }"
+      [ngClass]="{ 'small-slide-toogle': this.size === "${ToggleSwitchSize.Small}" }"
       [disabled]="this.disabled"
       (change)="this.onToggle($event)"
     >

--- a/projects/components/src/toggle-switch/toggle-switch.component.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.ts
@@ -10,7 +10,7 @@ import { ToggleSwitchSize } from './toggle-switch-size';
     <mat-slide-toggle
       color="primary"
       [(ngModel)]="this.checked"
-      [ngClass]="{ 'small-slide-toogle': this.size === ${ToggleSwitchSize.Small} }"
+      [ngClass]="{ 'small-slide-toogle': this.size === '${ToggleSwitchSize.Small}' }"
       [disabled]="this.disabled"
       (change)="this.onToggle($event)"
     >

--- a/projects/components/src/toggle-switch/toggle-switch.component.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
+import { ToggleSwitchSize } from './toggle-switch-size';
 
 @Component({
   selector: 'ht-toggle-switch',
@@ -9,7 +10,7 @@ import { MatSlideToggleChange } from '@angular/material/slide-toggle';
     <mat-slide-toggle
       color="primary"
       [(ngModel)]="this.checked"
-      [ngClass]="{ 'small-slide-toogle': this.size === 'small' }"
+      [ngClass]="{ 'small-slide-toogle': this.size === ${ToggleSwitchSize.Small} }"
       [disabled]="this.disabled"
       (change)="this.onToggle($event)"
     >
@@ -28,7 +29,7 @@ export class ToggleSwitchComponent {
   public disabled?: boolean;
 
   @Input()
-  public size?: string = 'small';
+  public size: ToggleSwitchSize = ToggleSwitchSize.Medium;
 
   @Output()
   public readonly checkedChange: EventEmitter<boolean> = new EventEmitter();

--- a/projects/components/src/toggle-switch/toggle-switch.component.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.ts
@@ -10,7 +10,7 @@ import { ToggleSwitchSize } from './toggle-switch-size';
     <mat-slide-toggle
       color="primary"
       [(ngModel)]="this.checked"
-      [ngClass]="{ 'small-slide-toogle': this.size === "${ToggleSwitchSize.Small}" }"
+      [ngClass]="{ 'small-slide-toogle': this.size === '${ToggleSwitchSize.Small}' }"
       [disabled]="this.disabled"
       (change)="this.onToggle($event)"
     >

--- a/projects/components/src/toggle-switch/toggle-switch.component.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.component.ts
@@ -9,6 +9,7 @@ import { MatSlideToggleChange } from '@angular/material/slide-toggle';
     <mat-slide-toggle
       color="primary"
       [(ngModel)]="this.checked"
+      [ngClass]="{ 'small-slide-toogle': this.size === 'small' }"
       [disabled]="this.disabled"
       (change)="this.onToggle($event)"
     >
@@ -25,6 +26,9 @@ export class ToggleSwitchComponent {
 
   @Input()
   public disabled?: boolean;
+
+  @Input()
+  public size?: string = 'small';
 
   @Output()
   public readonly checkedChange: EventEmitter<boolean> = new EventEmitter();

--- a/projects/components/src/toggle-switch/toggle-switch.module.ts
+++ b/projects/components/src/toggle-switch/toggle-switch.module.ts
@@ -1,10 +1,11 @@
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { ToggleSwitchComponent } from './toggle-switch.component';
 
 @NgModule({
-  imports: [FormsModule, MatSlideToggleModule, FormsModule],
+  imports: [FormsModule, MatSlideToggleModule, CommonModule],
   declarations: [ToggleSwitchComponent],
   exports: [ToggleSwitchComponent]
 })


### PR DESCRIPTION
## Description

Added an optional input to modify the default styles of the toggle switch that were defined as small. The styles were encapsulated in relation to the new class.

### Testing

Visual Verification.

![image](https://user-images.githubusercontent.com/79482271/110371166-5ac8f300-802b-11eb-840b-894c469e7c04.png)


### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
