### PR TITLE
feat: adding default interval for cartesian

### DIFF
--- a/projects/common/src/utilities/coercers/date-coercer.test.ts
+++ b/projects/common/src/utilities/coercers/date-coercer.test.ts
@@ -47,7 +47,7 @@ describe('Date coercer', () => {
     expect(basicCoercer.coerce('2009-04-11T16:33:47.046Z')).toBeUndefined();
     expect(basicCoercer.coerce('2019-04-11T16:33:47.046Z')).toBeDefined();
     // This will fail in 2021 too, just bump the year
-    expect(basicCoercer.coerce('2031-04-11T16:33:47.046Z')).toBeUndefined();
+    expect(basicCoercer.coerce('2032-04-11T16:33:47.046Z')).toBeUndefined();
   });
 
   test('rejects non dates', () => {

--- a/projects/common/src/utilities/coercers/date-coercer.test.ts
+++ b/projects/common/src/utilities/coercers/date-coercer.test.ts
@@ -46,7 +46,7 @@ describe('Date coercer', () => {
     expect(basicCoercer.coerce(0)).toBeUndefined();
     expect(basicCoercer.coerce('2009-04-11T16:33:47.046Z')).toBeUndefined();
     expect(basicCoercer.coerce('2019-04-11T16:33:47.046Z')).toBeDefined();
-    // This will fail in 2021 too, just bump the year
+    // This will fail in 2022 too, just bump the year
     expect(basicCoercer.coerce('2032-04-11T16:33:47.046Z')).toBeUndefined();
   });
 

--- a/projects/dashboards/src/model/time-duration/time-duration.model.ts
+++ b/projects/dashboards/src/model/time-duration/time-duration.model.ts
@@ -19,7 +19,15 @@ export class TimeDurationModel {
     // tslint:disable-next-line: no-object-literal-type-assertion
     type: {
       key: ENUM_TYPE.type,
-      values: [TimeUnit.Millisecond, TimeUnit.Second, TimeUnit.Minute, TimeUnit.Hour, TimeUnit.Week, TimeUnit.Month]
+      values: [
+        TimeUnit.Millisecond,
+        TimeUnit.Second,
+        TimeUnit.Minute,
+        TimeUnit.Hour,
+        TimeUnit.Day,
+        TimeUnit.Week,
+        TimeUnit.Month
+      ]
     } as EnumPropertyTypeInstance
   })
   public unit!: TimeUnit;

--- a/projects/observability/src/shared/components/interval-select/interval-select.component.ts
+++ b/projects/observability/src/shared/components/interval-select/interval-select.component.ts
@@ -23,7 +23,7 @@ import { SelectOption, SelectSize } from '@hypertrace/components';
 })
 export class IntervalSelectComponent implements OnChanges {
   @Input()
-  public interval: IntervalValue = 'AUTO';
+  public interval?: IntervalValue;
 
   @Input()
   public intervalOptions?: IntervalValue[];

--- a/projects/observability/src/shared/components/interval-select/interval-select.component.ts
+++ b/projects/observability/src/shared/components/interval-select/interval-select.component.ts
@@ -23,7 +23,7 @@ import { SelectOption, SelectSize } from '@hypertrace/components';
 })
 export class IntervalSelectComponent implements OnChanges {
   @Input()
-  public interval?: IntervalValue;
+  public interval: IntervalValue = 'AUTO';
 
   @Input()
   public intervalOptions?: IntervalValue[];
@@ -54,8 +54,9 @@ export class IntervalSelectComponent implements OnChanges {
     }
   }
 
-  public onIntervalChange(value: IntervalValue): void {
-    this.intervalChange.next(value);
+  public onIntervalChange(interval: IntervalValue): void {
+    this.interval = interval;
+    this.intervalChange.next(interval);
   }
 
   public isDisabledOrUnselectable(): boolean {

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.test.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.test.ts
@@ -1,4 +1,3 @@
-import { TimeDurationModel } from './../../../../../../../dashboards/src/model/time-duration/time-duration.model';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { IconLibraryTestingModule } from '@hypertrace/assets-library';
 import {
@@ -9,6 +8,7 @@ import {
   TimeUnit
 } from '@hypertrace/common';
 import { LoadAsyncModule } from '@hypertrace/components';
+import { TimeDurationModel } from '@hypertrace/dashboards';
 import { mockDashboardWidgetProviders } from '@hypertrace/dashboards/testing';
 import { ModelApi } from '@hypertrace/hyperdash';
 import { runFakeRxjs } from '@hypertrace/test-utils';

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
@@ -58,13 +58,16 @@ export class CartesianWidgetRendererComponent<TSeriesInterval> extends Interacti
     return this.model.getDataFetcher().pipe(
       tap(fetcher => {
         this.fetcher = fetcher;
+        const defaultInterval =
+          this.model.defaultInterval?.value !== undefined ? this.model.defaultInterval.getDuration() : undefined;
 
         if (this.intervalSupported()) {
           this.intervalOptions = this.buildIntervalOptions();
-          this.selectedInterval = this.getBestIntervalMatch(this.intervalOptions, this.selectedInterval);
+          this.selectedInterval =
+            defaultInterval ?? this.getBestIntervalMatch(this.intervalOptions, this.selectedInterval);
         } else {
           this.intervalOptions = undefined;
-          this.selectedInterval = undefined;
+          this.selectedInterval = defaultInterval;
         }
       }),
       switchMap(() => this.buildDataObservable())
@@ -87,7 +90,7 @@ export class CartesianWidgetRendererComponent<TSeriesInterval> extends Interacti
   }
 
   private intervalSupported(): boolean {
-    return this.model.selectableInterval;
+    return this.model.selectableInterval || this.model.defaultInterval !== undefined;
   }
 
   private resolveInterval(value?: IntervalValue): TimeDuration {

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
@@ -58,13 +58,14 @@ export class CartesianWidgetRendererComponent<TSeriesInterval> extends Interacti
     return this.model.getDataFetcher().pipe(
       tap(fetcher => {
         this.fetcher = fetcher;
-        const defaultInterval =
-          this.model.defaultInterval?.value !== undefined ? this.model.defaultInterval.getDuration() : undefined;
+        const defaultInterval = this.model.defaultInterval?.getDuration();
 
         if (this.intervalSupported()) {
           this.intervalOptions = this.buildIntervalOptions();
-          this.selectedInterval =
-            defaultInterval ?? this.getBestIntervalMatch(this.intervalOptions, this.selectedInterval);
+          this.selectedInterval = this.getBestIntervalMatch(
+            this.intervalOptions,
+            this.selectedInterval ?? defaultInterval
+          );
         } else {
           this.intervalOptions = undefined;
           this.selectedInterval = defaultInterval;

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
@@ -60,15 +60,11 @@ export class CartesianWidgetRendererComponent<TSeriesInterval> extends Interacti
         this.fetcher = fetcher;
         const defaultInterval = this.model.defaultInterval?.getDuration();
 
+        const intervalOptions = this.buildIntervalOptions();
+        this.selectedInterval = this.getBestIntervalMatch(intervalOptions, this.selectedInterval ?? defaultInterval);
+
         if (this.intervalSupported()) {
-          this.intervalOptions = this.buildIntervalOptions();
-          this.selectedInterval = this.getBestIntervalMatch(
-            this.intervalOptions,
-            this.selectedInterval ?? defaultInterval
-          );
-        } else {
-          this.intervalOptions = undefined;
-          this.selectedInterval = defaultInterval;
+          this.intervalOptions = intervalOptions; // The only thing this flag controls is whether options are available (and thus, the selector)
         }
       }),
       switchMap(() => this.buildDataObservable())

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
@@ -90,7 +90,7 @@ export class CartesianWidgetRendererComponent<TSeriesInterval> extends Interacti
   }
 
   private intervalSupported(): boolean {
-    return this.model.selectableInterval || this.model.defaultInterval !== undefined;
+    return this.model.selectableInterval;
   }
 
   private resolveInterval(value?: IntervalValue): TimeDuration {

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget.model.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget.model.ts
@@ -1,9 +1,10 @@
 import { ColorPaletteKey, ColorService, forkJoinSafeEmpty, TimeDuration } from '@hypertrace/common';
-import { EnumPropertyTypeInstance, ENUM_TYPE } from '@hypertrace/dashboards';
+import { EnumPropertyTypeInstance, ENUM_TYPE, TimeDurationModel } from '@hypertrace/dashboards';
 import {
   BOOLEAN_PROPERTY,
   Model,
   ModelApi,
+  ModelModelPropertyTypeInstance,
   ModelProperty,
   ModelPropertyType,
   NUMBER_PROPERTY,
@@ -101,6 +102,17 @@ export class CartesianWidgetModel<TInterval> {
     type: BOOLEAN_PROPERTY.type
   })
   public selectableInterval: boolean = true;
+
+  @ModelProperty({
+    key: 'default-interval',
+    required: false,
+    // tslint:disable-next-line: no-object-literal-type-assertion
+    type: {
+      key: ModelPropertyType.TYPE,
+      defaultModelClass: TimeDurationModel
+    } as ModelModelPropertyTypeInstance
+  })
+  public defaultInterval?: TimeDurationModel;
 
   @ModelProperty({
     key: 'show-summary',

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget.model.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget.model.ts
@@ -108,8 +108,7 @@ export class CartesianWidgetModel<TInterval> {
     required: false,
     // tslint:disable-next-line: no-object-literal-type-assertion
     type: {
-      key: ModelPropertyType.TYPE,
-      defaultModelClass: TimeDurationModel
+      key: ModelPropertyType.TYPE
     } as ModelModelPropertyTypeInstance
   })
   public defaultInterval?: TimeDurationModel;


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
feat: adding default interval for cartesian
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
