### PR TITLE
fix: Unable to click topology

### DIFF
--- a/projects/observability/src/shared/components/topology/d3/d3-topology.ts
+++ b/projects/observability/src/shared/components/topology/d3/d3-topology.ts
@@ -318,7 +318,7 @@ export class D3Topology implements Topology {
         this.neighborhoodFinder.neighborhoodForNode(hoverEvent.source.userNode),
         this.neighborhoodFinder.singleNodeNeighborhood(hoverEvent.source.userNode)
       );
-      this.tooltip && this.tooltip.showWithNodeData(hoverEvent.source.userNode);
+      this.showNodeTooltip(hoverEvent.source, false);
     }
   }
 
@@ -328,7 +328,7 @@ export class D3Topology implements Topology {
       this.tooltip && this.tooltip.hide();
     } else {
       this.emphasizeTopologyNeighborhood(this.neighborhoodFinder.neighborhoodForEdge(hoverEvent.source.userEdge));
-      this.tooltip && this.tooltip.showWithEdgeData(hoverEvent.source.userEdge);
+      this.showEdgeTooltip(hoverEvent.source, false);
     }
   }
 
@@ -386,7 +386,7 @@ export class D3Topology implements Topology {
     );
     if (this.tooltip) {
       // TODO - a modal tooltip disables the interactions like hover (which is good), but doesn't allow clicking another element without an extra click
-      this.tooltip.showWithNodeData(node.userNode, { modal: true });
+      this.showNodeTooltip(node, true);
       this.tooltip.hidden$.pipe(take(1)).subscribe(() => this.resetVisibility());
     }
   }
@@ -395,7 +395,7 @@ export class D3Topology implements Topology {
     this.emphasizeTopologyNeighborhood(this.neighborhoodFinder.neighborhoodForEdge(edge.userEdge));
     if (this.tooltip) {
       // TODO - a modal tooltip disables the interactions like hover (which is good), but doesn't allow clicking another element without an extra click
-      this.tooltip.showWithEdgeData(edge.userEdge, { modal: true });
+      this.showEdgeTooltip(edge, true);
       this.tooltip.hidden$.pipe(take(1)).subscribe(() => this.resetVisibility());
     }
   }
@@ -422,5 +422,20 @@ export class D3Topology implements Topology {
   private select<T extends Element>(selector: string | T): Selection<T, unknown, null, undefined> {
     return this.d3Util.select<T>(selector, this.domRenderer);
   }
-  // tslint:disable-next-line: max-file-line-count
+
+  private showNodeTooltip(node: RenderableTopologyNode, modal: boolean): void {
+    const originEl = this.nodeRenderer.getElementForNode(node);
+    if (!originEl || !this.tooltip) {
+      return;
+    }
+    this.tooltip.showWithNodeData(node.userNode, new ElementRef(originEl), { modal: modal });
+  }
+
+  private showEdgeTooltip(edge: RenderableTopologyEdge, modal: boolean): void {
+    const originEl = this.edgeRenderer.getElementForEdge(edge);
+    if (!originEl || !this.tooltip) {
+      return;
+    }
+    this.tooltip.showWithEdgeData(edge.userEdge, new ElementRef(originEl), { modal: modal });
+  }
 }

--- a/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
+++ b/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
@@ -20,7 +20,7 @@ export class TopologyTooltipPopover implements TopologyTooltip {
     private readonly injector: Injector,
     private readonly popoverService: PopoverService
   ) {
-    this.popoverSubject = new BehaviorSubject(this.buildPopover(false));
+    this.popoverSubject = new BehaviorSubject(this.buildPopover(false, null));
     this.hidden$ = this.popoverSubject.pipe(switchMap(popover => merge(popover.hidden$, popover.closed$)));
   }
 
@@ -64,7 +64,7 @@ export class TopologyTooltipPopover implements TopologyTooltip {
     this.popoverSubject.next(this.buildPopover(modal, node));
   }
 
-  private buildPopover(modal: boolean, node: any = null): PopoverRef {
+  private buildPopover(modal: boolean, node: TopologyNode | TopologyEdge | null): PopoverRef {
     const popover = this.popoverService.drawPopover({
       componentOrTemplate: this.tooltipDefinition.class,
       position: {
@@ -81,7 +81,7 @@ export class TopologyTooltipPopover implements TopologyTooltip {
 
     popover.updatePositionStrategy({
       type: PopoverPositionType.FollowMouse,
-      boundingElement: this.getElementContainer(node?.data?.name, modal),
+      boundingElement: this.getElementContainer((node as any)?.data?.name, modal),
       offsetX: 50,
       offsetY: 30
     });
@@ -94,14 +94,14 @@ export class TopologyTooltipPopover implements TopologyTooltip {
       return this.container.nativeElement;
     }
 
-    if (textContent) {
+    if (textContent !== '') {
       return (
         Array.from(this.container.nativeElement.querySelector('.topology-data').children as HTMLCollection).find(
           el => el.querySelector('text')?.textContent === textContent
         ) ?? this.container.nativeElement
       );
-    } else {
-      return this.container.nativeElement.querySelector('.topology-data .emphasized');
     }
+
+    return this.container.nativeElement.querySelector('.topology-data .emphasized');
   }
 }

--- a/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
+++ b/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
@@ -1,10 +1,5 @@
 import { ElementRef, Injector } from '@angular/core';
-import {
-  PopoverBackdrop,
-  PopoverPositionType,
-  PopoverRef,
-  PopoverService
-} from '@hypertrace/components';
+import { PopoverBackdrop, PopoverPositionType, PopoverRef, PopoverService } from '@hypertrace/components';
 import { BehaviorSubject, merge, Observable, ReplaySubject, Subject } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { TopologyEdge, TopologyNode, TopologyTooltip, TopologyTooltipOptions } from '../../topology';

--- a/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
+++ b/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
@@ -3,7 +3,6 @@ import {
   PopoverBackdrop,
   PopoverPositionType,
   PopoverRef,
-  PopoverRelativePositionLocation,
   PopoverService
 } from '@hypertrace/components';
 import { BehaviorSubject, merge, Observable, ReplaySubject, Subject } from 'rxjs';
@@ -86,9 +85,10 @@ export class TopologyTooltipPopover implements TopologyTooltip {
     }
 
     popover.updatePositionStrategy({
-      type: PopoverPositionType.Relative,
-      locationPreferences: [PopoverRelativePositionLocation.InsideTopLeft],
-      origin: this.container
+      type: PopoverPositionType.FollowMouse,
+      boundingElement: this.container.nativeElement,
+      offsetX: 50,
+      offsetY: 30
     });
 
     return popover;

--- a/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
+++ b/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
@@ -20,7 +20,7 @@ export class TopologyTooltipPopover implements TopologyTooltip {
     private readonly injector: Injector,
     private readonly popoverService: PopoverService
   ) {
-    this.popoverSubject = new BehaviorSubject(this.buildPopover(null, false));
+    this.popoverSubject = new BehaviorSubject(this.buildPopover(false));
     this.hidden$ = this.popoverSubject.pipe(switchMap(popover => merge(popover.hidden$, popover.closed$)));
   }
 
@@ -61,10 +61,10 @@ export class TopologyTooltipPopover implements TopologyTooltip {
     }
 
     this.popover.close(); // Close existing popover
-    this.popoverSubject.next(this.buildPopover(node, modal));
+    this.popoverSubject.next(this.buildPopover(modal, node));
   }
 
-  private buildPopover(node: any, modal: boolean): PopoverRef {
+  private buildPopover(modal: boolean, node: any = null): PopoverRef {
     const popover = this.popoverService.drawPopover({
       componentOrTemplate: this.tooltipDefinition.class,
       position: {

--- a/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
+++ b/projects/observability/src/shared/components/topology/renderers/tooltip/topology-tooltip-popover.ts
@@ -64,22 +64,7 @@ export class TopologyTooltipPopover implements TopologyTooltip {
     this.popoverSubject.next(this.buildPopover(!!options.modal, origin));
   }
 
-  // private buildHiddenPopover(): PopoverRef {
-  //   const popover = this.popoverService.drawPopover({
-  //     componentOrTemplate: this.tooltipDefinition.class,
-  //     position: {
-  //       type: PopoverPositionType.Hidden
-  //     },
-  //     parentInjector: this.injector,
-  //     backdrop: PopoverBackdrop.None,
-  //     data: this.dataSubject
-  //   });
-
-  //   return popover;
-  // }
-
   private buildPopover(modal: boolean, origin: ElementRef): PopoverRef {
-    console.log('entro aca');
     const popover = this.popoverService.drawPopover({
       componentOrTemplate: this.tooltipDefinition.class,
       position: {

--- a/projects/observability/src/shared/components/topology/topology.ts
+++ b/projects/observability/src/shared/components/topology/topology.ts
@@ -179,8 +179,8 @@ export interface TopologyTooltipRenderer {
 }
 
 export interface TopologyTooltip {
-  showWithNodeData(node: TopologyNode, options?: TopologyTooltipOptions): void;
-  showWithEdgeData(edge: TopologyEdge, options?: TopologyTooltipOptions): void;
+  showWithNodeData(node: TopologyNode, origin: ElementRef, options?: TopologyTooltipOptions): void;
+  showWithEdgeData(edge: TopologyEdge, origin: ElementRef, options?: TopologyTooltipOptions): void;
   hide(): void;
   destroy(): void;
   hidden$: Observable<void>;


### PR DESCRIPTION
## Description
The popover is positioned near the node or edge where the user hovers or clicks, dynamically adjusting to the screen.

### Testing
 Visual Testing 

Hovering:

![image](https://user-images.githubusercontent.com/79482271/113374930-b5acec00-9344-11eb-86be-85a9bd771d14.png)


After click:

![image](https://user-images.githubusercontent.com/79482271/113374787-4e8f3780-9344-11eb-872a-0ac2608a37a8.png)


### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
