### PR TITLE
feat: turn on paginator when total Items are larger than page size

### DIFF
--- a/projects/components/src/paginator/paginator.component.test.ts
+++ b/projects/components/src/paginator/paginator.component.test.ts
@@ -119,6 +119,6 @@ describe('Paginator component', () => {
     });
 
     const paginator = spectator.query('.paginator')!;
-    expect(paginator).toBeUndefined();
+    expect(paginator).toBeNull();
   });
 });

--- a/projects/components/src/paginator/paginator.component.test.ts
+++ b/projects/components/src/paginator/paginator.component.test.ts
@@ -111,7 +111,7 @@ describe('Paginator component', () => {
     expect(spectator.component.hasNextPage()).toBe(false);
   });
 
-  test('should hide the pag when totalItems is less than the pageSizeOptions options', () => {
+  test('should hide the paginator when totalItems is less than the pageSizeOptions options', () => {
     const spectator = createHost(`<ht-paginator [totalItems]="totalItems"></ht-paginator>`, {
       hostProps: {
         totalItems: 20

--- a/projects/components/src/paginator/paginator.component.test.ts
+++ b/projects/components/src/paginator/paginator.component.test.ts
@@ -37,7 +37,7 @@ describe('Paginator component', () => {
     });
   });
 
-  test('should hide the pager when totalItems is less than the pageSizeOptions options', () => {
+  test('should have the correct number of pages for the provided page size and total items', () => {
     const spectator = createHost(`<ht-paginator [totalItems]="totalItems"></ht-paginator>`, {
       hostProps: {
         totalItems: totalResults
@@ -111,7 +111,7 @@ describe('Paginator component', () => {
     expect(spectator.component.hasNextPage()).toBe(false);
   });
 
-  test('should navigate to first page when totalItems is changed', () => {
+  test('should hide the pag when totalItems is less than the pageSizeOptions options', () => {
     const spectator = createHost(`<ht-paginator [totalItems]="totalItems"></ht-paginator>`, {
       hostProps: {
         totalItems: 20

--- a/projects/components/src/paginator/paginator.component.test.ts
+++ b/projects/components/src/paginator/paginator.component.test.ts
@@ -37,7 +37,7 @@ describe('Paginator component', () => {
     });
   });
 
-  test('should have the correct number of pages for the provided page size and total items', () => {
+  test('should hide the pager when totalItems is less than the pageSizeOptions options', () => {
     const spectator = createHost(`<ht-paginator [totalItems]="totalItems"></ht-paginator>`, {
       hostProps: {
         totalItems: totalResults
@@ -109,5 +109,16 @@ describe('Paginator component', () => {
 
     expect(spectator.query(LabelComponent)?.label).toEqual('1-50 of 50');
     expect(spectator.component.hasNextPage()).toBe(false);
+  });
+
+  test('should navigate to first page when totalItems is changed', () => {
+    const spectator = createHost(`<ht-paginator [totalItems]="totalItems"></ht-paginator>`, {
+      hostProps: {
+        totalItems: 20
+      }
+    });
+
+    const paginator = spectator.query('.paginator')!;
+    expect(paginator).toBeUndefined();
   });
 });

--- a/projects/components/src/paginator/paginator.component.ts
+++ b/projects/components/src/paginator/paginator.component.ts
@@ -19,7 +19,7 @@ import { PaginationProvider } from './paginator-api';
   styleUrls: ['./paginator.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="paginator" *ngIf="this.totalItems && this.totalItems > this.pageSize">
+    <div class="paginator" *ngIf="this.totalItems && this.totalItems > this.pageSizeOptions[0]">
       <ht-label
         class="label"
         label="{{ this.firstItemNumberForPage() }}-{{ this.lastItemNumberForPage() }} of {{ this.totalItems }}"
@@ -59,7 +59,7 @@ import { PaginationProvider } from './paginator-api';
 })
 export class PaginatorComponent implements OnChanges, PaginationProvider {
   @Input()
-  public pageSizeOptions: number[] = [25, 50, 100];
+  public pageSizeOptions: number[] = [];
 
   @Input()
   public set pageIndex(pageIndex: number) {

--- a/projects/components/src/paginator/paginator.component.ts
+++ b/projects/components/src/paginator/paginator.component.ts
@@ -59,7 +59,7 @@ import { PaginationProvider } from './paginator-api';
 })
 export class PaginatorComponent implements OnChanges, PaginationProvider {
   @Input()
-  public pageSizeOptions: number[] = [];
+  public pageSizeOptions: number[] = [25, 50, 100];
 
   @Input()
   public set pageIndex(pageIndex: number) {

--- a/projects/components/src/paginator/paginator.component.ts
+++ b/projects/components/src/paginator/paginator.component.ts
@@ -19,7 +19,7 @@ import { PaginationProvider } from './paginator-api';
   styleUrls: ['./paginator.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="paginator" *ngIf="this.totalItems">
+    <div class="paginator" *ngIf="this.totalItems && this.totalItems > pageSizeOptions[0]">
       <ht-label
         class="label"
         label="{{ this.firstItemNumberForPage() }}-{{ this.lastItemNumberForPage() }} of {{ this.totalItems }}"

--- a/projects/components/src/paginator/paginator.component.ts
+++ b/projects/components/src/paginator/paginator.component.ts
@@ -19,7 +19,7 @@ import { PaginationProvider } from './paginator-api';
   styleUrls: ['./paginator.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="paginator" *ngIf="this.totalItems && this.totalItems > pageSizeOptions[0]">
+    <div class="paginator" *ngIf="this.totalItems && this.totalItems > this.pageSize">
       <ht-label
         class="label"
         label="{{ this.firstItemNumberForPage() }}-{{ this.lastItemNumberForPage() }} of {{ this.totalItems }}"


### PR DESCRIPTION
## Description
Turn on paginator when total items are greater than the smallest item in the page size drop-down menu.

### Testing
Visual testing

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.