### PR TITLE
Remove P99 as Default Sort Order on the Dashboard #268

### DIFF
--- a/src/app/root.module.ts
+++ b/src/app/root.module.ts
@@ -1,5 +1,5 @@
 import { HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ObservabilityDashboardModule } from '@hypertrace/observability';
@@ -8,6 +8,12 @@ import { ConfigModule } from './config.module';
 import { RootComponent } from './root.component';
 import { RootRoutingModule } from './routes/root-routing.module';
 import { NavigationModule } from './shared/navigation/navigation.module';
+
+import {ConfigService} from  './shared/services/config.service'
+
+export const configFactory = (configService: ConfigService) => {
+  return () => configService.loadConfig();
+};
 
 @NgModule({
   imports: [
@@ -21,6 +27,12 @@ import { NavigationModule } from './shared/navigation/navigation.module';
     ObservabilityDashboardModule
   ],
   declarations: [RootComponent],
-  bootstrap: [RootComponent]
+  bootstrap: [RootComponent],
+  providers: [{
+    provide: APP_INITIALIZER,
+    useFactory: configFactory,
+    deps: [ConfigService],
+    multi: true
+  }]
 })
 export class RootModule {}

--- a/src/app/shared/services/config.service.ts
+++ b/src/app/shared/services/config.service.ts
@@ -1,0 +1,24 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigService {
+
+  config: any;
+
+      constructor(private http: HttpClient) {}
+
+      loadConfig() {
+        return this.http
+          .get<any>('./assets/config.json')
+          .toPromise()
+          .then(config => {
+            this.config = config;
+          }).catch(err => {
+            throw new Error(err);
+
+          });
+      }
+}


### PR DESCRIPTION
 Since this is a feature, made this configurable by introducing a config service,  which reads runtime configuration from a JSON file located in the assets folder. If the config not exists then the default configuration will be loaded.