### PR TITLE
fix: header title highlighted when sorting

### DIFF
--- a/projects/components/src/table/header/table-header-cell-renderer.component.scss
+++ b/projects/components/src/table/header/table-header-cell-renderer.component.scss
@@ -49,6 +49,11 @@
     min-width: 0;
     width: 100%;
 
+    &.asc,
+    &.desc {
+      color: $gray-9;
+    }
+
     &:after {
       display: inline-block;
     }


### PR DESCRIPTION
## Description
A column is darkened/highlighted when sorting is active for that header.

### Testing
Visual Test

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.