### PR TITLE
fix: filter out all meta types from table edit columns modal

### DIFF
--- a/projects/components/src/table/cells/data-renderers/enum/string-enum-table-cell-renderer.component.ts
+++ b/projects/components/src/table/cells/data-renderers/enum/string-enum-table-cell-renderer.component.ts
@@ -13,7 +13,7 @@ import { TableCellAlignmentType } from '../../types/table-cell-alignment-type';
     <div
       [ngClass]="{ clickable: this.clickable, 'first-column': this.isFirstColumn }"
       class="string-enum-cell"
-      [htTooltip]="this.value"
+      [htTooltip]="this.value | htDisplayStringEnum"
     >
       {{ this.value | htDisplayStringEnum }}
     </div>

--- a/projects/components/src/table/columns/table-edit-columns-modal.component.ts
+++ b/projects/components/src/table/columns/table-edit-columns-modal.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
 import { ButtonRole } from '../../button/button';
+import { FilterAttribute } from '../../filtering/filter/filter-attribute';
 import { ModalRef, MODAL_DATA } from '../../modal/modal';
 import { TableColumnConfigExtended } from '../table.service';
 
@@ -49,8 +50,12 @@ export class TableEditColumnsModalComponent {
     @Inject(MODAL_DATA) public readonly modalData: TableColumnConfigExtended[]
   ) {
     this.editColumns = this.modalData
-      .filter(column => (column.attribute?.type as string) !== '$$state')
+      .filter(column => !this.isMetaTypeColumn(column.attribute))
       .sort((a, b) => (a.visible === b.visible ? 0 : a.visible ? -1 : 1));
+  }
+
+  private isMetaTypeColumn(attribute: FilterAttribute | undefined): boolean {
+    return attribute === undefined || attribute.type.startsWith('$$');
   }
 
   public isLastRemainingColumn(column: TableColumnConfigExtended): boolean {


### PR DESCRIPTION
## Description
This fixes an issue where meta type columns were showing up in the table's add/remove column modal. We've expanded the types of meta columns beyond just `$$state` and this change augments the filter used to remove these types of columns from the list.