### PR TITLE
feat: adding Medium size icon support in button

### DIFF
--- a/projects/components/src/button/button.component.test.ts
+++ b/projects/components/src/button/button.component.test.ts
@@ -95,7 +95,7 @@ describe('Button Component', () => {
       size: ButtonSize.Medium
     });
     expect(spectator.query('.button')).toHaveClass('button secondary medium');
-    expect(spectator.component.getIconSizeClass()).toEqual(IconSize.Small);
+    expect(spectator.component.getIconSizeClass()).toEqual(IconSize.Medium);
 
     // Tiny
     spectator.setInput({

--- a/projects/components/src/button/button.component.ts
+++ b/projects/components/src/button/button.component.ts
@@ -75,6 +75,8 @@ export class ButtonComponent {
     switch (this.size) {
       case ButtonSize.Large:
         return IconSize.Large;
+      case ButtonSize.Medium:
+        return IconSize.Medium;
       default:
         return IconSize.Small;
     }

--- a/projects/components/src/time-range/time-range.component.ts
+++ b/projects/components/src/time-range/time-range.component.ts
@@ -24,7 +24,7 @@ import { PopoverRef } from '../popover/popover-ref';
         <ht-popover (popoverOpen)="this.onPopoverOpen($event)" [closeOnNavigate]="false">
           <ht-popover-trigger>
             <div class="trigger">
-              <ht-icon class="trigger-icon" icon="${IconType.Time}" size="${IconSize.Large}"></ht-icon>
+              <ht-icon class="trigger-icon" icon="${IconType.Time}" size="${IconSize.Medium}"></ht-icon>
               <ht-label class="trigger-label" [label]="timeRange.toDisplayString()"></ht-label>
               <ht-icon class="trigger-caret" icon="${IconType.ChevronDown}" size="${IconSize.Small}"></ht-icon>
             </div>
@@ -59,7 +59,7 @@ import { PopoverRef } from '../popover/popover-ref';
         [ngClass]="refreshButton.isEmphasized ? 'emphasized' : ''"
         [label]="refreshButton.text$ | async"
         icon="${IconType.Refresh}"
-        size="${ButtonSize.Small}"
+        size="${ButtonSize.Medium}"
         [role]="refreshButton.role"
         (click)="refreshButton.onClick()"
       >


### PR DESCRIPTION
## Description
Adding Medium Size Icon Support in button (24px x 24px) also I modified the time-range component using Medium size Icons. 

### Testing
Visual Testing.

![image](https://user-images.githubusercontent.com/79482271/113882666-e1403400-9793-11eb-9641-f58a159c4312.png)

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
