### PR TITLE
feat: memoize record method call so it is only called once

### DIFF
--- a/projects/distributed-tracing/src/shared/components/log-events/log-events-table.component.ts
+++ b/projects/distributed-tracing/src/shared/components/log-events/log-events-table.component.ts
@@ -37,7 +37,7 @@ export const enum LogEventsTableViewType {
     <ng-template #detailContent let-row="row">
       <div class="content">
         <ht-list-view
-          [records]="this.getLogEventAttributeRecords(row.attributes)"
+          [records]="this.getLogEventAttributeRecords | htMemoize: row.attributes"
           [header]="this.header"
           data-sensitive-pii
         ></ht-list-view>

--- a/projects/distributed-tracing/src/shared/components/log-events/log-events-table.module.ts
+++ b/projects/distributed-tracing/src/shared/components/log-events/log-events-table.module.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormattingModule } from '@hypertrace/common';
+import { FormattingModule, MemoizeModule } from '@hypertrace/common';
 import { IconModule, ListViewModule, TableModule, TooltipModule } from '@hypertrace/components';
 import { LogEventsTableComponent } from './log-events-table.component';
 @NgModule({
-  imports: [CommonModule, TableModule, IconModule, TooltipModule, FormattingModule, ListViewModule],
+  imports: [CommonModule, TableModule, IconModule, TooltipModule, FormattingModule, ListViewModule, MemoizeModule],
   declarations: [LogEventsTableComponent],
   exports: [LogEventsTableComponent]
 })


### PR DESCRIPTION
## Description
Small fix to memoize call to `getLogEventAttributeRecords`. This stops it from calling multiple times and triggering change detection in `ht-list-view`.