### PR TITLE
fix: Make Time Ranges Configurable on the Dashboard #980

### DIFF
--- a/projects/components/src/time-range/predefined-time-duration.service.ts
+++ b/projects/components/src/time-range/predefined-time-duration.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
-import { TimeDuration, TimeUnit } from '@hypertrace/common';
+import { TimeDuration } from '@hypertrace/common';
+
+import {environment} from '../../../../src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -12,20 +14,7 @@ export class PredefinedTimeDurationService {
   }
 
   private createTimeDurations(): TimeDuration[] {
-    return [
-      new TimeDuration(15, TimeUnit.Minute),
-      new TimeDuration(30, TimeUnit.Minute),
-      new TimeDuration(1, TimeUnit.Hour),
-      new TimeDuration(2, TimeUnit.Hour),
-      new TimeDuration(3, TimeUnit.Hour),
-      new TimeDuration(6, TimeUnit.Hour),
-      new TimeDuration(12, TimeUnit.Hour),
-      new TimeDuration(1, TimeUnit.Day),
-      new TimeDuration(3, TimeUnit.Day),
-      new TimeDuration(1, TimeUnit.Week),
-      new TimeDuration(2, TimeUnit.Week),
-      new TimeDuration(1, TimeUnit.Month)
-    ];
+    return environment.timeDurations;
   }
 
   public getPredefinedTimeDurations(): TimeDuration[] {

--- a/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
+++ b/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
@@ -15,7 +15,7 @@ export class RadialDataLookupStrategy {
 
   public constructor(private readonly allSeries: RadarSeries[], radialAxisData: RadarAxisData[]) {
     this.radialBisector = bisector(axisData => axisData.axisRadian);
-    this.radialAxisData = clone(radialAxisData);
+    this.radialAxisData = clone(radialAxisData.sort(axisData => axisData.axisRadian));
     this.addCyclicRedundancy();
   }
 

--- a/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
+++ b/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
@@ -15,8 +15,7 @@ export class RadialDataLookupStrategy {
 
   public constructor(private readonly allSeries: RadarSeries[], radialAxisData: RadarAxisData[]) {
     this.radialBisector = bisector(axisData => axisData.axisRadian);
-    this.radialAxisData = clone(radialAxisData);
-    this.radialAxisData = this.radialAxisData.sort(axisData => axisData.axisRadian);
+    this.radialAxisData = clone(radialAxisData).sort(axisData => axisData.axisRadian);
     this.addCyclicRedundancy();
   }
 
@@ -41,7 +40,6 @@ export class RadialDataLookupStrategy {
 
     const leftValue = this.radialAxisData[insertionIndex - 1] as RadarAxisData | undefined;
     const rightValue = this.radialAxisData[insertionIndex] as RadarAxisData | undefined;
-
 
     if (leftValue === undefined) {
       // No values to the left. Target is smallest value.

--- a/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
+++ b/projects/observability/src/shared/components/radar/tooltip/radial-data-lookup-strategy.ts
@@ -15,7 +15,8 @@ export class RadialDataLookupStrategy {
 
   public constructor(private readonly allSeries: RadarSeries[], radialAxisData: RadarAxisData[]) {
     this.radialBisector = bisector(axisData => axisData.axisRadian);
-    this.radialAxisData = clone(radialAxisData.sort(axisData => axisData.axisRadian));
+    this.radialAxisData = clone(radialAxisData);
+    this.radialAxisData = this.radialAxisData.sort(axisData => axisData.axisRadian);
     this.addCyclicRedundancy();
   }
 
@@ -40,6 +41,7 @@ export class RadialDataLookupStrategy {
 
     const leftValue = this.radialAxisData[insertionIndex - 1] as RadarAxisData | undefined;
     const rightValue = this.radialAxisData[insertionIndex] as RadarAxisData | undefined;
+
 
     if (leftValue === undefined) {
       // No values to the left. Target is smallest value.

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,23 @@
+import { TimeUnit } from '../../projects/common/src/time/time-unit.type';
+import {TimeDuration} from '../../projects/common/src/time/time-duration'
+
 export const environment = {
   production: true,
-  graphqlUri: '/graphql'
+  graphqlUri: '/graphql',
+  timeDurations :
+    [
+      new TimeDuration(15, TimeUnit.Minute),
+      new TimeDuration(30, TimeUnit.Minute),
+      new TimeDuration(1, TimeUnit.Hour),
+      new TimeDuration(2, TimeUnit.Hour),
+      new TimeDuration(3, TimeUnit.Hour),
+      new TimeDuration(6, TimeUnit.Hour),
+      new TimeDuration(12, TimeUnit.Hour),
+      new TimeDuration(1, TimeUnit.Day),
+      new TimeDuration(3, TimeUnit.Day),
+      new TimeDuration(1, TimeUnit.Week),
+      new TimeDuration(2, TimeUnit.Week),
+      new TimeDuration(1, TimeUnit.Month)
+    ]
+
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,6 @@
+import { TimeUnit } from '../../projects/common/src/time/time-unit.type';
+import {TimeDuration} from '../../projects/common/src/time/time-duration'
+
 // tslint:disable
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
@@ -5,7 +8,22 @@
 
 export const environment = {
   production: false,
-  graphqlUri: 'http://localhost:2020/graphql'
+  graphqlUri: 'http://localhost:2020/graphql',
+  timeDurations :
+    [
+      new TimeDuration(15, TimeUnit.Minute),
+      new TimeDuration(30, TimeUnit.Minute),
+      new TimeDuration(1, TimeUnit.Hour),
+      new TimeDuration(2, TimeUnit.Hour),
+      new TimeDuration(3, TimeUnit.Hour),
+      new TimeDuration(6, TimeUnit.Hour),
+      new TimeDuration(12, TimeUnit.Hour),
+      new TimeDuration(1, TimeUnit.Day),
+      new TimeDuration(3, TimeUnit.Day),
+      new TimeDuration(1, TimeUnit.Week),
+      new TimeDuration(2, TimeUnit.Week),
+      new TimeDuration(1, TimeUnit.Month)
+    ]
 };
 
 /*


### PR DESCRIPTION
## Description
Timerange moved to environments, which can be configured at build time.


- **on a refactor**: Timerange moved to environments



### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
