### PR TITLE
fix: request apiCalleeNameCount only for API_TRACE

### DIFF
--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/api-trace-detail-data-source.model.ts
@@ -1,7 +1,8 @@
 import { Model } from '@hypertrace/hyperdash';
-import { Trace, traceIdKey } from '../../../../graphql/model/schema/trace';
+import { Trace, traceIdKey, traceTypeKey } from '../../../../graphql/model/schema/trace';
 
 import { Dictionary } from '@hypertrace/common';
+import { ObservabilityTraceType } from '@hypertrace/observability';
 import { TraceDetailData, TraceDetailDataSourceModel } from './trace-detail-data-source.model';
 
 @Model({
@@ -9,7 +10,12 @@ import { TraceDetailData, TraceDetailDataSourceModel } from './trace-detail-data
 })
 export class ApiTraceDetailDataSourceModel extends TraceDetailDataSourceModel {
   protected getTraceAttributes(): string[] {
-    return [...super.getTraceAttributes(), 'traceId', 'apiCalleeNameCount'];
+    const attributes: string[] = [...super.getTraceAttributes(), 'traceId'];
+    if (this.trace[traceTypeKey] === ObservabilityTraceType.Api) {
+      attributes.push('apiCalleeNameCount');
+    }
+
+    return attributes;
   }
 
   protected constructTraceDetailData(trace: Trace): ApiTraceDetailData {


### PR DESCRIPTION
## Description
apiCalleeNameCount is a valid attribute only for trace type 'API_TRACE'. This PR updates api trace detail data source to request for apiCalleeNameCount attribute only for API_TRACE type requests.

### Testing
Tested manually. UT added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules