### PR TITLE
refactor: updating display string to show 'null' as '-'

### DIFF
--- a/projects/common/src/utilities/formatters/string/string-formatter.test.ts
+++ b/projects/common/src/utilities/formatters/string/string-formatter.test.ts
@@ -4,6 +4,7 @@ describe('String formatter', () => {
   test('can convert to display string', () => {
     // tslint:disable-next-line: no-null-keyword
     expect(displayString(null)).toBe('-');
+    expect(displayString('null')).toBe('-');
     expect(displayString(undefined)).toBe('-');
     expect(displayString('')).toBe('');
     expect(displayString('value')).toBe('value');

--- a/projects/common/src/utilities/formatters/string/string-formatter.ts
+++ b/projects/common/src/utilities/formatters/string/string-formatter.ts
@@ -1,5 +1,5 @@
 export const displayString = (provided?: unknown): string => {
-  if (provided === null) {
+  if (provided === null || provided === 'null') {
     return '-';
   }
 


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
refactor: updating display string to show 'null' as '-'
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
