### PR TITLE
feat: adding options alignment in Radio Group

### DIFF
--- a/projects/components/src/radio/radio-group.component.scss
+++ b/projects/components/src/radio/radio-group.component.scss
@@ -8,6 +8,16 @@
 }
 
 .radio-group {
+  display: flex;
+
+  &.row {
+    flex-direction: row;
+  }
+
+  &.column {
+    flex-direction: column;
+  }
+
   ::ng-deep .radio-button {
     line-height: 18px;
     padding-right: 10px;

--- a/projects/components/src/radio/radio-group.component.ts
+++ b/projects/components/src/radio/radio-group.component.ts
@@ -11,6 +11,7 @@ import { RadioOption } from './radio-option';
     <ht-label class="title" [label]="this.title"></ht-label>
     <mat-radio-group
       class="radio-group"
+      [ngClass]="this.optionsDirection"
       [ngModel]="this.selected!.value"
       (change)="this.onRadioChange($event)"
       [disabled]="this.disabled"
@@ -39,6 +40,9 @@ export class RadioGroupComponent implements OnInit {
   @Input()
   public disabled: boolean | undefined;
 
+  @Input()
+  public optionsDirection: OptionsDirection = OptionsDirection.Row;
+
   @Output()
   public readonly selectedChange: EventEmitter<string> = new EventEmitter();
 
@@ -62,4 +66,9 @@ export class RadioGroupComponent implements OnInit {
     this.selected = this.options.find(option => option.value === event.value);
     this.selectedChange.emit(event.value);
   }
+}
+
+export const enum OptionsDirection {
+  Row = 'row',
+  Column = 'column'
 }

--- a/projects/components/src/radio/radio-group.component.ts
+++ b/projects/components/src/radio/radio-group.component.ts
@@ -41,7 +41,7 @@ export class RadioGroupComponent implements OnInit {
   public disabled: boolean | undefined;
 
   @Input()
-  public optionsDirection: OptionsDirection = OptionsDirection.Row;
+  public optionsDirection: OptionsDirection = OptionsDirection.Column;
 
   @Output()
   public readonly selectedChange: EventEmitter<string> = new EventEmitter();


### PR DESCRIPTION
## Description
Adding the attribute to configure horizontal/vertical options alignment from Radio Group (column default alignment).

### Testing
Visual Testing

Row View:
![image](https://user-images.githubusercontent.com/79482271/121386400-5826b400-c920-11eb-90f7-11039f7b6ef9.png)

Column View:
![image](https://user-images.githubusercontent.com/79482271/121386460-65dc3980-c920-11eb-8822-b39c94101990.png)


### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
