### PR TITLE
Fix to retain table control filters on refresh

### DIFF
--- a/projects/components/src/table/controls/table-controls-api.ts
+++ b/projects/components/src/table/controls/table-controls-api.ts
@@ -14,18 +14,21 @@ export interface TableFilterControlOption {
   type: TableControlOptionType.Filter;
   label: string;
   metaValue: TableFilter;
+  applied?: boolean;
 }
 
 export interface TableUnsetControlOption {
   type: TableControlOptionType.Unset;
   label: string;
   metaValue: string;
+  applied?: boolean;
 }
 
 export interface TablePropertyControlOption {
   type: TableControlOptionType.Property;
   label: string;
   metaValue: Dictionary<unknown>;
+  applied?: boolean;
 }
 
 /*

--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -44,6 +44,7 @@ import {
         <!-- Selects -->
         <ht-multi-select
           *ngFor="let selectControl of this.selectControls"
+          [selected]="this.appliedFilters(selectControl)"
           [placeholder]="selectControl.placeholder"
           class="control select"
           showBorder="true"
@@ -127,6 +128,11 @@ export class TableControlsComponent implements OnChanges {
   @Output()
   public readonly viewChange: EventEmitter<string> = new EventEmitter<string>();
 
+  private readonly selectSelections: Map<TableSelectControl, TableSelectControlOption[]> = new Map<
+    TableSelectControl,
+    TableSelectControlOption[]
+  >();
+
   public checkboxSelections: string[] = [];
   private readonly checkboxDiffer?: IterableDiffer<string>;
 
@@ -160,6 +166,10 @@ export class TableControlsComponent implements OnChanges {
   }
 
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
+    if (changes.selectControls) {
+      this.diffSelections();
+    }
+
     if (changes.checkboxControls) {
       this.diffCheckboxes();
     }
@@ -169,12 +179,26 @@ export class TableControlsComponent implements OnChanges {
     }
   }
 
+  private diffSelections(): void {
+    this.selectSelections.clear();
+    this.selectControls?.forEach(selectControl => {
+      this.selectSelections.set(
+        selectControl,
+        selectControl.options.filter(option => option.applied)
+      );
+    });
+  }
+
   private diffCheckboxes(): void {
     this.checkboxSelections = this.checkboxControls
       ? this.checkboxControls.filter(control => control.value).map(control => control.label)
       : [];
 
     this.checkboxDiffer?.diff(this.checkboxSelections);
+  }
+
+  public appliedFilters(selectControl: TableSelectControl): TableSelectControlOption[] | undefined {
+    return this.selectSelections.get(selectControl);
   }
 
   private setActiveViewItem(): void {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -29,7 +29,7 @@ import {
 } from '@hypertrace/components';
 import { WidgetRenderer } from '@hypertrace/dashboards';
 import { Renderer } from '@hypertrace/hyperdash';
-import { RENDERER_API, RendererApi } from '@hypertrace/hyperdash-angular';
+import { RendererApi, RENDERER_API } from '@hypertrace/hyperdash-angular';
 import { capitalize, isEmpty, isEqual, pick } from 'lodash-es';
 import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
 import { filter, map, pairwise, share, startWith, switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
@@ -189,13 +189,13 @@ export class TableWidgetRendererComponent
   private isFilterApplied(filterOption: TableFilter, appliedFilters: TableFilter[]): boolean {
     // This gets just a little tricky because multiple options for a single select could be IN filtered together
     return (
-      appliedFilters.find(filter => {
-        if (isEqual(filter, filterOption)) {
+      appliedFilters.find(f => {
+        if (isEqual(f, filterOption)) {
           return true;
         }
 
-        if (filter.field === filterOption.field && filter.operator === FilterOperator.In) {
-          return Array.isArray(filter.value) && filter.value.find(value => value === filterOption.value);
+        if (f.field === filterOption.field && f.operator === FilterOperator.In) {
+          return Array.isArray(f.value) && f.value.find(value => value === filterOption.value);
         }
       }) !== undefined
     );

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -29,10 +29,10 @@ import {
 } from '@hypertrace/components';
 import { WidgetRenderer } from '@hypertrace/dashboards';
 import { Renderer } from '@hypertrace/hyperdash';
-import { RendererApi, RENDERER_API } from '@hypertrace/hyperdash-angular';
-import { capitalize, isEmpty, pick } from 'lodash-es';
+import { RENDERER_API, RendererApi } from '@hypertrace/hyperdash-angular';
+import { capitalize, isEmpty, isEqual, pick } from 'lodash-es';
 import { BehaviorSubject, combineLatest, Observable, of, Subject } from 'rxjs';
-import { filter, map, pairwise, share, startWith, switchMap, take, tap } from 'rxjs/operators';
+import { filter, map, pairwise, share, startWith, switchMap, take, tap, withLatestFrom } from 'rxjs/operators';
 import { AttributeMetadata, toFilterAttributeType } from '../../../graphql/model/metadata/attribute-metadata';
 import { MetadataService } from '../../../services/metadata/metadata.service';
 import { InteractionHandler } from '../../interaction/interaction-handler';
@@ -173,12 +173,31 @@ export class TableWidgetRendererComponent
           // Fetch the values for the selectFilter dropdown
           selectControlModel.getOptions().pipe(
             take(1),
-            map(options => ({
+            withLatestFrom(this.selectFilterSubject),
+            map(([options, filters]) => ({
               placeholder: selectControlModel.placeholder,
-              options: options
+              options: options.map(option => ({
+                ...option,
+                applied: this.isFilterApplied(option.metaValue, filters)
+              }))
             }))
           )
         )
+    );
+  }
+
+  private isFilterApplied(filterOption: TableFilter, appliedFilters: TableFilter[]): boolean {
+    // This gets just a little tricky because multiple options for a single select could be IN filtered together
+    return (
+      appliedFilters.find(filter => {
+        if (isEqual(filter, filterOption)) {
+          return true;
+        }
+
+        if (filter.field === filterOption.field && filter.operator === FilterOperator.In) {
+          return Array.isArray(filter.value) && filter.value.find(value => value === filterOption.value);
+        }
+      }) !== undefined
     );
   }
 


### PR DESCRIPTION
## Description
This fixes a bug where when a table filter is applied and a user uses the internal refresh in the top bar, the table controls get cleared and there is no indication to the user that the filter is still applied. With this change, we now look at the currently applied filters and reapply them to the table controls upon refresh.