### PR TITLE
fix: remove host max width for select component

### DIFF
--- a/projects/components/src/select/select.component.scss
+++ b/projects/components/src/select/select.component.scss
@@ -2,7 +2,6 @@
 
 :host {
   width: 100%;
-  max-width: 240px;
 
   .select {
     .trigger-label {


### PR DESCRIPTION
## Description
Remove host max width for select component.
Containers of the component should be able to control the width.