### PR TITLE
fix: hover over a selected table changed color

### DIFF
--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -49,9 +49,9 @@
     border-top: 1px solid $blue-2;
 
     &.hovered-row {
-      background: $blue-2;
-      border-bottom: 1px solid $blue-5;
-      border-top: 1px solid $blue-5;
+      background: $gray-1;
+      border-bottom: 1px solid $gray-2;
+      border-top: 1px solid $gray-2;
     }
   }
 


### PR DESCRIPTION
## Description
The background color and borders were changed in hover over on a selected table.

### Testing
Visual Testing

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.