### PR TITLE
Adding new style button

### DIFF
--- a/projects/components/src/button/button.component.scss
+++ b/projects/components/src/button/button.component.scss
@@ -42,10 +42,6 @@
     color: inherit;
   }
 
-  .flipped {
-    transform: scaleX(-1);
-  }
-
   .conditional-padding {
     margin-left: 4px;
   }

--- a/projects/components/src/button/button.component.scss
+++ b/projects/components/src/button/button.component.scss
@@ -42,6 +42,10 @@
     color: inherit;
   }
 
+  .flipped {
+    transform: scaleX(-1);
+  }
+
   .conditional-padding {
     margin-left: 4px;
   }
@@ -117,7 +121,7 @@
   }
 }
 
-.text {
+.text, .plain-text {
   &.primary {
     @include button-style(inherit, inherit, $blue-5, $blue-4);
   }
@@ -147,7 +151,7 @@
   height: 40px;
   border-radius: 8px;
 
-  &:not(.icon-only) {
+  &:not(.icon-only, .plain-text) {
     padding: 0 20px;
   }
 
@@ -161,7 +165,7 @@
   height: 36px;
   border-radius: 6px;
 
-  &:not(.icon-only) {
+  &:not(.icon-only, .plain-text) {
     padding: 0 16px;
   }
 
@@ -189,7 +193,7 @@
   height: 24px;
   border-radius: 4px;
 
-  &:not(.icon-only) {
+  &:not(.icon-only, .plain-text) {
     padding: 0 12px;
   }
 
@@ -203,7 +207,7 @@
   height: 18px;
   border-radius: 4px;
 
-  &:not(.icon-only) {
+  &:not(.icon-only, .plain-text) {
     padding: 0 12px;
   }
 

--- a/projects/components/src/button/button.component.scss
+++ b/projects/components/src/button/button.component.scss
@@ -121,7 +121,8 @@
   }
 }
 
-.text, .plain-text {
+.text,
+.plain-text {
   &.primary {
     @include button-style(inherit, inherit, $blue-5, $blue-4);
   }

--- a/projects/components/src/button/button.component.test.ts
+++ b/projects/components/src/button/button.component.test.ts
@@ -146,6 +146,12 @@ describe('Button Component', () => {
     });
     expect(spectator.query('.button')).toHaveClass('button secondary small text');
 
+    // Text
+    spectator.setInput({
+      display: ButtonStyle.PlainText
+    });
+    expect(spectator.query('.button')).toHaveClass('button secondary small text');
+
     // Solid
     spectator.setInput({
       display: ButtonStyle.Solid

--- a/projects/components/src/button/button.component.test.ts
+++ b/projects/components/src/button/button.component.test.ts
@@ -169,7 +169,6 @@ describe('Button Component', () => {
     expect(spectator.query('.icon.leading')).toExist();
     expect(spectator.query('.icon.trailing')).not.toExist();
     expect(spectator.query('.label')).not.toExist();
-    expect(spectator.query('.flipped')).not.toExist();
 
     // Set Label
     spectator.setInput({

--- a/projects/components/src/button/button.component.test.ts
+++ b/projects/components/src/button/button.component.test.ts
@@ -169,6 +169,14 @@ describe('Button Component', () => {
     expect(spectator.query('.icon.leading')).toExist();
     expect(spectator.query('.icon.trailing')).not.toExist();
     expect(spectator.query('.label')).not.toExist();
+    expect(spectator.query('.flipped')).not.toExist();
+
+    // Set FlippingIcon
+    spectator.setInput({
+      flippingIcon: true
+    });
+
+    expect(spectator.query('.flipped')).toExist();
 
     // Set Label
     spectator.setInput({

--- a/projects/components/src/button/button.component.test.ts
+++ b/projects/components/src/button/button.component.test.ts
@@ -171,13 +171,6 @@ describe('Button Component', () => {
     expect(spectator.query('.label')).not.toExist();
     expect(spectator.query('.flipped')).not.toExist();
 
-    // Set FlippingIcon
-    spectator.setInput({
-      flippingIcon: true
-    });
-
-    expect(spectator.query('.flipped')).toExist();
-
     // Set Label
     spectator.setInput({
       label: 'Button'

--- a/projects/components/src/button/button.component.test.ts
+++ b/projects/components/src/button/button.component.test.ts
@@ -150,7 +150,7 @@ describe('Button Component', () => {
     spectator.setInput({
       display: ButtonStyle.PlainText
     });
-    expect(spectator.query('.button')).toHaveClass('button secondary small text');
+    expect(spectator.query('.button')).toHaveClass('button secondary small plain-text');
 
     // Solid
     spectator.setInput({

--- a/projects/components/src/button/button.component.ts
+++ b/projects/components/src/button/button.component.ts
@@ -17,7 +17,7 @@ import { ButtonRole, ButtonSize, ButtonStyle } from './button';
           [label]="this.label"
           [size]="this.getIconSizeClass()"
           class="icon leading"
-          [ngClass]="{'flipped': this.flippingIcon}"
+          [ngClass]="{ flipped: this.flippingIcon }"
         ></ht-icon>
 
         <div class="conditional-padding leading" *ngIf="this.label && this.icon && !this.trailingIcon"></div>
@@ -31,7 +31,7 @@ import { ButtonRole, ButtonSize, ButtonStyle } from './button';
           [label]="this.label"
           [size]="this.getIconSizeClass()"
           class="icon trailing"
-          [ngClass]="{'flipped': this.flippingIcon}"
+          [ngClass]="{ flipped: this.flippingIcon }"
         ></ht-icon>
       </button>
     </ht-event-blocker>

--- a/projects/components/src/button/button.component.ts
+++ b/projects/components/src/button/button.component.ts
@@ -17,7 +17,6 @@ import { ButtonRole, ButtonSize, ButtonStyle } from './button';
           [label]="this.label"
           [size]="this.getIconSizeClass()"
           class="icon leading"
-          [ngClass]="{ flipped: this.flippingIcon }"
         ></ht-icon>
 
         <div class="conditional-padding leading" *ngIf="this.label && this.icon && !this.trailingIcon"></div>
@@ -31,7 +30,6 @@ import { ButtonRole, ButtonSize, ButtonStyle } from './button';
           [label]="this.label"
           [size]="this.getIconSizeClass()"
           class="icon trailing"
-          [ngClass]="{ flipped: this.flippingIcon }"
         ></ht-icon>
       </button>
     </ht-event-blocker>
@@ -46,9 +44,6 @@ export class ButtonComponent {
 
   @Input()
   public trailingIcon?: boolean;
-
-  @Input()
-  public flippingIcon?: boolean;
 
   @Input()
   public role: ButtonRole = ButtonRole.Secondary;

--- a/projects/components/src/button/button.component.ts
+++ b/projects/components/src/button/button.component.ts
@@ -17,6 +17,7 @@ import { ButtonRole, ButtonSize, ButtonStyle } from './button';
           [label]="this.label"
           [size]="this.getIconSizeClass()"
           class="icon leading"
+          [ngClass]="{'flipped': this.flippingIcon}"
         ></ht-icon>
 
         <div class="conditional-padding leading" *ngIf="this.label && this.icon && !this.trailingIcon"></div>
@@ -30,6 +31,7 @@ import { ButtonRole, ButtonSize, ButtonStyle } from './button';
           [label]="this.label"
           [size]="this.getIconSizeClass()"
           class="icon trailing"
+          [ngClass]="{'flipped': this.flippingIcon}"
         ></ht-icon>
       </button>
     </ht-event-blocker>
@@ -44,6 +46,9 @@ export class ButtonComponent {
 
   @Input()
   public trailingIcon?: boolean;
+
+  @Input()
+  public flippingIcon?: boolean;
 
   @Input()
   public role: ButtonRole = ButtonRole.Secondary;

--- a/projects/components/src/button/button.ts
+++ b/projects/components/src/button/button.ts
@@ -20,7 +20,7 @@ export const enum ButtonStyle {
   // These values are used as css classes
   //                        Background Color | Background Hover Color | Text Hover Color | Border Color | Padding
   Solid = 'solid', //             Yes                   Yes                   No                No          Yes
-  Outlined = 'outlined', //       No                    Yes                   No                No          Yes 
+  Outlined = 'outlined', //       No                    Yes                   No                No          Yes
   Bordered = 'bordered', //       No                    Yes                   No                Yes         Yes
   Text = 'text', //               No                    No                    Yes               No          Yes
   PlainText = 'plain-text' //     No                    No                    Yes               No           No

--- a/projects/components/src/button/button.ts
+++ b/projects/components/src/button/button.ts
@@ -18,9 +18,10 @@ export const enum ButtonSize {
 
 export const enum ButtonStyle {
   // These values are used as css classes
-  //                        Background Color | Background Hover Color | Text Hover Color | Border Color
-  Solid = 'solid', //             Yes                   Yes                   No                No
-  Outlined = 'outlined', //       No                    Yes                   No                No
-  Bordered = 'bordered', //       No                    Yes                   No                Yes
-  Text = 'text' //                No                    No                    Yes               No
+  //                        Background Color | Background Hover Color | Text Hover Color | Border Color | Padding
+  Solid = 'solid', //             Yes                   Yes                   No                No          Yes
+  Outlined = 'outlined', //       No                    Yes                   No                No          Yes 
+  Bordered = 'bordered', //       No                    Yes                   No                Yes         Yes
+  Text = 'text', //               No                    No                    Yes               No          Yes
+  PlainText = 'plain-text' //     No                    No                    Yes               No           No
 }


### PR DESCRIPTION
## Description

- Add a new style called 'Plain Text' similar to 'Text' but without padding. 

### Testing
Visual testing. 

- 'Text' style with padding

![image](https://user-images.githubusercontent.com/79482271/124153461-d6333200-da6a-11eb-9fa4-c3f26c32fe38.png)

- 'Plain Text' style with no padding

![image](https://user-images.githubusercontent.com/79482271/124158905-e1895c00-da70-11eb-9796-d12e1eee699c.png)


### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

