### PR TITLE
fix: enable selectable time intervals for metrics across all screens

### DIFF
--- a/projects/observability/src/pages/apis/api-detail/overview/api-overview.dashboard.ts
+++ b/projects/observability/src/pages/apis/api-detail/overview/api-overview.dashboard.ts
@@ -198,7 +198,7 @@ export const apiOverviewDashboard: DashboardDefaultConfiguration = {
           {
             type: 'cartesian-widget',
             title: 'Latency',
-            'selectable-interval': false,
+            'selectable-interval': true,
             'legend-position': LegendPosition.None,
             'x-axis': {
               type: 'cartesian-axis',
@@ -291,7 +291,7 @@ export const apiOverviewDashboard: DashboardDefaultConfiguration = {
           {
             type: 'cartesian-widget',
             title: 'Errors',
-            'selectable-interval': false,
+            'selectable-interval': true,
             'legend-position': LegendPosition.None,
             'x-axis': {
               type: 'cartesian-axis',
@@ -385,7 +385,7 @@ export const apiOverviewDashboard: DashboardDefaultConfiguration = {
           {
             type: 'cartesian-widget',
             title: 'Calls',
-            'selectable-interval': false,
+            'selectable-interval': true,
             'legend-position': LegendPosition.None,
             'x-axis': {
               type: 'cartesian-axis',

--- a/projects/observability/src/pages/apis/backend-detail/overview/backend-overview.component.ts
+++ b/projects/observability/src/pages/apis/backend-detail/overview/backend-overview.component.ts
@@ -214,7 +214,7 @@ export class BackendOverviewComponent {
           {
             type: 'cartesian-widget',
             title: 'Latency',
-            'selectable-interval': false,
+            'selectable-interval': true,
             'legend-position': LegendPosition.None,
             'x-axis': {
               type: 'cartesian-axis',
@@ -291,7 +291,7 @@ export class BackendOverviewComponent {
           {
             type: 'cartesian-widget',
             title: 'Errors',
-            'selectable-interval': false,
+            'selectable-interval': true,
             'legend-position': LegendPosition.None,
             'x-axis': {
               type: 'cartesian-axis',
@@ -369,7 +369,7 @@ export class BackendOverviewComponent {
           {
             type: 'cartesian-widget',
             title: 'Calls',
-            'selectable-interval': false,
+            'selectable-interval': true,
             'legend-position': LegendPosition.None,
             'x-axis': {
               type: 'cartesian-axis',

--- a/projects/observability/src/pages/apis/service-detail/overview/service-overview.dashboard.ts
+++ b/projects/observability/src/pages/apis/service-detail/overview/service-overview.dashboard.ts
@@ -242,7 +242,7 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
               {
                 type: 'cartesian-widget',
                 title: 'Latency',
-                'selectable-interval': false,
+                'selectable-interval': true,
                 'legend-position': LegendPosition.None,
                 'x-axis': {
                   type: 'cartesian-axis',
@@ -335,7 +335,7 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
               {
                 type: 'cartesian-widget',
                 title: 'Errors',
-                'selectable-interval': false,
+                'selectable-interval': true,
                 'legend-position': LegendPosition.None,
                 'x-axis': {
                   type: 'cartesian-axis',
@@ -429,7 +429,7 @@ export const serviceOverviewDashboard: DashboardDefaultConfiguration = {
               {
                 type: 'cartesian-widget',
                 title: 'Calls',
-                'selectable-interval': false,
+                'selectable-interval': true,
                 'legend-position': LegendPosition.None,
                 'x-axis': {
                   type: 'cartesian-axis',

--- a/src/app/home/home.dashboard.ts
+++ b/src/app/home/home.dashboard.ts
@@ -406,7 +406,7 @@ export const homeDashboard: DashboardDefaultConfiguration = {
             type: 'cartesian-widget',
             title: 'Latency',
             'legend-position': LegendPosition.None,
-            'selectable-interval': false,
+            'selectable-interval': true,
             'x-axis': {
               type: 'cartesian-axis',
               'show-grid-lines': false
@@ -482,7 +482,7 @@ export const homeDashboard: DashboardDefaultConfiguration = {
             type: 'cartesian-widget',
             title: 'Calls',
             'legend-position': LegendPosition.None,
-            'selectable-interval': false,
+            'selectable-interval': true,
             'x-axis': {
               type: 'cartesian-axis',
               'show-grid-lines': false
@@ -559,7 +559,7 @@ export const homeDashboard: DashboardDefaultConfiguration = {
             type: 'cartesian-widget',
             title: 'Errors',
             'legend-position': LegendPosition.None,
-            'selectable-interval': false,
+            'selectable-interval': true,
             'x-axis': {
               type: 'cartesian-axis',
               'show-grid-lines': false


### PR DESCRIPTION
## Description
Resolves https://github.com/hypertrace/hypertrace-ui/issues/749 by making changes as per the discussion here: https://github.com/hypertrace/hypertrace-ui/issues/749#issuecomment-829140138 . 

Enabling `selectable-interval` will show up in UI like this screenshot from earlier version:

![image](https://user-images.githubusercontent.com/26570044/116839204-038c6c80-abef-11eb-9950-3cee2805b3bc.png)


### Testing
NA

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
