### PR TITLE
feat: time range uses default when unavailable

### DIFF
--- a/projects/common/src/time/time-range.service.test.ts
+++ b/projects/common/src/time/time-range.service.test.ts
@@ -1,4 +1,5 @@
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { RelativeTimeRange, TimeDuration, TimeUnit } from '@hypertrace/common';
 import { runFakeRxjs } from '@hypertrace/test-utils';
 import { createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
 import { NEVER, Observable, of } from 'rxjs';
@@ -28,9 +29,10 @@ describe('Time range service', () => {
     ]
   });
 
-  test('throws error when asking for time range before initialization', () => {
+  test('provides default when asking for time range before initialization', () => {
     const spectator = buildService();
-    expect(() => spectator.service.getCurrentTimeRange()).toThrow();
+    expect(spectator.service.getCurrentTimeRange().toDisplayString())
+      .toEqual(new RelativeTimeRange(new TimeDuration(1, TimeUnit.Hour)).toDisplayString());
   });
 
   test('returns time range when requested after init', () => {
@@ -49,7 +51,8 @@ describe('Time range service', () => {
       });
 
       const spectator = buildService();
-      expect(() => spectator.service.getCurrentTimeRange()).toThrow();
+      expect(spectator.service.getCurrentTimeRange().toDisplayString())
+        .toEqual(new RelativeTimeRange(new TimeDuration(1, TimeUnit.Hour)).toDisplayString());
 
       cold('5ms x').subscribe(() =>
         spectator.service.setFixedRange(lateArrivingTimeRange.startTime, lateArrivingTimeRange.endTime)

--- a/projects/common/src/time/time-range.service.ts
+++ b/projects/common/src/time/time-range.service.ts
@@ -45,7 +45,7 @@ export class TimeRangeService {
 
   public getCurrentTimeRange(): TimeRange {
     if (!this.currentTimeRange) {
-      throw Error('Time range not yet initialized');
+      return this.defaultTimeRange;
     }
 
     return this.currentTimeRange;


### PR DESCRIPTION
## Description
Calling `getCurrentTimeRange()` before initialization now provides the default time range instead of throwing an error.