### PR TITLE
refactor: make table scope optional

### DIFF
--- a/projects/components/src/table/data/table-data-source.ts
+++ b/projects/components/src/table/data/table-data-source.ts
@@ -3,7 +3,7 @@ import { TableColumnConfig, TableFilter, TableSortDirection } from '../table-api
 
 export interface TableDataSource<TResult, TCol extends TableColumnConfig = TableColumnConfig> {
   getData(request: TableDataRequest<TCol>): Observable<TableDataResponse<TResult>>;
-  getScope(): string | undefined;
+  getScope?(): string | undefined;
 }
 
 export interface TableDataRequest<TCol extends TableColumnConfig = TableColumnConfig> {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -215,7 +215,7 @@ export class TableWidgetRendererComponent
   }
 
   private getScope(): Observable<string | undefined> {
-    return this.data$!.pipe(map(data => data?.getScope()));
+    return this.data$!.pipe(map(data => data?.getScope?.()));
   }
 
   private getColumnConfigs(persistedColumns: TableColumnConfig[] = []): Observable<TableColumnConfig[]> {


### PR DESCRIPTION
## Description
Rather than requiring dummy implementations of getScope everywhere, this allows omitting it if not needed.

