### PR TITLE
refactor: update positioning of table state watcher

### DIFF
--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -1,6 +1,7 @@
 @import 'mixins';
 @import 'layout';
 
+$header-height: 32px;
 .table {
   position: relative;
   display: flex;
@@ -28,7 +29,7 @@
   flex-direction: row;
   position: sticky;
   top: 0;
-  height: 32px;
+  height: $header-height;
   background: $gray-1;
   border-bottom: 1px solid $gray-2;
   border-top-left-radius: 3px;
@@ -111,7 +112,8 @@
 }
 
 .state-watcher {
-  height: calc(100% - #{$paginator-height});
+  top: $header-height;
+  height: calc(100% - #{$header-height});
   width: 100%;
   position: absolute;
   background: transparent;


### PR DESCRIPTION
## Description
The paginator was updated to hide if not needed, which makes the positioning of the state watcher extra weird. Previously, it was centering between the top of the header row and the top of the paginator. Now that the paginator is hidden in loading and error scenarios (when there's no data to power the paginator), this skews quite high in the component (more extreme for smaller tables). With this change, it centers in the whitespace underneath the header.

After change:
![image](https://user-images.githubusercontent.com/45047841/115479026-5718b680-a1fc-11eb-843a-54481afd0cd2.png)

Before:
![image](https://user-images.githubusercontent.com/45047841/115479092-862f2800-a1fc-11eb-95dc-55b0c51a7d04.png)

### Testing
Visual (on a main list and embedded)



