### PR TITLE
fix: reset paging if table filters or sorts

### DIFF
--- a/projects/components/src/paginator/paginator.component.ts
+++ b/projects/components/src/paginator/paginator.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { IconType } from '@hypertrace/assets-library';
 import { TypedSimpleChanges } from '@hypertrace/common';
-import { Observable } from 'rxjs';
+import { merge, Observable, Subject } from 'rxjs';
 import { ButtonSize, ButtonStyle } from '../button/button';
 import { PageEvent } from './page.event';
 import { PaginationProvider } from './paginator-api';
@@ -90,16 +90,25 @@ export class PaginatorComponent implements OnChanges, PaginationProvider {
   }
   private _totalItems: number = 0;
 
+  private readonly pageSizeInputSubject: Subject<PageEvent> = new Subject();
+
   @Output()
   public readonly pageChange: EventEmitter<PageEvent> = new EventEmitter();
 
-  public readonly pageEvent$: Observable<PageEvent> = this.pageChange.asObservable();
+  // Caused either by a change in the provided page, or user change being emitted
+  public readonly pageEvent$: Observable<PageEvent> = merge(this.pageChange, this.pageSizeInputSubject);
 
   public constructor(private readonly changeDetectorRef: ChangeDetectorRef) {}
 
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
     if (changes.totalItems) {
       this.gotoFirstPage();
+    }
+    if (changes.pageIndex || changes.pageSize) {
+      this.pageSizeInputSubject.next({
+        pageSize: this.pageSize,
+        pageIndex: this.pageIndex
+      });
     }
   }
 

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -24,7 +24,7 @@ import {
   TypedSimpleChanges
 } from '@hypertrace/common';
 import { without } from 'lodash-es';
-import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
+import { BehaviorSubject, combineLatest, merge, Observable, Subject } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { FilterAttribute } from '../filtering/filter/filter-attribute';
 import { PageEvent } from '../paginator/page.event';
@@ -168,7 +168,7 @@ import { TableColumnConfigExtended, TableService } from './table.service';
         [style.position]="this.isTableFullPage ? 'fixed' : 'sticky'"
       >
         <ht-paginator
-          *htLetAsync="this.pagination$ as pagination"
+          *htLetAsync="this.currentPage$ as pagination"
           (pageChange)="this.onPageChange($event)"
           [pageSizeOptions]="this.pageSizeOptions"
           [pageSize]="pagination?.pageSize"
@@ -335,9 +335,15 @@ export class TableComponent
   /*
    * Pagination
    */
-  public readonly pagination$: Observable<Partial<PageEvent> | undefined> = this.activatedRoute.queryParamMap.pipe(
-    map(params => this.getPagination(params))
-  );
+  // For pushing changes to the page explicitly
+  private readonly pageSubject: Subject<Partial<PageEvent>> = new Subject();
+  // When route, sort or filters change, reset pagination
+  public readonly paginationReset$: Observable<Partial<PageEvent>> = combineLatest([
+    this.activatedRoute.queryParamMap,
+    this.columnState$,
+    this.filters$
+  ]).pipe(map(([params]) => this.calculateDefaultPagination(params)));
+  public readonly currentPage$: Observable<Partial<PageEvent>> = merge(this.pageSubject, this.paginationReset$);
 
   public dataSource?: TableCdkDataSource;
   public isTableFullPage: boolean = false;
@@ -696,6 +702,7 @@ export class TableComponent
   }
 
   public onPageChange(pageEvent: PageEvent): void {
+    this.pageSubject.next(pageEvent);
     if (this.syncWithUrl) {
       this.navigationService.addQueryParametersToUrl({
         [TableComponent.PAGE_INDEX_URL_PARAM]: pageEvent.pageIndex,
@@ -711,7 +718,7 @@ export class TableComponent
     this.pageChange.emit(pageEvent);
   }
 
-  private getPagination(params: ParamMap): Partial<PageEvent> {
+  private calculateDefaultPagination(params: ParamMap): Partial<PageEvent> {
     return this.syncWithUrl
       ? {
           pageSize: new NumberCoercer({ defaultValue: this.pageSize }).coerce(


### PR DESCRIPTION
## Description
Tables should switch page to page one if the user searches, applies a sort or filters. Currently, any offset is preserved meaning a search when on page two will show you page two of search results etc. The cause of this is three parts - 
1. the paginator, which actually pushes changes to the data, only pushed if the change was caused by the component itself, not if the inputs to the paginator changed.
2. The table only pushed changes to the paginator when the url/route changed
3. Because changes emitting from the paginator never made it back to the paginator's inputs, change detection in the reset case wasn't firing (because the reset page was equivalent to the last page input)

### Testing
Visual/E2E

