### PR TITLE
feat: add custom configurations to the topology widget

### DIFF
--- a/projects/observability/src/shared/components/topology/d3/d3-topology.ts
+++ b/projects/observability/src/shared/components/topology/d3/d3-topology.ts
@@ -182,7 +182,7 @@ export class D3Topology implements Topology {
       target: data,
       scroll: this.config.zoomable ? zoomScrollConfig : undefined,
       pan: this.config.zoomable ? zoomPanConfig : undefined,
-      showBrush: true
+      showBrush: this.config.showBrush
     });
 
     this.onDestroy(() => {

--- a/projects/observability/src/shared/components/topology/d3/interactions/topology-interaction-control.component.ts
+++ b/projects/observability/src/shared/components/topology/d3/interactions/topology-interaction-control.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, InjectionToken } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, InjectionToken, OnInit } from '@angular/core';
 import { IconType } from '@hypertrace/assets-library';
 import { SubscriptionLifecycle, throwIfNil } from '@hypertrace/common';
 
@@ -69,7 +69,7 @@ export const TOPOLOGY_INTERACTION_CONTROL_DATA = new InjectionToken<TopologyInte
     </div>
   `
 })
-export class TopologyInteractionControlComponent {
+export class TopologyInteractionControlComponent implements OnInit {
   public currentZoomPercentage: string = '100';
   public canIncrement: boolean = true;
   public canDecrement: boolean = true;
@@ -109,6 +109,12 @@ export class TopologyInteractionControlComponent {
 
     this.edgeDataSpecifiers = interactionControlData.topologyConfig.edgeDataSpecifiers;
     this.nodeDataSpecifiers = interactionControlData.topologyConfig.nodeDataSpecifiers;
+  }
+
+  public ngOnInit(): void {
+    if (this.interactionControlData.topologyConfig.autoZoomToFit) {
+      this.zoomToFit();
+    }
   }
 
   // TODO should make the increments logarithmic

--- a/projects/observability/src/shared/components/topology/d3/interactions/topology-interaction-control.component.ts
+++ b/projects/observability/src/shared/components/topology/d3/interactions/topology-interaction-control.component.ts
@@ -112,7 +112,7 @@ export class TopologyInteractionControlComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-    if (this.interactionControlData.topologyConfig.autoZoomToFit) {
+    if (this.interactionControlData.topologyConfig.shouldAutoZoomToFit) {
       this.zoomToFit();
     }
   }

--- a/projects/observability/src/shared/components/topology/topology.component.ts
+++ b/projects/observability/src/shared/components/topology/topology.component.ts
@@ -47,7 +47,7 @@ export class TopologyComponent implements OnChanges, OnDestroy {
   public showBrush?: boolean = true;
 
   @Input()
-  public autoZoomToFit?: boolean = false;
+  public shouldAutoZoomToFit?: boolean = false;
 
   @ViewChild('topologyContainer', { static: true })
   private readonly container!: ElementRef;
@@ -73,7 +73,7 @@ export class TopologyComponent implements OnChanges, OnDestroy {
       edgeDataSpecifiers: this.edgeDataSpecifiers,
       tooltipRenderer: this.tooltipRenderer,
       showBrush: this.showBrush,
-      autoZoomToFit: this.autoZoomToFit
+      shouldAutoZoomToFit: this.shouldAutoZoomToFit
     });
 
     // Angular doesn't like introducing new child views mid-change detection

--- a/projects/observability/src/shared/components/topology/topology.component.ts
+++ b/projects/observability/src/shared/components/topology/topology.component.ts
@@ -43,6 +43,12 @@ export class TopologyComponent implements OnChanges, OnDestroy {
   @Input()
   public edgeDataSpecifiers?: TopologyDataSpecifier[];
 
+  @Input()
+  public showBrush?: boolean = true;
+
+  @Input()
+  public autoZoomToFit?: boolean = false;
+
   @ViewChild('topologyContainer', { static: true })
   private readonly container!: ElementRef;
 
@@ -65,7 +71,9 @@ export class TopologyComponent implements OnChanges, OnDestroy {
       edgeRenderer: this.edgeRenderer,
       nodeDataSpecifiers: this.nodeDataSpecifiers,
       edgeDataSpecifiers: this.edgeDataSpecifiers,
-      tooltipRenderer: this.tooltipRenderer
+      tooltipRenderer: this.tooltipRenderer,
+      showBrush: this.showBrush,
+      autoZoomToFit: this.autoZoomToFit
     });
 
     // Angular doesn't like introducing new child views mid-change detection

--- a/projects/observability/src/shared/components/topology/topology.ts
+++ b/projects/observability/src/shared/components/topology/topology.ts
@@ -52,7 +52,7 @@ export interface TopologyConfiguration {
   /**
    * If true, it will be automatic zoom to fit
    */
-  autoZoomToFit?: boolean;
+  shouldAutoZoomToFit?: boolean;
 
   /**
    * A list of specifiers for node data. Up to one will be selectable to the user,

--- a/projects/observability/src/shared/components/topology/topology.ts
+++ b/projects/observability/src/shared/components/topology/topology.ts
@@ -45,6 +45,16 @@ export interface TopologyConfiguration {
   zoomable: boolean;
 
   /**
+   * If true, brush will be shown
+   */
+  showBrush?: boolean;
+
+  /**
+   * If true, it will be automatic zoom to fit
+   */
+  autoZoomToFit?: boolean;
+
+  /**
    * A list of specifiers for node data. Up to one will be selectable to the user,
    * and provided to the node renderer.
    */

--- a/projects/observability/src/shared/dashboard/widgets/topology/topology-widget-renderer.component.test.ts
+++ b/projects/observability/src/shared/dashboard/widgets/topology/topology-widget-renderer.component.test.ts
@@ -83,7 +83,8 @@ describe('Topology Widget renderer', () => {
         edgeSpecification: edgeSpec,
         nodeTypes: uniq(mockResponse.map(node => node.data[entityTypeKey]))
       })
-    )
+    ),
+    showLegend: true
   };
 
   const createComponent = createComponentFactory<TopologyWidgetRendererComponent>({

--- a/projects/observability/src/shared/dashboard/widgets/topology/topology-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/topology/topology-widget-renderer.component.ts
@@ -60,7 +60,7 @@ import { TopologyWidgetModel } from './topology-widget.model';
           [nodeDataSpecifiers]="data.nodeSpecs"
           [edgeDataSpecifiers]="data.edgeSpecs"
           [showBrush]="this.model.showBrush"
-          [autoZoomToFit]="this.model.autoZoomToFit"
+          [shouldAutoZoomToFit]="this.model.shouldAutoZoomToFit"
         >
         </ht-topology>
       </div>

--- a/projects/observability/src/shared/dashboard/widgets/topology/topology-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/topology/topology-widget-renderer.component.ts
@@ -35,7 +35,7 @@ import { TopologyWidgetModel } from './topology-widget.model';
   template: `
     <ht-titled-content [title]="this.model.title | htDisplayTitle">
       <div class="visualization" *htLoadAsync="this.data$ as data">
-        <div class="legend">
+        <div *ngIf="this.model.showLegend" class="legend">
           <div class="latency">
             <div class="label">P99 Latency:</div>
             <div class="entry" *ngFor="let entry of this.getLatencyLegendConfig()">
@@ -59,6 +59,8 @@ import { TopologyWidgetModel } from './topology-widget.model';
           [tooltipRenderer]="this.tooltipRenderer"
           [nodeDataSpecifiers]="data.nodeSpecs"
           [edgeDataSpecifiers]="data.edgeSpecs"
+          [showBrush]="this.model.showBrush"
+          [autoZoomToFit]="this.model.autoZoomToFit"
         >
         </ht-topology>
       </div>

--- a/projects/observability/src/shared/dashboard/widgets/topology/topology-widget.model.ts
+++ b/projects/observability/src/shared/dashboard/widgets/topology/topology-widget.model.ts
@@ -33,12 +33,12 @@ export class TopologyWidgetModel {
   public showBrush?: boolean = true;
 
   @ModelProperty({
-    key: 'autoZoomToFit',
-    displayName: 'Auto Zoom To Fit',
+    key: 'shouldAutoZoomToFit',
+    displayName: 'Should Auto Zoom To Fit',
     type: BOOLEAN_PROPERTY.type,
     required: false
   })
-  public autoZoomToFit?: boolean = false;
+  public shouldAutoZoomToFit?: boolean = false;
 
   @ModelInject(MODEL_API)
   private readonly api!: ModelApi;

--- a/projects/observability/src/shared/dashboard/widgets/topology/topology-widget.model.ts
+++ b/projects/observability/src/shared/dashboard/widgets/topology/topology-widget.model.ts
@@ -1,4 +1,4 @@
-import { Model, ModelApi, ModelProperty, STRING_PROPERTY } from '@hypertrace/hyperdash';
+import { BOOLEAN_PROPERTY, Model, ModelApi, ModelProperty, STRING_PROPERTY } from '@hypertrace/hyperdash';
 import { ModelInject, MODEL_API } from '@hypertrace/hyperdash-angular';
 import { Observable } from 'rxjs';
 import { TopologyData, TopologyDataSourceModel } from '../../data/graphql/topology/topology-data-source.model';
@@ -15,6 +15,30 @@ export class TopologyWidgetModel {
     required: false
   })
   public title?: string;
+
+  @ModelProperty({
+    key: 'showLegend',
+    displayName: 'Show Legend',
+    type: BOOLEAN_PROPERTY.type,
+    required: false
+  })
+  public showLegend?: boolean = true;
+
+  @ModelProperty({
+    key: 'showBrush',
+    displayName: 'Show Brush',
+    type: BOOLEAN_PROPERTY.type,
+    required: false
+  })
+  public showBrush?: boolean = true;
+
+  @ModelProperty({
+    key: 'autoZoomToFit',
+    displayName: 'Auto Zoom To Fit',
+    type: BOOLEAN_PROPERTY.type,
+    required: false
+  })
+  public autoZoomToFit?: boolean = false;
 
   @ModelInject(MODEL_API)
   private readonly api!: ModelApi;


### PR DESCRIPTION
## Description
Add custom configurations to the topology widget

- Make legend optional
- Make minimap/brush optional
- Add zoom to fit configuration

### Testing
Local testing done

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
