### PR TITLE
refactor: using css grid to differentiate with flex parent

### DIFF
--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -3,16 +3,14 @@
 
 .table-container {
   position: relative;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: 1fr max-content;
   height: 100%;
   width: 100%;
 }
 
-.table {
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
+.data-container {
   height: 100%;
   width: 100%;
   overflow: auto;
@@ -114,16 +112,15 @@
 }
 
 .state-watcher {
-  height: calc(100% - #{$paginator-height});
+  height: 100%;
   width: 100%;
   position: absolute;
   background: transparent;
+  z-index: 10;
 }
 
 .pagination-controls {
-  position: fixed;
   width: 100%;
   height: #{$paginator-height};
-  bottom: 0;
   background: white;
 }


### PR DESCRIPTION

## Description
Please include a summary of the change, motivation and context.
refactor: using css grid to differentiate with flex parent

- I think we don't understand flex propertly. When this table is put
  inside a variable height flex container, things doesn't work. After
  some hit and trial, i noticed that using a grid boundary does
  at the root level does help with our layout issues as it no
  longer react to parent flex changes in a similar fashion

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
