### PR TITLE
refactor: only add aggregation in fragment if value is present

### DIFF
--- a/projects/distributed-tracing/src/public-api.ts
+++ b/projects/distributed-tracing/src/public-api.ts
@@ -73,6 +73,7 @@ export {
 } from './shared/graphql/model/schema/metrics/graphql-metric-aggregation-type';
 export * from './shared/graphql/model/schema/sort/graphql-sort-argument';
 export * from './shared/graphql/model/schema/sort/graphql-sort-direction';
+export * from './shared/graphql/model/schema/sort/graphql-sort-without-direction';
 export * from './shared/graphql/model/schema/sort/graphql-sort-by-specification';
 export * from './shared/graphql/model/schema/timerange/graphql-time-range';
 export * from './shared/graphql/model/schema/specifier/specification';

--- a/projects/observability/src/shared/graphql/request/builders/specification/explore/explore-specification-builder.ts
+++ b/projects/observability/src/shared/graphql/request/builders/specification/explore/explore-specification-builder.ts
@@ -1,10 +1,9 @@
-import { Dictionary } from './../../../../../../../../common/src/utilities/types/types';
-import { GraphQlSortWithoutDirection } from './../../../../../../../../distributed-tracing/src/shared/graphql/model/schema/sort/graphql-sort-without-direction';
-import { DateCoercer } from '@hypertrace/common';
+import { DateCoercer, Dictionary } from '@hypertrace/common';
 import {
   AttributeMetadataType,
   convertToGraphQlMetricAggregationType,
   GraphQlMetricAggregationType,
+  GraphQlSortWithoutDirection,
   MetricAggregationType
 } from '@hypertrace/distributed-tracing';
 import { GraphQlEnumArgument } from '@hypertrace/graphql-client';

--- a/projects/observability/src/shared/graphql/request/builders/specification/explore/explore-specification-builder.ts
+++ b/projects/observability/src/shared/graphql/request/builders/specification/explore/explore-specification-builder.ts
@@ -1,3 +1,5 @@
+import { Dictionary } from './../../../../../../../../common/src/utilities/types/types';
+import { GraphQlSortWithoutDirection } from './../../../../../../../../distributed-tracing/src/shared/graphql/model/schema/sort/graphql-sort-without-direction';
 import { DateCoercer } from '@hypertrace/common';
 import {
   AttributeMetadataType,
@@ -47,10 +49,17 @@ export class ExploreSpecificationBuilder {
         children: [{ path: 'value' }, { path: 'type' }]
       }),
       extractFromServerData: serverData => serverData[queryAlias],
-      asGraphQlOrderByFragment: () => ({
-        key: key,
-        aggregation: aggregation === undefined ? undefined : this.aggregationAsEnum(aggregation)
-      })
+      asGraphQlOrderByFragment: () => {
+        const fragment: GraphQlSortWithoutDirection & Dictionary<unknown> = {
+          key: key
+        };
+
+        if (aggregation !== undefined) {
+          fragment.aggregation = this.aggregationAsEnum(aggregation);
+        }
+
+        return fragment;
+      }
     };
   }
 


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
refactor: only add aggregation in fragment if value is present
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
