### PR TITLE
Table multiselect filters

### DIFF
--- a/projects/common/src/utilities/lang/lang-utils.ts
+++ b/projects/common/src/utilities/lang/lang-utils.ts
@@ -35,3 +35,7 @@ const ignoreFunctions = (first: unknown, second: unknown) => {
 // tslint:disable-next-line: no-null-undefined-union
 export const isNonEmptyString = (str: string | undefined | null): str is string =>
   str !== undefined && str !== null && str !== '';
+
+export const hasOwnProperty = <X extends {}, Y extends PropertyKey>(obj: X, prop: Y): obj is X & Record<Y, unknown> =>
+  // Since Typescript doesn't know how to type guard native hasOwnProperty, we wrap it here.
+  obj.hasOwnProperty(prop);

--- a/projects/components/src/table/controls/table-controls-api.ts
+++ b/projects/components/src/table/controls/table-controls-api.ts
@@ -59,7 +59,7 @@ export interface TableCheckboxChange {
   option: TableCheckboxControlOption;
 }
 
-export type TableCheckboxControlOption<T extends boolean = boolean> = TableControlOption & {
+export type TableCheckboxControlOption<T = boolean> = TableControlOption & {
   value: T;
 };
 
@@ -79,5 +79,5 @@ export const toInFilter = (tableFilters: TableFilter[]): TableFilter =>
       field: previousValue.field,
       operator: FilterOperator.In,
       value: [...(Array.isArray(previousValue.value) ? previousValue.value : [previousValue.value]), currentValue.value]
-    }
+    };
   });

--- a/projects/components/src/table/controls/table-controls-api.ts
+++ b/projects/components/src/table/controls/table-controls-api.ts
@@ -1,17 +1,52 @@
 import { Dictionary } from '@hypertrace/common';
-import { SelectOption } from '../../select/select-option';
+import { FilterOperator } from '../../filtering/filter/filter-operators';
 import { TableFilter } from '../table-api';
 
+export const enum TableControlOptionType {
+  Filter = 'filter',
+  Property = 'property',
+  Unset = 'unset'
+}
+
+export type TableControlOption = TableUnsetControlOption | TableFilterControlOption | TablePropertyControlOption;
+
+export type TableFilterControlOption = {
+  type: TableControlOptionType.Filter;
+  label: string;
+  metaValue: TableFilter;
+};
+
+export type TableUnsetControlOption = {
+  type: TableControlOptionType.Unset;
+  label: string;
+  metaValue: string;
+};
+
+export type TablePropertyControlOption = {
+  type: TableControlOptionType.Property;
+  label: string;
+  metaValue: Dictionary<unknown>;
+};
+
+/*
+ * Select Control
+ */
+
 export interface SelectControl {
-  placeholder?: string;
-  default?: SelectOption<TableControlOption>;
-  options: SelectOption<TableControlOption>[];
+  placeholder: string;
+  options: TableSelectControlOption[];
 }
 
 export interface SelectChange {
   select: SelectControl;
-  value: TableControlOption;
+  values: TableSelectControlOption[];
 }
+
+export type TableSelectControlOption = TableFilterControlOption;
+
+/*
+ * Checkbox Control
+ */
 
 export interface CheckboxControl {
   label: string;
@@ -21,38 +56,22 @@ export interface CheckboxControl {
 
 export interface CheckboxChange {
   checkbox: CheckboxControl;
-  option: TableControlOption<boolean>;
+  option: TableCheckboxControlOption;
 }
 
-export const enum TableControlOptionType {
-  Filter = 'filter',
-  Property = 'property',
-  UnsetFilter = 'unset-filter'
-}
-
-export type TableControlOption<T = unknown> =
-  | TableUnsetFilterControlOption<T>
-  | TableFilterControlOption<T>
-  | TablePropertyControlOption<T>;
-
-interface TableControlOptionBase<T> {
-  value?: T;
-}
-export interface TableUnsetFilterControlOption<T = unknown> extends TableControlOptionBase<T> {
-  type: TableControlOptionType.UnsetFilter;
-  metaValue: string;
-}
-
-export interface TableFilterControlOption<T = unknown> extends TableControlOptionBase<T> {
-  type: TableControlOptionType.Filter;
-  metaValue: TableFilter;
-}
-
-export interface TablePropertyControlOption<T = unknown> extends TableControlOptionBase<T> {
-  type: TableControlOptionType.Property;
-  metaValue: Dictionary<unknown>;
-}
-
-export type TableCheckboxControlOption<T extends boolean> = TableControlOption<T> & { label: string };
+export type TableCheckboxControlOption<T extends boolean = boolean> = TableControlOption & {
+  value: T;
+};
 
 export type TableCheckboxOptions = [TableCheckboxControlOption<true>, TableCheckboxControlOption<false>];
+
+/*
+ * Util
+ */
+
+export const toInFilter = (tableFilters: TableFilter[]): TableFilter =>
+  tableFilters.reduce((previousValue, currentValue) => ({
+    field: previousValue.field,
+    operator: FilterOperator.In,
+    value: [...(Array.isArray(previousValue.value) ? previousValue.value : [previousValue.value]), currentValue.value]
+  }));

--- a/projects/components/src/table/controls/table-controls-api.ts
+++ b/projects/components/src/table/controls/table-controls-api.ts
@@ -70,8 +70,14 @@ export type TableCheckboxOptions = [TableCheckboxControlOption<true>, TableCheck
  */
 
 export const toInFilter = (tableFilters: TableFilter[]): TableFilter =>
-  tableFilters.reduce((previousValue, currentValue) => ({
-    field: previousValue.field,
-    operator: FilterOperator.In,
-    value: [...(Array.isArray(previousValue.value) ? previousValue.value : [previousValue.value]), currentValue.value]
-  }));
+  tableFilters.reduce((previousValue, currentValue) => {
+    if (currentValue.operator !== FilterOperator.Equals || previousValue.field !== currentValue.field) {
+      throw Error('Filters must all contain same field and use = operator');
+    }
+
+    return {
+      field: previousValue.field,
+      operator: FilterOperator.In,
+      value: [...(Array.isArray(previousValue.value) ? previousValue.value : [previousValue.value]), currentValue.value]
+    }
+  });

--- a/projects/components/src/table/controls/table-controls-api.ts
+++ b/projects/components/src/table/controls/table-controls-api.ts
@@ -32,13 +32,13 @@ export interface TablePropertyControlOption {
  * Select Control
  */
 
-export interface SelectControl {
+export interface TableSelectControl {
   placeholder: string;
   options: TableSelectControlOption[];
 }
 
-export interface SelectChange {
-  select: SelectControl;
+export interface TableSelectChange {
+  select: TableSelectControl;
   values: TableSelectControlOption[];
 }
 
@@ -48,14 +48,14 @@ export type TableSelectControlOption = TableFilterControlOption;
  * Checkbox Control
  */
 
-export interface CheckboxControl {
+export interface TableCheckboxControl {
   label: string;
   value: boolean;
   options: TableCheckboxOptions;
 }
 
-export interface CheckboxChange {
-  checkbox: CheckboxControl;
+export interface TableCheckboxChange {
+  checkbox: TableCheckboxControl;
   option: TableCheckboxControlOption;
 }
 

--- a/projects/components/src/table/controls/table-controls-api.ts
+++ b/projects/components/src/table/controls/table-controls-api.ts
@@ -10,23 +10,23 @@ export const enum TableControlOptionType {
 
 export type TableControlOption = TableUnsetControlOption | TableFilterControlOption | TablePropertyControlOption;
 
-export type TableFilterControlOption = {
+export interface TableFilterControlOption {
   type: TableControlOptionType.Filter;
   label: string;
   metaValue: TableFilter;
-};
+}
 
-export type TableUnsetControlOption = {
+export interface TableUnsetControlOption {
   type: TableControlOptionType.Unset;
   label: string;
   metaValue: string;
-};
+}
 
-export type TablePropertyControlOption = {
+export interface TablePropertyControlOption {
   type: TableControlOptionType.Property;
   label: string;
   metaValue: Dictionary<unknown>;
-};
+}
 
 /*
  * Select Control

--- a/projects/components/src/table/controls/table-controls.component.test.ts
+++ b/projects/components/src/table/controls/table-controls.component.test.ts
@@ -1,6 +1,6 @@
 import { fakeAsync } from '@angular/core/testing';
 import { SubscriptionLifecycle } from '@hypertrace/common';
-import { SelectComponent } from '@hypertrace/components';
+import { MultiSelectComponent } from '@hypertrace/components';
 import { createHostFactory, mockProvider } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { SearchBoxComponent } from '../../search-box/search-box.component';
@@ -14,7 +14,7 @@ describe('Table Controls component', () => {
     providers: [mockProvider(SubscriptionLifecycle)],
     declarations: [
       MockComponent(SearchBoxComponent),
-      MockComponent(SelectComponent),
+      MockComponent(MultiSelectComponent),
       MockComponent(ToggleGroupComponent)
     ],
     template: `
@@ -67,11 +67,11 @@ describe('Table Controls component', () => {
             options: [
               {
                 label: 'first1',
-                value: 'first-1'
+                metaValue: 'first-1'
               },
               {
                 label: 'second1',
-                value: 'second-1'
+                metaValue: 'second-1'
               }
             ]
           }
@@ -79,7 +79,7 @@ describe('Table Controls component', () => {
       }
     });
 
-    expect(spectator.query(SelectComponent)?.placeholder).toEqual('test1');
+    expect(spectator.query(MultiSelectComponent)?.placeholder).toEqual('test1');
   });
 
   test('should emit selection when selected', () => {
@@ -106,10 +106,12 @@ describe('Table Controls component', () => {
       }
     });
 
-    spectator.triggerEventHandler(SelectComponent, 'selectedChange', {
-      label: 'first1',
-      value: 'first-1'
-    });
+    spectator.triggerEventHandler(MultiSelectComponent, 'selectedChange', [
+      {
+        label: 'first1',
+        value: 'first-1'
+      }
+    ]);
 
     expect(onChangeSpy).toHaveBeenCalled();
   });

--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -93,6 +93,7 @@ import {
 })
 export class TableControlsComponent implements OnChanges {
   public readonly DEFAULT_SEARCH_PLACEHOLDER: string = 'Search...';
+
   @Input()
   public searchEnabled?: boolean;
 

--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -17,10 +17,10 @@ import { MultiSelectJustify } from '../../multi-select/multi-select-justify';
 import { MultiSelectSearchMode, TriggerLabelDisplayMode } from '../../multi-select/multi-select.component';
 import { ToggleItem } from '../../toggle-group/toggle-item';
 import {
-  CheckboxChange,
-  CheckboxControl,
-  SelectChange,
-  SelectControl,
+  TableCheckboxChange,
+  TableCheckboxControl,
+  TableSelectChange,
+  TableSelectControl,
   TableSelectControlOption
 } from './table-controls-api';
 
@@ -101,10 +101,10 @@ export class TableControlsComponent implements OnChanges {
   public searchPlaceholder?: string;
 
   @Input()
-  public selectControls?: SelectControl[] = [];
+  public selectControls?: TableSelectControl[] = [];
 
   @Input()
-  public checkboxControls?: CheckboxControl[] = [];
+  public checkboxControls?: TableCheckboxControl[] = [];
 
   @Input()
   public activeFilterItem?: ToggleItem;
@@ -119,10 +119,10 @@ export class TableControlsComponent implements OnChanges {
   public readonly searchChange: EventEmitter<string> = new EventEmitter<string>();
 
   @Output()
-  public readonly selectChange: EventEmitter<SelectChange> = new EventEmitter<SelectChange>();
+  public readonly selectChange: EventEmitter<TableSelectChange> = new EventEmitter<TableSelectChange>();
 
   @Output()
-  public readonly checkboxChange: EventEmitter<CheckboxChange> = new EventEmitter<CheckboxChange>();
+  public readonly checkboxChange: EventEmitter<TableCheckboxChange> = new EventEmitter<TableCheckboxChange>();
 
   @Output()
   public readonly viewChange: EventEmitter<string> = new EventEmitter<string>();
@@ -187,7 +187,7 @@ export class TableControlsComponent implements OnChanges {
     this.searchDebounceSubject.next(text);
   }
 
-  public onMultiSelectChange(select: SelectControl, selections: TableSelectControlOption[]): void {
+  public onMultiSelectChange(select: TableSelectControl, selections: TableSelectControlOption[]): void {
     this.selectChange.emit({
       select: select,
       values: selections
@@ -201,7 +201,7 @@ export class TableControlsComponent implements OnChanges {
     }
 
     diff.forEachAddedItem(addedItem => {
-      const found: CheckboxControl | undefined = this.checkboxControls?.find(
+      const found: TableCheckboxControl | undefined = this.checkboxControls?.find(
         control => control.label === addedItem.item
       );
       if (found) {
@@ -213,7 +213,7 @@ export class TableControlsComponent implements OnChanges {
     });
 
     diff.forEachRemovedItem(removedItem => {
-      const found: CheckboxControl | undefined = this.checkboxControls?.find(
+      const found: TableCheckboxControl | undefined = this.checkboxControls?.find(
         control => control.label === removedItem.item
       );
       if (found) {

--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -14,9 +14,15 @@ import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { IconSize } from '../../icon/icon-size';
 import { MultiSelectJustify } from '../../multi-select/multi-select-justify';
-import { TriggerLabelDisplayMode } from '../../multi-select/multi-select.component';
+import { MultiSelectSearchMode, TriggerLabelDisplayMode } from '../../multi-select/multi-select.component';
 import { ToggleItem } from '../../toggle-group/toggle-item';
-import { CheckboxChange, CheckboxControl, SelectChange, SelectControl, TableControlOption } from './table-controls-api';
+import {
+  CheckboxChange,
+  CheckboxControl,
+  SelectChange,
+  SelectControl,
+  TableSelectControlOption
+} from './table-controls-api';
 
 @Component({
   selector: 'ht-table-controls',
@@ -36,19 +42,20 @@ import { CheckboxChange, CheckboxControl, SelectChange, SelectControl, TableCont
         ></ht-search-box>
 
         <!-- Selects -->
-        <ht-select
+        <ht-multi-select
           *ngFor="let selectControl of this.selectControls"
           [placeholder]="selectControl.placeholder"
-          [selected]="selectControl.default?.value"
           class="control select"
-          (selectedChange)="this.onSelectChange(selectControl, $event)"
+          showBorder="true"
+          searchMode="${MultiSelectSearchMode.CaseInsensitive}"
+          (selectedChange)="this.onMultiSelectChange(selectControl, $event)"
         >
           <ht-select-option
             *ngFor="let option of selectControl.options"
             [label]="option.label"
-            [value]="option.value"
+            [value]="option"
           ></ht-select-option>
-        </ht-select>
+        </ht-multi-select>
       </div>
 
       <!-- Right -->
@@ -179,15 +186,15 @@ export class TableControlsComponent implements OnChanges {
     this.searchDebounceSubject.next(text);
   }
 
-  public onSelectChange(select: SelectControl, value: TableControlOption): void {
+  public onMultiSelectChange(select: SelectControl, selections: TableSelectControlOption[]): void {
     this.selectChange.emit({
       select: select,
-      value: value
+      values: selections
     });
   }
 
-  public onCheckboxChange(checks: string[]): void {
-    const diff = this.checkboxDiffer?.diff(checks);
+  public onCheckboxChange(checked: string[]): void {
+    const diff = this.checkboxDiffer?.diff(checked);
     if (!diff) {
       return;
     }
@@ -216,7 +223,7 @@ export class TableControlsComponent implements OnChanges {
       }
     });
 
-    this.checkboxSelections = checks;
+    this.checkboxSelections = checked;
     this.checkboxDiffer?.diff(this.checkboxSelections);
   }
 

--- a/projects/distributed-tracing/src/shared/dashboard/data/graphql/graphql-table-control-options-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/data/graphql/graphql-table-control-options-data-source.model.ts
@@ -1,9 +1,7 @@
+import { TableControlOption } from '@hypertrace/components';
 import { Observable } from 'rxjs';
-import { LabeledTableControlOption } from '../../widgets/table/table-widget-control.model';
 import { GraphQlDataSourceModel } from './graphql-data-source.model';
 
-export abstract class GraphqlTableControlOptionsDataSourceModel extends GraphQlDataSourceModel<
-  LabeledTableControlOption[]
-> {
-  public abstract getData(): Observable<LabeledTableControlOption[]>;
+export abstract class GraphqlTableControlOptionsDataSourceModel extends GraphQlDataSourceModel<TableControlOption[]> {
+  public abstract getData(): Observable<TableControlOption[]>;
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-control-checkbox-option.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-control-checkbox-option.model.ts
@@ -1,4 +1,5 @@
-import { TableCheckboxOptions, TableControlOption } from '@hypertrace/components';
+import { hasOwnProperty } from '@hypertrace/common';
+import { TableCheckboxControlOption, TableCheckboxOptions, TableControlOption } from '@hypertrace/components';
 import { BOOLEAN_PROPERTY, Model, ModelProperty } from '@hypertrace/hyperdash';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -7,7 +8,7 @@ import { TableWidgetControlModel } from './table-widget-control.model';
 @Model({
   type: 'table-widget-checkbox-option'
 })
-export class TableWidgetControlCheckboxOptionModel extends TableWidgetControlModel {
+export class TableWidgetControlCheckboxOptionModel extends TableWidgetControlModel<TableCheckboxControlOption> {
   @ModelProperty({
     key: 'checked',
     displayName: 'Checked',
@@ -19,7 +20,7 @@ export class TableWidgetControlCheckboxOptionModel extends TableWidgetControlMod
   public getOptions(): Observable<TableCheckboxOptions> {
     return super.getOptions().pipe(
       map(options => {
-        if (!this.isValidCheckboxControlOption(options)) {
+        if (!this.isValidCheckboxControlOptions(options)) {
           throw Error(`Invalid table widget checkbox data source for options '${JSON.stringify(options)}'`);
         }
 
@@ -31,7 +32,10 @@ export class TableWidgetControlCheckboxOptionModel extends TableWidgetControlMod
     );
   }
 
-  private isValidCheckboxControlOption(options: TableControlOption[]): options is TableCheckboxOptions {
-    return options.length === 2 && options.every(option => typeof option.value === 'boolean');
+  private isValidCheckboxControlOptions(options: TableControlOption[]): options is TableCheckboxOptions {
+    return (
+      options.length === 2 &&
+      options.every(option => hasOwnProperty(option, 'value') && typeof option.value === 'boolean')
+    );
   }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-control-select-option.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-control-select-option.model.ts
@@ -1,14 +1,34 @@
+import { TableControlOption, TableControlOptionType, TableSelectControlOption } from '@hypertrace/components';
 import { Model, ModelProperty, STRING_PROPERTY } from '@hypertrace/hyperdash';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { TableWidgetControlModel } from './table-widget-control.model';
 
 @Model({
   type: 'table-widget-select-option'
 })
-export class TableWidgetControlSelectOptionModel extends TableWidgetControlModel {
+export class TableWidgetControlSelectOptionModel extends TableWidgetControlModel<TableSelectControlOption> {
   @ModelProperty({
     key: 'placeholder',
     displayName: 'Placeholder',
-    type: STRING_PROPERTY.type
+    type: STRING_PROPERTY.type,
+    required: true
   })
-  public placeholder?: string;
+  public placeholder!: string;
+
+  public getOptions(): Observable<TableSelectControlOption[]> {
+    return super.getOptions().pipe(
+      map(options => {
+        if (!this.isValidSelectControlOptions(options)) {
+          throw Error(`Invalid table widget select data source for options '${JSON.stringify(options)}'`);
+        }
+
+        return options;
+      })
+    );
+  }
+
+  private isValidSelectControlOptions(options: TableControlOption[]): options is TableSelectControlOption[] {
+    return options.every(option => option.type === TableControlOptionType.Filter);
+  }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-control.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-control.model.ts
@@ -5,7 +5,7 @@ import { uniqWith } from 'lodash-es';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-export abstract class TableWidgetControlModel {
+export abstract class TableWidgetControlModel<T extends TableControlOption> {
   @ModelProperty({
     key: 'sort',
     type: BOOLEAN_PROPERTY.type
@@ -29,24 +29,24 @@ export abstract class TableWidgetControlModel {
   @ModelInject(MODEL_API)
   protected readonly api!: ModelApi;
 
-  public getOptions(): Observable<LabeledTableControlOption[]> {
-    return this.api.getData<LabeledTableControlOption[]>().pipe(
-      map(options => (this.uniqueValues ? this.filterUniqueValues(options) : options)),
+  public getOptions(): Observable<T[]> {
+    return this.api.getData<T[]>().pipe(
+      map(options => (this.uniqueValues ? this.filterUnique(options) : options)),
       map(options => (this.sort ? this.applySort(options) : options))
     );
   }
 
-  private filterUniqueValues(options: LabeledTableControlOption[]): LabeledTableControlOption[] {
-    return uniqWith(options, (a, b) => a.value === b.value);
+  protected filterUnique(options: T[]): T[] {
+    return uniqWith(options, (a, b) => a.label === b.label);
   }
 
-  private applySort(options: LabeledTableControlOption[]): LabeledTableControlOption[] {
+  protected applySort(options: T[]): T[] {
     return options.sort((a, b) => {
       // Unset option always at the top
-      if (a.type === TableControlOptionType.UnsetFilter) {
+      if (a.type === TableControlOptionType.Unset) {
         return -1;
       }
-      if (b.type === TableControlOptionType.UnsetFilter) {
+      if (b.type === TableControlOptionType.Unset) {
         return 1;
       }
 
@@ -54,7 +54,3 @@ export abstract class TableWidgetControlModel {
     });
   }
 }
-
-export type LabeledTableControlOption = TableControlOption & {
-  label: string;
-};

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -8,12 +8,12 @@ import {
   PreferenceService
 } from '@hypertrace/common';
 import {
-  CheckboxChange,
-  CheckboxControl,
+  TableCheckboxChange,
+  TableCheckboxControl,
   FilterAttribute,
   FilterOperator,
-  SelectChange,
-  SelectControl,
+  TableSelectChange,
+  TableSelectControl,
   StatefulTableRow,
   TableColumnConfig,
   TableControlOption,
@@ -100,8 +100,8 @@ export class TableWidgetRendererComponent
   implements OnInit {
   public viewItems: ToggleItem<string>[] = [];
 
-  public selectControls$!: Observable<SelectControl[]>;
-  public checkboxControls$!: Observable<CheckboxControl[]>;
+  public selectControls$!: Observable<TableSelectControl[]>;
+  public checkboxControls$!: Observable<TableCheckboxControl[]>;
 
   public metadata$!: Observable<FilterAttribute[]>;
   public columnConfigs$!: Observable<TableColumnConfig[]>;
@@ -198,7 +198,7 @@ export class TableWidgetRendererComponent
           )
         )
     ).pipe(
-      tap((checkboxControls: CheckboxControl[]) => {
+      tap((checkboxControls: TableCheckboxControl[]) => {
         // Apply initial values for checkboxes
         checkboxControls.forEach(checkboxControl => {
           this.onCheckboxChange({
@@ -271,7 +271,7 @@ export class TableWidgetRendererComponent
     );
   }
 
-  public onSelectChange(changed: SelectChange): void {
+  public onSelectChange(changed: TableSelectChange): void {
     if (changed.values.length === 0) {
       // tslint:disable-next-line: no-void-expression
       return this.selectFilterSubject.next(this.removeFilters(changed.select.options[0].metaValue.field));
@@ -283,7 +283,7 @@ export class TableWidgetRendererComponent
     return this.selectFilterSubject.next(this.mergeFilters(toInFilter(tableFilters)));
   }
 
-  public onCheckboxChange(changed: CheckboxChange): void {
+  public onCheckboxChange(changed: TableCheckboxChange): void {
     switch (changed.option.type) {
       case TableControlOptionType.Property:
         this.queryPropertiesSubject.next(this.mergeQueryProperties(changed.option.metaValue));

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -8,13 +8,11 @@ import {
   PreferenceService
 } from '@hypertrace/common';
 import {
-  TableCheckboxChange,
-  TableCheckboxControl,
   FilterAttribute,
   FilterOperator,
-  TableSelectChange,
-  TableSelectControl,
   StatefulTableRow,
+  TableCheckboxChange,
+  TableCheckboxControl,
   TableColumnConfig,
   TableControlOption,
   TableControlOptionType,
@@ -22,6 +20,8 @@ import {
   TableFilter,
   TableFilterControlOption,
   TableRow,
+  TableSelectChange,
+  TableSelectControl,
   TableSelectionMode,
   TableStyle,
   ToggleItem,

--- a/projects/observability/src/pages/apis/endpoints/endpoint-list.dashboard.ts
+++ b/projects/observability/src/pages/apis/endpoints/endpoint-list.dashboard.ts
@@ -26,10 +26,9 @@ export const endpointListDashboard: DashboardDefaultConfiguration = {
           {
             type: 'table-widget-select-option',
             'unique-values': true,
-            placeholder: 'All Services',
+            placeholder: 'Services',
             data: {
               type: 'entities-attribute-options-data-source',
-              'unset-label': 'All Services',
               // Use API so we can inherit API filters
               entity: ObservabilityEntityType.Api,
               attribute: {

--- a/projects/observability/src/shared/dashboard/data/graphql/entity/attribute/entities-attribute-options-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/entity/attribute/entities-attribute-options-data-source.model.ts
@@ -1,6 +1,5 @@
-import { FilterOperator, TableControlOptionType } from '@hypertrace/components';
-import { LabeledTableControlOption } from '@hypertrace/distributed-tracing';
-import { Model, ModelProperty, STRING_PROPERTY } from '@hypertrace/hyperdash';
+import { FilterOperator, TableControlOptionType, TableSelectControlOption } from '@hypertrace/components';
+import { Model } from '@hypertrace/hyperdash';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { EntitiesAttributeDataSourceModel } from './entities-attribute-data-source.model';
@@ -9,32 +8,19 @@ import { EntitiesAttributeDataSourceModel } from './entities-attribute-data-sour
   type: 'entities-attribute-options-data-source'
 })
 export class EntitiesAttributeOptionsDataSourceModel extends EntitiesAttributeDataSourceModel {
-  @ModelProperty({
-    key: 'unset-label',
-    type: STRING_PROPERTY.type,
-    required: true
-  })
-  public unsetLabel: string = 'All';
-
-  public getData(): Observable<LabeledTableControlOption[]> {
+  public getData(): Observable<TableSelectControlOption[]> {
     return super.getData().pipe(
-      map((values: unknown[]) => [
-        {
-          type: TableControlOptionType.UnsetFilter,
-          label: this.unsetLabel,
-          metaValue: this.specification.name
-        },
-        ...values.map(value => ({
+      map((values: unknown[]) =>
+        values.map(value => ({
           type: TableControlOptionType.Filter as const,
           label: String(value),
-          value: value,
           metaValue: {
             field: this.specification.name,
             operator: FilterOperator.Equals,
             value: value
           }
         }))
-      ])
+      )
     );
   }
 }


### PR DESCRIPTION
## Description
This change is to make all of the table control dropdowns multiselect instead of single select. 

It also cleans up some messiness around the table control filter types. Using multi-select is actually easier to configure because it no-longer requires an `Unset` option in the dropdown. This simplifies the API for the `select` dropdowns and reduces its possible filter types to just `TableControlOptionType.Filter`. Now only `checkbox` table controls use `TableControlOptionType.Unset` and `TableControlOptionType.Property` types.

https://user-images.githubusercontent.com/45181984/117207822-4134f500-ada9-11eb-8ce1-0135296d830a.mov
