### PR TITLE
feat: Adding bar gauge htDisplayNumber pipe

### DIFF
--- a/projects/observability/src/shared/components/bar-gauge/bar-gauge.component.ts
+++ b/projects/observability/src/shared/components/bar-gauge/bar-gauge.component.ts
@@ -27,11 +27,9 @@ import {
       <div class="header-data" [ngClass]="this.display">
         <div *ngIf="this.title" class="title">{{ this.title | htDisplayTitle }}</div>
         <div class="count">
-          <span>{{ !this.units ? (this.totalValue | htDisplayNumber) : (this.totalValue | number) }}</span>
+          <span>{{ this.totalValue | htDisplayNumber }}</span>
           <span> / </span>
-          <span *ngIf="!this.isUnlimited">{{
-            !this.units ? (this.maxValue | htDisplayNumber) : (this.maxValue | number)
-          }}</span>
+          <span *ngIf="!this.isUnlimited">{{ this.maxValue | htDisplayNumber }}</span>
           <span class="unlimited-symbol" *ngIf="this.isUnlimited">&#8734;</span>
           <span class="units" *ngIf="this.units && !this.isUnlimited"> {{ this.units }}</span>
         </div>

--- a/projects/observability/src/shared/components/bar-gauge/bar-gauge.component.ts
+++ b/projects/observability/src/shared/components/bar-gauge/bar-gauge.component.ts
@@ -27,10 +27,11 @@ import {
       <div class="header-data" [ngClass]="this.display">
         <div *ngIf="this.title" class="title">{{ this.title | htDisplayTitle }}</div>
         <div class="count">
-          <span>{{ this.totalValue | number }}</span>
-          <span class="units" *ngIf="this.units && this.isUnlimited"> {{ this.units }}</span>
+          <span>{{ !this.units ? (this.totalValue | htDisplayNumber) : (this.totalValue | number) }}</span>
           <span> / </span>
-          <span *ngIf="!this.isUnlimited">{{ this.maxValue | number }}</span>
+          <span *ngIf="!this.isUnlimited">{{
+            !this.units ? (this.maxValue | htDisplayNumber) : (this.maxValue | number)
+          }}</span>
           <span class="unlimited-symbol" *ngIf="this.isUnlimited">&#8734;</span>
           <span class="units" *ngIf="this.units && !this.isUnlimited"> {{ this.units }}</span>
         </div>


### PR DESCRIPTION
## Description
Adding HTDisplayNumber pipe to Bar Gauge

### Testing
Visual Testing:

![image](https://user-images.githubusercontent.com/79482271/126544737-f482d3c4-4e15-42d4-b27f-9d2ba0d0e4f5.png)

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
