### PR TITLE
fix: reducing space in tab's title

### DIFF
--- a/projects/components/src/tabs/navigable/navigable-tab-group.component.scss
+++ b/projects/components/src/tabs/navigable/navigable-tab-group.component.scss
@@ -25,10 +25,6 @@
   }
 }
 
-.tab-group {
-  height: 48px;
-}
-
 .divider {
   position: relative;
   bottom: 2px;
@@ -67,13 +63,14 @@
 }
 
 .tab-link {
-  height: 46px; // plus ink-bar is 48
+  height: auto; // plus ink-bar is 48
   min-width: 0;
   padding: 0;
   font-size: 16px;
   font-weight: 500;
   color: $gray-5;
   opacity: 1;
+  padding-bottom: 6px;
 }
 
 .ink-bar {

--- a/projects/components/src/tabs/navigable/navigable-tab-group.component.scss
+++ b/projects/components/src/tabs/navigable/navigable-tab-group.component.scss
@@ -63,7 +63,7 @@
 }
 
 .tab-link {
-  height: auto; // plus ink-bar is 48
+  height: auto;
   min-width: 0;
   padding: 0;
   font-size: 16px;


### PR DESCRIPTION
## Description
Reducing space in Tab's titles.

### Testing
Visual Testing

Before:
![image](https://user-images.githubusercontent.com/79482271/113936457-297c4800-97ce-11eb-8778-d38bb10b13d2.png)

After:
![image](https://user-images.githubusercontent.com/79482271/113936474-30a35600-97ce-11eb-8371-822393bd0bee.png)

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
