### PR TITLE
fix: set background color for resize button

### DIFF
--- a/projects/components/src/navigation/navigation-list.component.scss
+++ b/projects/components/src/navigation/navigation-list.component.scss
@@ -43,6 +43,7 @@
     border-radius: 0 6px 6px 0;
     cursor: pointer;
     color: $gray-7;
+    background: white;
 
     &:hover {
       color: $gray-4;


### PR DESCRIPTION
## Description
Setting background color for the resize button on nav.

### Testing
N/A

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules