### PR TITLE
fix: enlarging button height

### DIFF
--- a/projects/components/src/time-range/time-range.component.scss
+++ b/projects/components/src/time-range/time-range.component.scss
@@ -15,7 +15,7 @@
 .trigger {
   display: flex;
   align-items: center;
-  height: 32px;
+  height: 36px;
   cursor: pointer;
 
   .trigger-icon {


### PR DESCRIPTION
## Description
The button corresponding to the time is changed from 32px to 36px in height.

### Testing
Visual Testing

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.