### PR TITLE
refactor: use new group limit in explorer

### DIFF
--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.test.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.test.ts
@@ -87,6 +87,7 @@ describe('Explorer dashboard builder', () => {
       const mockRequest: ExploreVisualizationRequest = {
         context: ObservabilityTraceType.Api,
         series: [series],
+        resultLimit: 1000,
         exploreQuery$: EMPTY,
         resultsQuery$: of({
           requestType: TRACES_GQL_REQUEST,

--- a/projects/observability/src/pages/explorer/explorer.component.test.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.test.ts
@@ -138,7 +138,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: EXPLORE_GQL_REQUEST,
         context: ObservabilityTraceType.Api,
-        limit: 500,
+        limit: 1000,
         interval: new TimeDuration(15, TimeUnit.Second)
       }),
       expect.objectContaining({})
@@ -186,7 +186,7 @@ describe('Explorer component', () => {
         requestType: EXPLORE_GQL_REQUEST,
         context: ObservabilityTraceType.Api,
         filters: [new GraphQlFieldFilter('first', GraphQlOperatorType.Equals, 'foo')],
-        limit: 500,
+        limit: 1000,
         interval: new TimeDuration(15, TimeUnit.Second)
       }),
       expect.objectContaining({})
@@ -222,7 +222,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: EXPLORE_GQL_REQUEST,
         context: SPAN_SCOPE,
-        limit: 500,
+        limit: 1000,
         interval: new TimeDuration(15, TimeUnit.Second)
       }),
       expect.objectContaining({})
@@ -274,7 +274,7 @@ describe('Explorer component', () => {
       expect.objectContaining({
         requestType: EXPLORE_GQL_REQUEST,
         context: SPAN_SCOPE,
-        limit: 500,
+        limit: 1000,
         interval: new TimeDuration(15, TimeUnit.Second),
         filters: [new GraphQlFieldFilter('first', GraphQlOperatorType.Equals, 'foo')]
       }),

--- a/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.test.ts
@@ -174,9 +174,9 @@ describe('Explore query editor', () => {
     expect(onRequestChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
         series: [defaultSeries],
-        groupByLimit: 5, // Default group by limit
         groupBy: {
-          keys: ['first groupable']
+          keys: ['first groupable'],
+          limit: 5 // Default group by limit
         }
       })
     );
@@ -213,9 +213,9 @@ describe('Explore query editor', () => {
     expect(onQueryChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
         series: [defaultSeries],
-        groupByLimit: 6,
         groupBy: {
-          keys: ['first groupable']
+          keys: ['first groupable'],
+          limit: 6
         }
       })
     );

--- a/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.ts
@@ -44,12 +44,12 @@ import {
         ></ht-explore-query-group-by-editor>
 
         <ht-explore-query-limit-editor
+          *ngIf="currentVisualization.groupBy"
           class="limit"
-          [limit]="currentVisualization.groupByLimit"
-          (limitChange)="this.setLimit($event)"
+          [limit]="currentVisualization.groupBy?.limit"
+          (limitChange)="this.updateGroupByLimit(currentVisualization.groupBy!, $event)"
           [includeRest]="currentVisualization.groupBy?.includeRest"
           (includeRestChange)="this.updateGroupByIncludeRest(currentVisualization.groupBy!, $event)"
-          [disabled]="!currentVisualization.groupBy"
         >
         </ht-explore-query-limit-editor>
       </div>
@@ -57,6 +57,7 @@ import {
   `
 })
 export class ExploreQueryEditorComponent implements OnChanges, OnInit {
+  private static readonly DEFAULT_GROUP_LIMIT: number = 5;
   @Input()
   public filters?: Filter[];
 
@@ -94,7 +95,9 @@ export class ExploreQueryEditorComponent implements OnChanges, OnInit {
     if (key === undefined) {
       this.visualizationBuilder.groupBy();
     } else {
-      this.visualizationBuilder.groupBy(groupBy ? { ...groupBy, keys: [key] } : { keys: [key] });
+      this.visualizationBuilder.groupBy(
+        groupBy ? { ...groupBy, keys: [key] } : { keys: [key], limit: ExploreQueryEditorComponent.DEFAULT_GROUP_LIMIT }
+      );
     }
   }
 
@@ -102,8 +105,8 @@ export class ExploreQueryEditorComponent implements OnChanges, OnInit {
     this.visualizationBuilder.groupBy({ ...groupBy, includeRest: includeRest });
   }
 
-  public setLimit(limit: number): void {
-    this.visualizationBuilder.groupByLimit(limit);
+  public updateGroupByLimit(groupBy: GraphQlGroupBy, limit: number): void {
+    this.visualizationBuilder.groupBy({ ...groupBy, limit: limit });
   }
 
   public setInterval(interval: IntervalValue): void {

--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.test.ts
@@ -83,30 +83,23 @@ describe('Explore visualization builder', () => {
       spectator.service
         .setSeries([buildSeries('test1')])
         .groupBy({
-          keys: ['testGroupBy']
+          keys: ['testGroupBy'],
+          limit: 15
         })
-        .groupByLimit(15)
         .setSeries([buildSeries('test2')]);
 
-      expectObservable(recordedRequests).toBe('(abcde)', {
+      expectObservable(recordedRequests).toBe('(abcd)', {
         a: expectedQuery(),
         b: expectedQuery({
           series: [matchSeriesWithName('test1')]
         }),
         c: expectedQuery({
           series: [matchSeriesWithName('test1')],
-          groupBy: { keys: ['testGroupBy'] },
-          groupByLimit: 5
+          groupBy: { keys: ['testGroupBy'], limit: 15 }
         }),
         d: expectedQuery({
-          series: [matchSeriesWithName('test1')],
-          groupBy: { keys: ['testGroupBy'] },
-          groupByLimit: 15
-        }),
-        e: expectedQuery({
           series: [matchSeriesWithName('test2')],
-          groupBy: { keys: ['testGroupBy'] },
-          groupByLimit: 15
+          groupBy: { keys: ['testGroupBy'], limit: 15 }
         })
       });
     });

--- a/projects/observability/src/shared/components/explore-query-editor/limit/explore-query-limit-editor.component.scss
+++ b/projects/observability/src/shared/components/explore-query-editor/limit/explore-query-limit-editor.component.scss
@@ -13,7 +13,6 @@
 
     .limit-label {
       @include body-1-medium($gray-9);
-      @include disableable;
       height: 32px;
       line-height: 32px;
       margin-bottom: 12px;

--- a/projects/observability/src/shared/components/explore-query-editor/limit/explore-query-limit-editor.component.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/limit/explore-query-limit-editor.component.test.ts
@@ -26,25 +26,6 @@ describe('Explore Query Limit Editor component', () => {
     expect(spectator.query(InputComponent)!.value).toBe(12);
   });
 
-  test('sets limit as disabled and display to Auto when disabled', () => {
-    const spectator = hostBuilder(
-      `
-    <ht-explore-query-limit-editor [limit]="limit" [disabled]="disabled">
-    </ht-explore-query-limit-editor>`,
-      {
-        hostProps: {
-          limit: 12,
-          disabled: true
-        }
-      }
-    );
-
-    expect(spectator.query(InputComponent)!.value).toBe('Auto');
-    expect(spectator.query(InputComponent)!.type).toBe('text');
-    expect(spectator.query(InputComponent)!.disabled).toBe(true);
-    expect(spectator.query('.limit-label')).toHaveClass('disabled');
-  });
-
   test('updates when the provided limit changes', () => {
     const spectator = hostBuilder(
       `

--- a/projects/observability/src/shared/components/explore-query-editor/limit/explore-query-limit-editor.component.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/limit/explore-query-limit-editor.component.ts
@@ -8,27 +8,21 @@ import { InputAppearance } from '@hypertrace/components';
   template: `
     <div class="limit-container">
       <div class="limit-number-input-container">
-        <span class="limit-label" [ngClass]="{ disabled: this.disabled }"> Max Results </span>
+        <span class="limit-label"> Max Groups </span>
         <div class="limit-input-wrapper">
           <ht-input
-            [type]="this.getInputType()"
+            type="number"
             class="limit-input"
             appearance="${InputAppearance.Border}"
-            [disabled]="this.disabled"
-            [value]="this.getLimitValue()"
+            [value]="this.limit"
             (valueChange)="this.limitChange.emit($event)"
           >
           </ht-input>
         </div>
       </div>
-      <div class="limit-include-rest-container" *ngIf="!this.disabled">
+      <div class="limit-include-rest-container">
         <span class="limit-include-rest-label"> Show Other: </span>
-        <ht-checkbox
-          [disabled]="this.disabled"
-          [checked]="this.includeRest"
-          (checkedChange)="this.includeRestChange.emit($event)"
-        >
-        </ht-checkbox>
+        <ht-checkbox [checked]="this.includeRest" (checkedChange)="this.includeRestChange.emit($event)"> </ht-checkbox>
       </div>
     </div>
   `
@@ -40,20 +34,9 @@ export class ExploreQueryLimitEditorComponent {
   @Input()
   public includeRest: boolean = false;
 
-  @Input()
-  public disabled: boolean = false;
-
   @Output()
   public readonly limitChange: EventEmitter<number> = new EventEmitter();
 
   @Output()
   public readonly includeRestChange: EventEmitter<boolean> = new EventEmitter();
-
-  public getInputType(): string {
-    return this.disabled ? 'text' : 'number';
-  }
-
-  public getLimitValue(): string | number {
-    return this.disabled ? 'Auto' : this.limit;
-  }
 }

--- a/projects/observability/src/shared/dashboard/data/graphql/explore/explore-cartesian-data-source.model.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/explore/explore-cartesian-data-source.model.test.ts
@@ -150,7 +150,8 @@ describe('Explore cartesian data source model', () => {
 
     model.groupBy = {
       keys: ['baz'],
-      includeRest: true
+      includeRest: true,
+      limit: 5
     };
 
     runFakeRxjs(({ expectObservable }) => {
@@ -212,7 +213,8 @@ describe('Explore cartesian data source model', () => {
     ];
 
     model.groupBy = {
-      keys: ['baz']
+      keys: ['baz'],
+      limit: 5
     };
 
     runFakeRxjs(({ expectObservable }) => {
@@ -316,7 +318,7 @@ export class TestExploreCartesianDataSourceModel extends ExploreCartesianDataSou
   public series?: ExploreSeries[];
   public context?: string = 'context_scope';
   public groupBy?: GraphQlGroupBy;
-  public groupByLimit?: number;
+  public resultLimit: number = 100;
 
   protected buildRequestState(interval?: TimeDuration | 'AUTO'): ExploreRequestState | undefined {
     if ((this.series ?? [])?.length === 0 || this.context === undefined) {
@@ -328,7 +330,7 @@ export class TestExploreCartesianDataSourceModel extends ExploreCartesianDataSou
       context: this.context,
       interval: interval,
       groupBy: this.groupBy,
-      groupByLimit: this.groupByLimit
+      resultLimit: this.resultLimit
     };
   }
 }

--- a/projects/observability/src/shared/dashboard/data/graphql/explore/explore-cartesian-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/explore/explore-cartesian-data-source.model.ts
@@ -63,7 +63,7 @@ export abstract class ExploreCartesianDataSourceModel extends GraphQlDataSourceM
       requestType: EXPLORE_GQL_REQUEST,
       selections: requestState.series.map(series => series.specification),
       context: requestState.context,
-      limit: requestState.groupByLimit ?? 100,
+      limit: requestState.resultLimit,
       timeRange: this.getTimeRangeOrThrow(),
       interval: requestState.interval as TimeDuration,
       filters: filters,

--- a/projects/observability/src/shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-cartesian-data-source.model.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-cartesian-data-source.model.test.ts
@@ -80,6 +80,7 @@ describe('Explorer Visualization cartesian data source model', () => {
       selections: partialRequest.series.map(series => series.specification)
     } as const),
     resultsQuery$: EMPTY,
+    resultLimit: 1000,
     series: partialRequest.series,
     groupBy: partialRequest.groupBy,
     interval: partialRequest.interval,
@@ -160,7 +161,8 @@ describe('Explorer Visualization cartesian data source model', () => {
     model.request = buildVisualizationRequest({
       interval: undefined,
       groupBy: {
-        keys: ['baz']
+        keys: ['baz'],
+        limit: 10
       },
       series: [
         {
@@ -224,7 +226,8 @@ describe('Explorer Visualization cartesian data source model', () => {
     model.request = buildVisualizationRequest({
       interval: 'AUTO',
       groupBy: {
-        keys: ['baz']
+        keys: ['baz'],
+        limit: 5
       },
       series: [
         {

--- a/projects/observability/src/shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-cartesian-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-cartesian-data-source.model.ts
@@ -1,4 +1,3 @@
-import { TimeDuration } from '@hypertrace/common';
 import { GraphQlFilter } from '@hypertrace/distributed-tracing';
 import { Model } from '@hypertrace/hyperdash';
 import { NEVER, Observable } from 'rxjs';
@@ -19,10 +18,8 @@ import { ExploreCartesianDataSourceModel, ExplorerData } from '../explore/explor
 export class ExplorerVisualizationCartesianDataSourceModel extends ExploreCartesianDataSourceModel {
   public request?: ExploreVisualizationRequest;
 
-  protected fetchResults(interval: TimeDuration | 'AUTO'): Observable<CartesianResult<ExplorerData>> {
-    const requestState = this.buildRequestState(interval);
-
-    if (this.request === undefined || requestState === undefined) {
+  protected fetchResults(): Observable<CartesianResult<ExplorerData>> {
+    if (this.request === undefined) {
       return NEVER;
     }
 
@@ -30,7 +27,7 @@ export class ExplorerVisualizationCartesianDataSourceModel extends ExploreCartes
       switchMap(exploreRequest =>
         this.query<ExploreGraphQlQueryHandlerService>(inheritedFilters =>
           this.appendFilters(exploreRequest, this.getFilters(inheritedFilters))
-        ).pipe(mergeMap(response => this.mapResponseData(requestState, response)))
+        ).pipe(mergeMap(response => this.mapResponseData(this.request!, response)))
       )
     );
   }
@@ -46,17 +43,8 @@ export class ExplorerVisualizationCartesianDataSourceModel extends ExploreCartes
     };
   }
 
-  protected buildRequestState(interval: TimeDuration | 'AUTO'): ExploreRequestState | undefined {
-    if (this.request?.series.length === 0 || this.request?.context === undefined) {
-      return undefined;
-    }
-
-    return {
-      series: this.request.series,
-      context: this.request.context,
-      interval: interval,
-      groupBy: this.request.groupBy,
-      groupByLimit: this.request.groupByLimit
-    };
+  protected buildRequestState(): ExploreRequestState | undefined {
+    // Unused since fetchResults is overriden, but abstract so requires a def
+    return undefined;
   }
 }

--- a/projects/observability/src/shared/dashboard/data/graphql/table/explore/explore-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/explore/explore-table-data-source.model.ts
@@ -12,6 +12,7 @@ import {
   ModelModelPropertyTypeInstance,
   ModelProperty,
   ModelPropertyType,
+  NUMBER_PROPERTY,
   STRING_PROPERTY
 } from '@hypertrace/hyperdash';
 import { ExploreSpecification } from './../../../../../graphql/model/schema/specifications/explore-specification';
@@ -57,6 +58,13 @@ export class ExploreTableDataSourceModel extends TableDataSourceModel {
   })
   public groupByIncludeRest: boolean = true;
 
+  @ModelProperty({
+    key: 'group-limit',
+    required: false,
+    type: NUMBER_PROPERTY.type
+  })
+  public groupLimit: number = 100;
+
   public getScope(): string {
     return this.context;
   }
@@ -82,7 +90,8 @@ export class ExploreTableDataSourceModel extends TableDataSourceModel {
       timeRange: this.getTimeRangeOrThrow(),
       groupBy: {
         keys: this.groupBy,
-        includeRest: this.groupByIncludeRest
+        includeRest: this.groupByIncludeRest,
+        limit: this.groupLimit
       }
     };
   }

--- a/projects/observability/src/shared/dashboard/data/graphql/trace/donut/trace-donut-data-source.model.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/trace/donut/trace-donut-data-source.model.test.ts
@@ -65,7 +65,8 @@ describe('Donut data source model', () => {
           timeRange: GraphQlTimeRange.fromTimeRange(mockTimeRange),
           filters: [],
           groupBy: {
-            keys: ['bar']
+            keys: ['bar'],
+            limit: 3
           },
           limit: 3,
           selections: [

--- a/projects/observability/src/shared/dashboard/data/graphql/trace/donut/trace-donut-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/trace/donut/trace-donut-data-source.model.ts
@@ -63,7 +63,8 @@ export class TraceDonutDataSourceModel extends GraphQlDataSourceModel<DonutSerie
       timeRange: this.getTimeRangeOrThrow(),
       filters: filters,
       groupBy: {
-        keys: [this.groupBy.name]
+        keys: [this.groupBy.name],
+        limit: this.maxResults
       }
     })).pipe(map(exploreResponse => this.buildDonutResults(exploreResponse, this.metric)));
   }

--- a/projects/observability/src/shared/dashboard/widgets/top-n/data/top-n-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/widgets/top-n/data/top-n-data-source.model.ts
@@ -65,7 +65,8 @@ export class TopNDataSourceModel extends GraphQlDataSourceModel<TopNWidgetDataFe
       selections: [labelAttributeSpec, idAttributeSpec, metricSpec.metric],
       filters: (filters ?? []).concat(metricSpec.filters ?? []),
       groupBy: {
-        keys: [labelAttributeSpec.name, idAttributeSpec.name]
+        keys: [labelAttributeSpec.name, idAttributeSpec.name],
+        limit: this.resultLimit
       },
       orderBy: [
         {

--- a/projects/observability/src/shared/graphql/model/schema/groupby/graphql-group-by.ts
+++ b/projects/observability/src/shared/graphql/model/schema/groupby/graphql-group-by.ts
@@ -1,4 +1,5 @@
 export interface GraphQlGroupBy {
   keys: string[];
   includeRest?: boolean;
+  limit: number;
 }

--- a/projects/observability/src/shared/graphql/request/builders/argument/graphql-observability-argument-builder.ts
+++ b/projects/observability/src/shared/graphql/request/builders/argument/graphql-observability-argument-builder.ts
@@ -142,10 +142,12 @@ export class GraphQlObservabilityArgumentBuilder extends GraphQlArgumentBuilder 
           // Remove includeRest key if undefined
           groupBy.includeRest === undefined
             ? {
-                keys: groupBy.keys
+                keys: groupBy.keys,
+                groupLimit: groupBy.limit
               }
             : {
                 keys: groupBy.keys,
+                groupLimit: groupBy.limit,
                 includeRest: groupBy.includeRest
               }
       }

--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
@@ -53,7 +53,7 @@ describe('Explore graphql query handler', () => {
     requestType: EXPLORE_GQL_REQUEST,
     context: ObservabilityTraceType.Api,
     timeRange: testTimeRange,
-    limit: 2,
+    limit: 4,
     offset: 0,
     includeTotal: true,
     selections: [
@@ -62,6 +62,7 @@ describe('Explore graphql query handler', () => {
     ],
     interval: new TimeDuration(1, TimeUnit.Minute),
     groupBy: {
+      limit: 2,
       includeRest: true,
       keys: ['serviceName']
     },
@@ -90,7 +91,7 @@ describe('Explore graphql query handler', () => {
       path: 'explore',
       arguments: [
         { name: 'context', value: new GraphQlEnumArgument(ObservabilityTraceType.Api) },
-        { name: 'limit', value: 2 },
+        { name: 'limit', value: 4 },
         {
           name: 'between',
           value: {
@@ -121,7 +122,8 @@ describe('Explore graphql query handler', () => {
           name: 'groupBy',
           value: {
             includeRest: true,
-            keys: ['serviceName']
+            keys: ['serviceName'],
+            groupLimit: 2
           }
         },
         {
@@ -184,7 +186,7 @@ describe('Explore graphql query handler', () => {
       path: 'explore',
       arguments: [
         { name: 'context', value: new GraphQlEnumArgument(ObservabilityEntityType.Api) },
-        { name: 'limit', value: 2 },
+        { name: 'limit', value: 4 },
         {
           name: 'between',
           value: {
@@ -215,7 +217,8 @@ describe('Explore graphql query handler', () => {
           name: 'groupBy',
           value: {
             includeRest: true,
-            keys: ['serviceName']
+            keys: ['serviceName'],
+            groupLimit: 2
           }
         },
         {


### PR DESCRIPTION
## Description
Uses the new group limit parameter in explorer api instead of the deprecated row limit behavior.

### Testing
Visual verification, updated tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

