### PR TITLE
fix: table column and content misalignment

### DIFF
--- a/projects/components/src/table/cells/data-renderers/table-data-cell-renderer.component.scss
+++ b/projects/components/src/table/cells/data-renderers/table-data-cell-renderer.component.scss
@@ -5,7 +5,7 @@
   align-items: center;
   height: calc(100% - 8px); // subtract margin
   margin: 4px 4px;
-  padding: 2px 4px;
+  padding: 2px 8px;
 
   &.selected {
     background: $blue-1;

--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -71,7 +71,7 @@
   }
 
   .header-column-resize-handle {
-    padding: 6px 2px;
+    padding: 6px 0px;
     height: 100%;
     cursor: col-resize;
 

--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -67,11 +67,15 @@
 
   .header-cell-renderer {
     width: 100%;
-    padding: 10px 12px;
+    padding: 10px 12px 10px 7px;
+  }
+
+  .header-cell-renderer:first-child {
+    padding-left: 12px;
   }
 
   .header-column-resize-handle {
-    padding: 6px 0px;
+    padding: 6px 2px;
     height: 100%;
     cursor: col-resize;
 


### PR DESCRIPTION
## Description
Column bars padding was removed and content was centered.

### Testing
Visual Testing

Before: 

![image](https://user-images.githubusercontent.com/79482271/113621607-33694400-9632-11eb-9fcb-0df1ad03c1e6.png)

After: 

![image](https://user-images.githubusercontent.com/79482271/113607398-8a195280-961f-11eb-9612-a996101567a8.png)

![image](https://user-images.githubusercontent.com/79482271/113727551-9bb83400-96cb-11eb-8a6e-07d368b54cc4.png)


### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
