### PR TITLE
feat: add navigation handling for inactive entities

### DIFF
--- a/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.test.ts
+++ b/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.test.ts
@@ -83,7 +83,7 @@ describe('Entity Renderer Component', () => {
 
     expect(rendererElement).toHaveClass('navigable');
     spectator.dispatchFakeEvent(rendererElement, 'click');
-    expect(entityNavService.navigateToEntity).toHaveBeenCalledWith(entity);
+    expect(entityNavService.navigateToEntity).toHaveBeenCalledWith(entity, false);
   });
 
   test('renders an entity without icon by default', () => {

--- a/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
+++ b/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
@@ -33,6 +33,9 @@ export class EntityRendererComponent implements OnChanges {
   public entity?: Entity;
 
   @Input()
+  public inactive: boolean = false;
+
+  @Input()
   public navigable: boolean = true;
 
   @Input()
@@ -59,8 +62,9 @@ export class EntityRendererComponent implements OnChanges {
       this.setIconType();
     }
   }
+
   public onClickNavigate(): void {
-    this.navigable && this.entity && this.entityNavService.navigateToEntity(this.entity);
+    this.navigable && this.entity && this.entityNavService.navigateToEntity(this.entity, this.inactive);
   }
 
   private setName(): void {

--- a/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-parser.ts
+++ b/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-parser.ts
@@ -1,14 +1,23 @@
 import { TableCellParser, TableCellParserBase, TableRow } from '@hypertrace/components';
 import { Entity, entityIdKey } from '../../../../graphql/model/schema/entity';
 import { ObservabilityTableCellType } from '../../observability-table-cell-type';
-import { parseEntityFromTableRow } from './entity-table-cell-renderer-util';
+import { isInactiveEntity, parseEntityFromTableRow } from './entity-table-cell-renderer-util';
 
 @TableCellParser({
   type: ObservabilityTableCellType.Entity
 })
 export class EntityTableCellParser extends TableCellParserBase<CellData, CellData, string | undefined> {
   public parseValue(cellData: CellData, row: TableRow): CellData {
-    return parseEntityFromTableRow(cellData, row);
+    const entity = parseEntityFromTableRow(cellData, row);
+
+    if (entity === undefined) {
+      return undefined;
+    }
+
+    return {
+      ...entity,
+      isInactive: isInactiveEntity(row) === true
+    };
   }
 
   public parseFilterValue(cellData: CellData): string | undefined {
@@ -16,4 +25,8 @@ export class EntityTableCellParser extends TableCellParserBase<CellData, CellDat
   }
 }
 
-type CellData = Entity | undefined;
+type CellData = MaybeInactiveEntity | undefined;
+
+export interface MaybeInactiveEntity extends Entity {
+  isInactive: boolean;
+}

--- a/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
+++ b/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
@@ -43,6 +43,6 @@ export const isInactiveEntity = (row: TableRow): boolean | undefined => {
 };
 
 const filterMetricAggregations = (row: TableRow): MetricAggregation[] =>
-  Object.values(row).filter(value => isMetricAggregation(value)) as MetricAggregation[];
+  Object.values(row).filter(isMetricAggregation);
 
 const isValidMetricAggregation = (metricAggregation: MetricAggregation): boolean => !isNull(metricAggregation.value);

--- a/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
+++ b/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
@@ -42,10 +42,8 @@ export const isInactiveEntity = (row: TableRow): boolean | undefined => {
   return !hasValidMaxEndTimeTimestamp(maxEndTimeAggregation.value);
 };
 
-const includesMaxEndTimeAggregation = (maxEndTimeAggregation?: unknown): maxEndTimeAggregation is MetricAggregation => {
-  return maxEndTimeAggregation !== undefined;
-};
+const includesMaxEndTimeAggregation = (maxEndTimeAggregation?: unknown): maxEndTimeAggregation is MetricAggregation =>
+  maxEndTimeAggregation !== undefined;
 
-const hasValidMaxEndTimeTimestamp = (maxEndTime?: unknown): maxEndTime is number => {
-  return maxEndTime !== undefined && isNumber(maxEndTime);
-};
+const hasValidMaxEndTimeTimestamp = (maxEndTime?: unknown): maxEndTime is number =>
+  maxEndTime !== undefined && isNumber(maxEndTime);

--- a/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
+++ b/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
@@ -42,7 +42,6 @@ export const isInactiveEntity = (row: TableRow): boolean | undefined => {
   return metricAggregations.some(metricAggregation => !isValidMetricAggregation(metricAggregation));
 };
 
-const filterMetricAggregations = (row: TableRow): MetricAggregation[] =>
-  Object.values(row).filter(isMetricAggregation);
+const filterMetricAggregations = (row: TableRow): MetricAggregation[] => Object.values(row).filter(isMetricAggregation);
 
 const isValidMetricAggregation = (metricAggregation: MetricAggregation): boolean => !isNull(metricAggregation.value);

--- a/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
+++ b/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer-util.ts
@@ -39,7 +39,7 @@ export const isInactiveEntity = (row: TableRow): boolean | undefined => {
     return undefined;
   }
 
-  return metricAggregations.some(metricAggregation => !isValidMetricAggregation(metricAggregation));
+  return metricAggregations.every(metricAggregation => !isValidMetricAggregation(metricAggregation));
 };
 
 const filterMetricAggregations = (row: TableRow): MetricAggregation[] => Object.values(row).filter(isMetricAggregation);

--- a/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer.component.test.ts
+++ b/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer.component.test.ts
@@ -35,7 +35,10 @@ describe('Entity table cell renderer component', () => {
 
   test('should render a milliseconds only value', () => {
     const spectator = buildComponent();
-    expect(spectator.component.value).toEqual(entity);
+    expect(spectator.component.value).toEqual({
+      ...entity,
+      isInactive: false
+    });
   });
 
   test('should render first column with additional css class', () => {

--- a/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer.component.ts
+++ b/projects/observability/src/shared/components/table/data-cell/entity/entity-table-cell-renderer.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { TableCellAlignmentType, TableCellRenderer, TableCellRendererBase } from '@hypertrace/components';
-import { Entity } from '../../../../graphql/model/schema/entity';
 import { ObservabilityTableCellType } from '../../observability-table-cell-type';
+import { MaybeInactiveEntity } from './entity-table-cell-parser';
 
 @Component({
   selector: 'ht-entity-table-cell-renderer',
@@ -9,7 +9,11 @@ import { ObservabilityTableCellType } from '../../observability-table-cell-type'
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="fill-container entity-cell" [ngClass]="{ 'first-column': this.isFirstColumn }">
-      <ht-entity-renderer [entity]="this.value" [navigable]="true"></ht-entity-renderer>
+      <ht-entity-renderer
+        [entity]="this.value"
+        [inactive]="this.value?.isInactive === true"
+        [navigable]="true"
+      ></ht-entity-renderer>
     </div>
   `
 })
@@ -18,4 +22,4 @@ import { ObservabilityTableCellType } from '../../observability-table-cell-type'
   alignment: TableCellAlignmentType.Left,
   parser: ObservabilityTableCellType.Entity
 })
-export class EntityTableCellRendererComponent extends TableCellRendererBase<Entity | undefined> {}
+export class EntityTableCellRendererComponent extends TableCellRendererBase<MaybeInactiveEntity | undefined> {}

--- a/projects/observability/src/shared/constants/entity-metadata.ts
+++ b/projects/observability/src/shared/constants/entity-metadata.ts
@@ -3,7 +3,7 @@ import { InjectionToken } from '@angular/core';
 export interface EntityMetadata {
   entityType: string;
   icon: string;
-  detailPath(id: string, sourceRoute?: string): string[];
+  detailPath(id: string, sourceRoute?: string, inactive?: boolean): string[];
   listPath?: string[];
   apisListPath?(id: string): string[];
   sourceRoutes?: string[];

--- a/projects/observability/src/shared/services/navigation/entity/entity-navigation.service.ts
+++ b/projects/observability/src/shared/services/navigation/entity/entity-navigation.service.ts
@@ -11,18 +11,18 @@ export class EntityNavigationService {
     @Inject(ENTITY_METADATA) private readonly entityMetadata: EntityMetadataMap
   ) {
     Array.from(this.entityMetadata.values()).forEach(item => {
-      this.registerEntityNavigationAction(item.entityType, (id, sourceRoute) =>
-        this.navigationService.navigateWithinApp(item.detailPath(id, sourceRoute))
+      this.registerEntityNavigationAction(item.entityType, (id, sourceRoute, inactive) =>
+        this.navigationService.navigateWithinApp(item.detailPath(id, sourceRoute, inactive))
       );
     });
   }
 
   private readonly entityNavigationMap: Map<
     EntityType,
-    (id: string, sourceRoute?: string) => Observable<boolean>
+    (id: string, sourceRoute?: string, inactive?: boolean) => Observable<boolean>
   > = new Map();
 
-  public navigateToEntity(entity: Entity): Observable<boolean> {
+  public navigateToEntity(entity: Entity, isInactive?: boolean): Observable<boolean> {
     const entityType = entity[entityTypeKey];
     const entityId = entity[entityIdKey];
     const navigationFunction = this.entityNavigationMap.get(entityType);
@@ -35,13 +35,13 @@ export class EntityNavigationService {
     );
 
     return navigationFunction
-      ? navigationFunction(entityId, sourceRoute)
+      ? navigationFunction(entityId, sourceRoute, isInactive)
       : throwError(`Requested entity type not registered for navigation: ${entityType}`);
   }
 
   public registerEntityNavigationAction(
     entityType: EntityType,
-    action: (id: string, sourceRoute?: string) => Observable<boolean>
+    action: (id: string, sourceRoute?: string, inactive?: boolean) => Observable<boolean>
   ): void {
     this.entityNavigationMap.set(entityType, action);
   }


### PR DESCRIPTION
## Description
This change allows navigation routes to know when an entity is inactive so it can be routed differently if needed.
