### PR TITLE
ci: ignore error in unit test result publish

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,6 +146,7 @@ jobs:
 
       - name: Publish Unit Test Results
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: artifacts/**/*.xml


### PR DESCRIPTION
## Description
Dependabot now has a read only token and fails to upload test results - so making that optional.