### PR TITLE
fix: build initiial nav params on observable

### DIFF
--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -128,6 +128,7 @@ export class NavigationService {
     paramsOrUrl: NavigationParams | string
   ): Observable<{ path: NavigationPath; extras?: NavigationExtras }> {
     return this.navigation$.pipe(
+      startWith(this.getCurrentActivatedRoute()),
       switchMap(route => route.queryParams),
       map(() => this.buildNavigationParams(paramsOrUrl)),
       distinctUntilChanged(isEqualIgnoreFunctions)


### PR DESCRIPTION
## Description
Link observable was only emitting after a change in route, so initial state was empty.

### Testing
Manual

