### PR TITLE
fix: wrong tooltip in radar chart in firefox

### DIFF
--- a/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
+++ b/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
@@ -15,7 +15,7 @@ export class RadialDataLookupStrategy {
 
   public constructor(private readonly allSeries: RadarSeries[], radialAxisData: RadarAxisData[]) {
     this.radialBisector = bisector(axisData => axisData.axisRadian);
-    this.radialAxisData = clone(radialAxisData);
+    this.radialAxisData = clone(radialAxisData.sort(axisData => axisData.axisRadian));
     this.addCyclicRedundancy();
   }
 

--- a/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
+++ b/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
@@ -15,8 +15,7 @@ export class RadialDataLookupStrategy {
 
   public constructor(private readonly allSeries: RadarSeries[], radialAxisData: RadarAxisData[]) {
     this.radialBisector = bisector(axisData => axisData.axisRadian);
-    this.radialAxisData = clone(radialAxisData);
-    this.radialAxisData = this.radialAxisData.sort(axisData => axisData.axisRadian);
+    this.radialAxisData = clone(radialAxisData).sort(axisData => axisData.axisRadian);
     this.addCyclicRedundancy();
   }
 
@@ -41,7 +40,6 @@ export class RadialDataLookupStrategy {
 
     const leftValue = this.radialAxisData[insertionIndex - 1] as RadarAxisData | undefined;
     const rightValue = this.radialAxisData[insertionIndex] as RadarAxisData | undefined;
-
 
     if (leftValue === undefined) {
       // No values to the left. Target is smallest value.

--- a/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
+++ b/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
@@ -15,7 +15,8 @@ export class RadialDataLookupStrategy {
 
   public constructor(private readonly allSeries: RadarSeries[], radialAxisData: RadarAxisData[]) {
     this.radialBisector = bisector(axisData => axisData.axisRadian);
-    this.radialAxisData = clone(radialAxisData.sort(axisData => axisData.axisRadian));
+    this.radialAxisData = clone(radialAxisData);
+    this.radialAxisData = this.radialAxisData.sort(axisData => axisData.axisRadian);
     this.addCyclicRedundancy();
   }
 
@@ -40,6 +41,7 @@ export class RadialDataLookupStrategy {
 
     const leftValue = this.radialAxisData[insertionIndex - 1] as RadarAxisData | undefined;
     const rightValue = this.radialAxisData[insertionIndex] as RadarAxisData | undefined;
+
 
     if (leftValue === undefined) {
       // No values to the left. Target is smallest value.


### PR DESCRIPTION
## Description
In Firefox alone, wrong tooltip was shown for radar chart

- **on a bugfix**: Bug: Wrong tooltip is showing for radar chart #748. For firefox, radialAxisData was not sorted on the basis of axisRadian



### Testing
Run all test cases using npm run lint && npm run test

### Checklist:
- [x] My changes generate no new warnings





