### PR TITLE
feat: table cell no-op parser update

### DIFF
--- a/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
@@ -1,4 +1,3 @@
-import { Dictionary } from '@hypertrace/common';
 import { TableCellParser } from '../table-cell-parser';
 import { TableCellParserBase } from '../table-cell-parser-base';
 import { CoreTableCellParserType } from '../types/core-table-cell-parser-type';
@@ -6,14 +5,14 @@ import { CoreTableCellParserType } from '../types/core-table-cell-parser-type';
 @TableCellParser({
   type: CoreTableCellParserType.NoOp
 })
-export class TableCellNoOpParser extends TableCellParserBase<unknown, unknown, string | undefined> {
-  public parseValue(cellData: unknown): unknown {
+export class TableCellNoOpParser<T = unknown> extends TableCellParserBase<T, T, string | undefined> {
+  public parseValue(cellData: T): T {
     return cellData;
   }
 
-  public parseFilterValue(cellData: unknown): string | undefined {
+  public parseFilterValue(cellData: T | { filterValue?: string }): string | undefined {
     if (typeof cellData === 'object' && cellData !== null && 'filterValue' in cellData) {
-      return (cellData as Dictionary<unknown>).filterValue as string;
+      return cellData.filterValue;
     }
 
     return String(cellData);

--- a/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
@@ -11,7 +11,7 @@ export class TableCellNoOpParser<T = unknown> extends TableCellParserBase<T, T, 
   }
 
   public parseFilterValue(cellData: T | { filterValue?: string }): string | undefined {
-    // tslint:disable-next-line: no-unused-expression
+    // tslint:disable-next-line:strict-type-predicates
     if (typeof cellData === 'object' && cellData !== null && 'filterValue' in cellData) {
       return cellData.filterValue;
     }

--- a/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
@@ -11,7 +11,8 @@ export class TableCellNoOpParser<T = unknown> extends TableCellParserBase<T, T, 
   }
 
   public parseFilterValue(cellData: T | { filterValue?: string }): string | undefined {
-    if ('filterValue' in cellData) {
+    // tslint:disable-next-line: no-unused-expression
+    if (typeof cellData === 'object' && cellData !== null && 'filterValue' in cellData) {
       return cellData.filterValue;
     }
 

--- a/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-no-op-parser.ts
@@ -11,7 +11,7 @@ export class TableCellNoOpParser<T = unknown> extends TableCellParserBase<T, T, 
   }
 
   public parseFilterValue(cellData: T | { filterValue?: string }): string | undefined {
-    if (typeof cellData === 'object' && cellData !== null && 'filterValue' in cellData) {
+    if ('filterValue' in cellData) {
       return cellData.filterValue;
     }
 


### PR DESCRIPTION
## Description
Table Cell NoOp was updated to allow single data in the parser

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
