### PR TITLE
fix: svg content can overflow container

### DIFF
--- a/projects/components/src/titled-content/titled-content.component.scss
+++ b/projects/components/src/titled-content/titled-content.component.scss
@@ -35,7 +35,6 @@
     height: 100%;
     width: 100%;
     flex: 1 1 auto;
-    overflow: hidden;
   }
 
   .footer {

--- a/projects/observability/src/shared/components/radar/radar-chart.scss
+++ b/projects/observability/src/shared/components/radar/radar-chart.scss
@@ -6,6 +6,10 @@
   height: 100%;
 
   ::ng-deep {
+    svg {
+      overflow: visible;
+    }
+
     .axis {
       line {
         stroke: $gray-1;


### PR DESCRIPTION
## Description
Text is cropping on an SVG graph because the container is overflow hidden and SVG is also overflow hidden on this particular graph. To solve this we have 3 options 
- Make text shorter. (Not recommended as text is already very short and reducing it even further may make it confusing)
- Reduce font size. (Not recommended as the font is already very small and reducing it even further may make it unreadable)
- Allow SVG to overflow and control it from the consumer container.


### Testing
Changes verified locally on all affected areas. This PR contains CSS changes only, no new test cases are added or updated

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
