### PR TITLE
feat: Adding form field wrapper

### DIFF
--- a/projects/components/src/form-field/form-field.component.scss
+++ b/projects/components/src/form-field/form-field.component.scss
@@ -1,0 +1,34 @@
+@import 'mixins';
+
+.form-field {
+  padding-top: 8px;
+
+  &.optional {
+    margin-bottom: 18px;
+  }
+
+  .info-label {
+    display: flex;
+    padding-bottom: 4px;
+
+    .label {
+      @include body-2-medium($gray-7);
+      display: block;
+    }
+
+    .optional-label {
+      @include body-2-regular($gray-4);
+      padding-left: 4px;
+    }
+
+    .infobox {
+      cursor: pointer;
+      color: $gray-5;
+      padding-left: 6px;
+    }
+  }
+
+  .error-message {
+    @include footnote($red-6);
+  }
+}

--- a/projects/components/src/form-field/form-field.component.test.ts
+++ b/projects/components/src/form-field/form-field.component.test.ts
@@ -17,13 +17,13 @@ describe('Form Field Component', () => {
   test('should show mandatory form field data', () => {
     const spectator = hostFactory(
       `
-    <ht-form-field [infoLabel]="infoLabel" [icon]="icon" [infoIconTooltip]="infoIconTooltip" [errorLabel]="errorLabel">
+    <ht-form-field [label]="label" [icon]="icon" [iconTooltip]="iconTooltip" [errorLabel]="errorLabel">
     </ht-form-field>`,
       {
         hostProps: {
-          infoLabel: 'Label',
+          label: 'Label',
           icon: IconType.Info,
-          infoIconTooltip: 'Add or update a text',
+          iconTooltip: 'Add or update a text',
           errorLabel: 'Error message'
         }
       }
@@ -39,14 +39,14 @@ describe('Form Field Component', () => {
   test('should show optional form field data', () => {
     const spectator = hostFactory(
       `
-    <ht-form-field [infoLabel]="infoLabel" [optional]="optional" [infoIconTooltip]="infoIconTooltip">
+    <ht-form-field [label]="label" [isOptional]="isOptional" [iconTooltip]="iconTooltip">
     </ht-form-field>`,
       {
         hostProps: {
-          infoLabel: 'Label',
+          label: 'Label',
           icon: IconType.Info,
-          infoIconTooltip: 'Add or update a text',
-          optional: true
+          iconTooltip: 'Add or update a text',
+          isOptional: true
         }
       }
     );

--- a/projects/components/src/form-field/form-field.component.test.ts
+++ b/projects/components/src/form-field/form-field.component.test.ts
@@ -1,0 +1,57 @@
+import { IconType } from '@hypertrace/assets-library';
+import { createHostFactory } from '@ngneat/spectator/jest';
+import { MockComponent, MockModule } from 'ng-mocks';
+import { IconComponent } from '../icon/icon.component';
+import { LabelComponent } from '../label/label.component';
+import { TooltipModule } from '../tooltip/tooltip.module';
+import { FormFieldComponent } from './form-field.component';
+
+describe('Form Field Component', () => {
+  const hostFactory = createHostFactory({
+    component: FormFieldComponent,
+    declarations: [MockComponent(LabelComponent), MockComponent(IconComponent)],
+    imports: [MockModule(TooltipModule)],
+    shallow: true
+  });
+
+  test('should show mandatory form field data', () => {
+    const spectator = hostFactory(
+      `
+    <ht-form-section [infoLabel]="infoLabel" [icon]="icon" [infoIconTooltip]="infoIconTooltip" [errorLabel]="errorLabel">
+    </ht-form-section>`,
+      {
+        hostProps: {
+          infoLabel: 'Label',
+          icon: IconType.Info,
+          infoIconTooltip: 'Add or update a text',
+          errorLabel: 'Error message'
+        }
+      }
+    );
+    const labels = spectator.queryAll(LabelComponent);
+    expect(labels[0].label).toEqual('Label');
+    expect(labels[1].label).toEqual('Error message');
+
+    const icon = spectator.query(IconComponent);
+    expect(icon?.icon).toEqual(IconType.Info);
+  });
+
+  test('should show optional form field data', () => {
+    const spectator = hostFactory(
+      `
+    <ht-form-section [infoLabel]="infoLabel" [optional]="optional" [infoIconTooltip]="infoIconTooltip">
+    </ht-form-section>`,
+      {
+        hostProps: {
+          infoLabel: 'Label',
+          icon: IconType.Info,
+          infoIconTooltip: 'Add or update a text',
+          optional: true
+        }
+      }
+    );
+    const labels = spectator.queryAll(LabelComponent);
+    expect(labels[0].label).toEqual('Label');
+    expect(labels[1].label).toEqual('(Optional)');
+  });
+});

--- a/projects/components/src/form-field/form-field.component.test.ts
+++ b/projects/components/src/form-field/form-field.component.test.ts
@@ -17,8 +17,8 @@ describe('Form Field Component', () => {
   test('should show mandatory form field data', () => {
     const spectator = hostFactory(
       `
-    <ht-form-section [infoLabel]="infoLabel" [icon]="icon" [infoIconTooltip]="infoIconTooltip" [errorLabel]="errorLabel">
-    </ht-form-section>`,
+    <ht-form-field [infoLabel]="infoLabel" [icon]="icon" [infoIconTooltip]="infoIconTooltip" [errorLabel]="errorLabel">
+    </ht-form-field>`,
       {
         hostProps: {
           infoLabel: 'Label',
@@ -39,8 +39,8 @@ describe('Form Field Component', () => {
   test('should show optional form field data', () => {
     const spectator = hostFactory(
       `
-    <ht-form-section [infoLabel]="infoLabel" [optional]="optional" [infoIconTooltip]="infoIconTooltip">
-    </ht-form-section>`,
+    <ht-form-field [infoLabel]="infoLabel" [optional]="optional" [infoIconTooltip]="infoIconTooltip">
+    </ht-form-field>`,
       {
         hostProps: {
           infoLabel: 'Label',

--- a/projects/components/src/form-field/form-field.component.ts
+++ b/projects/components/src/form-field/form-field.component.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { IconType } from '@hypertrace/assets-library';
+import { IconSize } from '../icon/icon-size';
+
+@Component({
+  selector: 'ht-form-field',
+  styleUrls: ['./form-field.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="form-field" [ngClass]="{ optional: this.optional }">
+      <div class="info-label">
+        <ht-label *ngIf="this.infoLabel" class="label" [label]="this.infoLabel"></ht-label>
+        <ht-label *ngIf="this.optional" class="optional-label" label="(Optional)"></ht-label>
+        <ht-icon
+          *ngIf="this.icon"
+          class="infobox"
+          [icon]="this.icon"
+          [size]="this.iconSize"
+          [htTooltip]="this.infoIconTooltip"
+        ></ht-icon>
+      </div>
+      <ng-content></ng-content>
+      <ht-label *ngIf="!this.optional" class="error-message" [label]="this.errorLabel"></ht-label>
+    </section>
+  `
+})
+export class FormFieldComponent {
+  @Input()
+  public infoLabel?: string;
+
+  @Input()
+  public optional?: boolean = false;
+
+  @Input()
+  public icon?: IconType;
+
+  @Input()
+  public iconSize?: IconSize = IconSize.Small;
+
+  @Input()
+  public infoIconTooltip?: string;
+
+  @Input()
+  public errorLabel?: string = '';
+}

--- a/projects/components/src/form-field/form-field.component.ts
+++ b/projects/components/src/form-field/form-field.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { IconType } from '@hypertrace/assets-library';
 import { IconSize } from '../icon/icon-size';
 
 @Component({
@@ -7,38 +6,38 @@ import { IconSize } from '../icon/icon-size';
   styleUrls: ['./form-field.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <section class="form-field" [ngClass]="{ optional: this.optional }">
+    <section class="form-field" [ngClass]="{ optional: this.isOptional }">
       <div class="info-label">
-        <ht-label *ngIf="this.infoLabel" class="label" [label]="this.infoLabel"></ht-label>
-        <ht-label *ngIf="this.optional" class="optional-label" label="(Optional)"></ht-label>
+        <ht-label *ngIf="this.label" class="label" [label]="this.label"></ht-label>
+        <ht-label *ngIf="this.isOptional" class="optional-label" label="(Optional)"></ht-label>
         <ht-icon
           *ngIf="this.icon"
           class="infobox"
           [icon]="this.icon"
           [size]="this.iconSize"
-          [htTooltip]="this.infoIconTooltip"
+          [htTooltip]="this.iconTooltip"
         ></ht-icon>
       </div>
       <ng-content></ng-content>
-      <ht-label *ngIf="!this.optional" class="error-message" [label]="this.errorLabel"></ht-label>
+      <ht-label *ngIf="!this.isOptional" class="error-message" [label]="this.errorLabel"></ht-label>
     </section>
   `
 })
 export class FormFieldComponent {
   @Input()
-  public infoLabel?: string;
+  public label?: string;
 
   @Input()
-  public optional?: boolean = false;
+  public isOptional?: boolean = false;
 
   @Input()
-  public icon?: IconType;
+  public icon?: string;
 
   @Input()
   public iconSize?: IconSize = IconSize.Small;
 
   @Input()
-  public infoIconTooltip?: string;
+  public iconTooltip?: string;
 
   @Input()
   public errorLabel?: string = '';

--- a/projects/components/src/form-field/form-field.module.ts
+++ b/projects/components/src/form-field/form-field.module.ts
@@ -1,0 +1,13 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { IconModule } from '../icon/icon.module';
+import { LabelModule } from '../label/label.module';
+import { TooltipModule } from '../tooltip/tooltip.module';
+import { FormFieldComponent } from './form-field.component';
+
+@NgModule({
+  imports: [CommonModule, LabelModule, IconModule, TooltipModule],
+  declarations: [FormFieldComponent],
+  exports: [FormFieldComponent]
+})
+export class FormFieldModule {}

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -104,6 +104,10 @@ export * from './filtering/filter-modal/in-filter-modal.component';
 // Filter Parser
 export * from './filtering/filter/parser/filter-parser-lookup.service';
 
+// Form Section
+export * from './form-field/form-field.component';
+export * from './form-field/form-field.module';
+
 // Greeting label
 export { GreetingLabelModule } from './greeting-label/greeting-label.module';
 export { GreetingLabelComponent } from './greeting-label/greeting-label.component';


### PR DESCRIPTION
## Description
A new component was created that works as a wrapper for the label, icon, and input field to have a standard to insert in the different components. The component allows attaching any input field present in the library

### Testing
Unit test and visual test.

![image](https://user-images.githubusercontent.com/79482271/120344175-bd025e80-c2cf-11eb-8d09-ec227192a472.png)

References:

![image](https://user-images.githubusercontent.com/79482271/120381415-c522c400-c2f8-11eb-85ae-cf0690921bba.png)

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
