### PR TITLE
refactor: splitting request response in its own query

### DIFF
--- a/projects/distributed-tracing/src/shared/components/span-detail/request/span-request-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/request/span-request-detail.component.ts
@@ -13,7 +13,10 @@ import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
         <ht-span-detail-call-headers [headers]="this.requestHeaders"></ht-span-detail-call-headers>
       </div>
       <div class="section">
-        <ht-span-detail-call-body [body]="this.requestBody$ | async"></ht-span-detail-call-body>
+        <ht-span-detail-call-body
+          *htLoadAsync="this.requestBody$ as requestBody"
+          [body]="requestBody"
+        ></ht-span-detail-call-body>
       </div>
     </div>
   `

--- a/projects/distributed-tracing/src/shared/components/span-detail/request/span-request-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/request/span-request-detail.component.ts
@@ -12,8 +12,8 @@ import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
       <div class="section">
         <ht-span-detail-call-headers [headers]="this.requestHeaders"></ht-span-detail-call-headers>
       </div>
-      <div class="section" *htLoadAsync="this.requestBody$ as requestBody">
-        <ht-span-detail-call-body [body]="requestBody"></ht-span-detail-call-body>
+      <div class="section">
+        <ht-span-detail-call-body [body]="this.requestBody$ | async"></ht-span-detail-call-body>
       </div>
     </div>
   `

--- a/projects/distributed-tracing/src/shared/components/span-detail/request/span-request-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/request/span-request-detail.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { Dictionary } from '@hypertrace/common';
+import { Observable } from 'rxjs';
 import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
 
 @Component({
@@ -11,8 +12,8 @@ import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
       <div class="section">
         <ht-span-detail-call-headers [headers]="this.requestHeaders"></ht-span-detail-call-headers>
       </div>
-      <div class="section">
-        <ht-span-detail-call-body [body]="this.requestBody"></ht-span-detail-call-body>
+      <div class="section" *htLoadAsync="this.requestBody$ as requestBody">
+        <ht-span-detail-call-body [body]="requestBody"></ht-span-detail-call-body>
       </div>
     </div>
   `
@@ -22,7 +23,7 @@ export class SpanRequestDetailComponent {
   public requestHeaders?: Dictionary<unknown>;
 
   @Input()
-  public requestBody?: string;
+  public requestBody$?: Observable<string>;
 
   @Input()
   public layout: SpanDetailLayoutStyle = SpanDetailLayoutStyle.Horizontal;

--- a/projects/distributed-tracing/src/shared/components/span-detail/response/span-response-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/response/span-response-detail.component.ts
@@ -13,7 +13,10 @@ import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
         <ht-span-detail-call-headers [headers]="this.responseHeaders"></ht-span-detail-call-headers>
       </div>
       <div class="section">
-        <ht-span-detail-call-body [body]="this.responseBody$ | async"></ht-span-detail-call-body>
+        <ht-span-detail-call-body
+          *htLoadAsync="this.responseBody$ as responseBody"
+          [body]="responseBody"
+        ></ht-span-detail-call-body>
       </div>
     </div>
   `

--- a/projects/distributed-tracing/src/shared/components/span-detail/response/span-response-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/response/span-response-detail.component.ts
@@ -12,8 +12,8 @@ import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
       <div class="section">
         <ht-span-detail-call-headers [headers]="this.responseHeaders"></ht-span-detail-call-headers>
       </div>
-      <div class="section" *htLoadAsync="this.responseBody$ as responseBody">
-        <ht-span-detail-call-body [body]="this.responseBody"></ht-span-detail-call-body>
+      <div class="section">
+        <ht-span-detail-call-body [body]="this.responseBody$ | async"></ht-span-detail-call-body>
       </div>
     </div>
   `

--- a/projects/distributed-tracing/src/shared/components/span-detail/response/span-response-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/response/span-response-detail.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { Dictionary } from '@hypertrace/common';
+import { Observable } from 'rxjs';
 import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
 
 @Component({
@@ -11,7 +12,7 @@ import { SpanDetailLayoutStyle } from '../span-detail-layout-style';
       <div class="section">
         <ht-span-detail-call-headers [headers]="this.responseHeaders"></ht-span-detail-call-headers>
       </div>
-      <div class="section">
+      <div class="section" *htLoadAsync="this.responseBody$ as responseBody">
         <ht-span-detail-call-body [body]="this.responseBody"></ht-span-detail-call-body>
       </div>
     </div>
@@ -22,7 +23,7 @@ export class SpanResponseDetailComponent {
   public responseHeaders?: Dictionary<unknown>;
 
   @Input()
-  public responseBody?: string;
+  public responseBody$?: Observable<string>;
 
   @Input()
   public layout: SpanDetailLayoutStyle = SpanDetailLayoutStyle.Horizontal;

--- a/projects/distributed-tracing/src/shared/components/span-detail/span-data.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/span-data.ts
@@ -1,4 +1,5 @@
 import { Dictionary } from '@hypertrace/common';
+import { Observable } from 'rxjs';
 import { LogEvent } from '../../dashboard/widgets/waterfall/waterfall/waterfall-chart';
 
 export interface SpanData {
@@ -7,9 +8,9 @@ export interface SpanData {
   apiName?: string;
   protocolName?: string;
   requestHeaders: Dictionary<unknown>;
-  requestBody: string;
+  requestBody$: Observable<string>;
   responseHeaders: Dictionary<unknown>;
-  responseBody: string;
+  responseBody$: Observable<string>;
   tags: Dictionary<unknown>;
   requestUrl: string;
   exitCallsBreakup?: Dictionary<string>;

--- a/projects/distributed-tracing/src/shared/components/span-detail/span-detail.component.test.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/span-detail.component.test.ts
@@ -3,6 +3,7 @@ import { fakeAsync } from '@angular/core/testing';
 import { IconLibraryTestingModule } from '@hypertrace/assets-library';
 import { NavigationService } from '@hypertrace/common';
 import { createHostFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
+import { of } from 'rxjs';
 import { SpanData } from './span-data';
 import { SpanDetailComponent } from './span-detail.component';
 import { SpanDetailModule } from './span-detail.module';
@@ -24,9 +25,9 @@ describe('Span detail component', () => {
       apiName: 'My API Name',
       protocolName: 'My Protocol Name',
       requestHeaders: { header1: 'value1', header2: 'value2' },
-      requestBody: '[{"data": 5000}]',
+      requestBody$: of('[{"data": 5000}]'),
       responseHeaders: { header1: 'value1', header2: 'value2' },
-      responseBody: '[{"data": 5000}]',
+      responseBody$: of('[{"data": 5000}]'),
       tags: { tag1: 'value1', tag2: 'value2' },
       requestUrl: 'test-url',
       startTime: 1604567825671
@@ -49,9 +50,9 @@ describe('Span detail component', () => {
       apiName: 'My API Name',
       protocolName: 'My Protocol Name',
       requestHeaders: {},
-      requestBody: '',
+      requestBody$: of(''),
       responseHeaders: { header1: 'value1', header2: 'value2' },
-      responseBody: '[{"data": 5000}]',
+      responseBody$: of('[{"data": 5000}]'),
       tags: { tag1: 'value1', tag2: 'value2' },
       requestUrl: 'test-url',
       startTime: 1604567825671
@@ -69,15 +70,15 @@ describe('Span detail component', () => {
   }));
 
   test('should show Request tab if either request header params and body are present', fakeAsync(() => {
-    const spanData = {
+    const spanData: SpanData = {
       id: '2',
       serviceName: 'My Service Name',
       apiName: 'My API Name',
       protocolName: 'My Protocol Name',
       requestHeaders: {},
-      requestBody: '[{"data": 5000}]',
+      requestBody$: of('[{"data": 5000}]'),
       responseHeaders: { header1: 'value1', header2: 'value2' },
-      responseBody: '[{"data": 5000}]',
+      responseBody$: of('[{"data": 5000}]'),
       tags: { tag1: 'value1', tag2: 'value2' },
       requestUrl: 'test-url',
       startTime: 1604567825671
@@ -100,9 +101,9 @@ describe('Span detail component', () => {
       apiName: 'My API Name',
       protocolName: 'My Protocol Name',
       requestHeaders: { header1: 'value1', header2: 'value2' },
-      requestBody: '[{"data": 5000}]',
+      requestBody$: of('[{"data": 5000}]'),
       responseHeaders: {},
-      responseBody: '',
+      responseBody$: of(''),
       tags: { tag1: 'value1', tag2: 'value2' },
       requestUrl: 'test-url',
       startTime: 1604567825671

--- a/projects/distributed-tracing/src/shared/components/span-detail/span-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/span-detail.component.ts
@@ -30,7 +30,7 @@ import { SpanDetailTab } from './span-detail-tab';
             class="request"
             [layout]="this.layout"
             [requestHeaders]="this.spanData.requestHeaders"
-            [requestBody]="this.spanData.requestBody"
+            [requestBody$]="this.spanData.requestBody$"
           ></ht-span-request-detail>
         </ht-tab>
         <ht-tab label="${SpanDetailTab.Response}" *ngIf="this.showResponseTab">
@@ -38,7 +38,7 @@ import { SpanDetailTab } from './span-detail-tab';
             class="response"
             [layout]="this.layout"
             [responseHeaders]="this.spanData.responseHeaders"
-            [responseBody]="this.spanData.responseBody"
+            [responseBody$]="this.spanData.responseBody$"
           ></ht-span-response-detail>
         </ht-tab>
         <ht-tab label="${SpanDetailTab.Attributes}" class="attributes">
@@ -78,8 +78,8 @@ export class SpanDetailComponent implements OnChanges {
 
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
     if (changes.spanData) {
-      this.showRequestTab = !isEmpty(this.spanData?.requestHeaders) || !isEmpty(this.spanData?.requestBody);
-      this.showResponseTab = !isEmpty(this.spanData?.responseHeaders) || !isEmpty(this.spanData?.responseBody);
+      this.showRequestTab = !isEmpty(this.spanData?.requestHeaders) || !isEmpty(this.spanData?.requestBody$);
+      this.showResponseTab = !isEmpty(this.spanData?.responseHeaders) || !isEmpty(this.spanData?.responseBody$);
       this.showExitCallsTab = !isEmpty(this.spanData?.exitCallsBreakup);
       this.showLogEventsTab = !isEmpty(this.spanData?.logEvents);
       this.totalLogEvents = (this.spanData?.logEvents ?? []).length;

--- a/projects/distributed-tracing/src/shared/components/span-detail/span-detail.component.ts
+++ b/projects/distributed-tracing/src/shared/components/span-detail/span-detail.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { TypedSimpleChanges } from '@hypertrace/common';
 import { isEmpty } from 'lodash-es';
-import { combineLatest } from 'rxjs';
 import { SpanData } from './span-data';
 import { SpanDetailLayoutStyle } from './span-detail-layout-style';
 import { SpanDetailTab } from './span-detail-tab';
@@ -79,27 +78,11 @@ export class SpanDetailComponent implements OnChanges {
 
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
     if (changes.spanData) {
-      if (this.spanData === undefined) {
-        this.resetView();
-      } else {
-        combineLatest([this.spanData.requestBody$, this.spanData.responseBody$]).subscribe(
-          ([requestBody, responseBody]) => {
-            this.showRequestTab = !isEmpty(this.spanData?.requestHeaders) || !isEmpty(requestBody);
-            this.showResponseTab = !isEmpty(this.spanData?.responseHeaders) || !isEmpty(responseBody);
-            this.showExitCallsTab = !isEmpty(this.spanData?.exitCallsBreakup);
-            this.showLogEventsTab = !isEmpty(this.spanData?.logEvents);
-            this.totalLogEvents = (this.spanData?.logEvents ?? []).length;
-          }
-        );
-      }
+      this.showRequestTab = !isEmpty(this.spanData?.requestHeaders);
+      this.showResponseTab = !isEmpty(this.spanData?.responseHeaders);
+      this.showExitCallsTab = !isEmpty(this.spanData?.exitCallsBreakup);
+      this.showLogEventsTab = !isEmpty(this.spanData?.logEvents);
+      this.totalLogEvents = (this.spanData?.logEvents ?? []).length;
     }
-  }
-
-  private resetView(): void {
-    this.showRequestTab = false;
-    this.showResponseTab = false;
-    this.showExitCallsTab = false;
-    this.showLogEventsTab = false;
-    this.totalLogEvents = 0;
   }
 }

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/span-detail/data/span-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/span-detail/data/span-detail-data-source.model.ts
@@ -29,7 +29,7 @@ export class SpanDetailDataSourceModel extends GraphQlDataSourceModel<SpanDetail
   })
   public startTime?: unknown;
 
-  private readonly attributeSpecBuilder: SpecificationBuilder = new SpecificationBuilder();
+  protected readonly attributeSpecBuilder: SpecificationBuilder = new SpecificationBuilder();
   private readonly dateCoercer: DateCoercer = new DateCoercer();
 
   protected getSpanAttributes(): string[] {

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/trace-detail/data/trace-detail-data-source.model.ts
@@ -34,8 +34,8 @@ export class TraceDetailDataSourceModel extends GraphQlDataSourceModel<TraceDeta
   })
   public attributes: string[] = [];
 
-  private readonly attributeSpecBuilder: SpecificationBuilder = new SpecificationBuilder();
-  private readonly dateCoercer: DateCoercer = new DateCoercer();
+  protected readonly attributeSpecBuilder: SpecificationBuilder = new SpecificationBuilder();
+  protected readonly dateCoercer: DateCoercer = new DateCoercer();
 
   public getData(): Observable<TraceDetailData> {
     return this.query<TraceGraphQlQueryHandlerService>({

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.component.test.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.component.test.ts
@@ -4,7 +4,7 @@ import { IconLibraryTestingModule } from '@hypertrace/assets-library';
 import { DEFAULT_COLOR_PALETTE, NavigationService } from '@hypertrace/common';
 import { getMockFlexLayoutProviders } from '@hypertrace/test-utils';
 import { createHostFactory, mockProvider } from '@ngneat/spectator/jest';
-import { EMPTY } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { SpanType } from '../../../../graphql/model/schema/span';
 import { WaterfallData } from './waterfall-chart';
 import { WaterfallChartComponent } from './waterfall-chart.component';
@@ -27,9 +27,9 @@ describe('Waterfall Chart component', () => {
       protocolName: 'Protocol Name 1',
       spanType: SpanType.Entry,
       requestHeaders: {},
-      requestBody: 'Request Body',
+      requestBody$: of('Request Body'),
       responseHeaders: {},
-      responseBody: 'Response Body',
+      responseBody$: of('Response Body'),
       tags: {},
       errorCount: 0,
       logEvents: []
@@ -49,9 +49,9 @@ describe('Waterfall Chart component', () => {
       protocolName: 'Protocol Name 2',
       spanType: SpanType.Exit,
       requestHeaders: {},
-      requestBody: '',
+      requestBody$: of(''),
       responseHeaders: {},
-      responseBody: '',
+      responseBody$: of(''),
       tags: {},
       errorCount: 0,
       logEvents: []
@@ -71,9 +71,9 @@ describe('Waterfall Chart component', () => {
       protocolName: 'Protocol Name 3',
       spanType: SpanType.Exit,
       requestHeaders: {},
-      requestBody: '',
+      requestBody$: of(''),
       responseHeaders: {},
-      responseBody: '',
+      responseBody$: of(''),
       tags: {},
       errorCount: 0,
       logEvents: []

--- a/projects/distributed-tracing/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.ts
+++ b/projects/distributed-tracing/src/shared/dashboard/widgets/waterfall/waterfall/waterfall-chart.ts
@@ -1,5 +1,6 @@
 import { Dictionary } from '@hypertrace/common';
 import { StatefulPrefetchedTreeTableRow } from '@hypertrace/components';
+import { Observable } from 'rxjs';
 import { SpanType } from '../../../../graphql/model/schema/span';
 import { SpanNameCellData } from './span-name/span-name-cell-data';
 
@@ -18,9 +19,9 @@ export interface WaterfallData {
   apiName?: string;
   spanType: SpanType;
   requestHeaders?: Dictionary<unknown>;
-  requestBody?: string;
   responseHeaders?: Dictionary<unknown>;
-  responseBody?: string;
+  requestBody$?: Observable<string>;
+  responseBody$?: Observable<string>;
   tags: Dictionary<unknown>;
   errorCount: number;
   logEvents: LogEvent[];

--- a/projects/observability/src/shared/dashboard/data/graphql/waterfall/api-trace-waterfall-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/waterfall/api-trace-waterfall-data-source.model.ts
@@ -46,7 +46,7 @@ export class ApiTraceWaterfallDataSourceModel extends GraphQlDataSourceModel<Wat
   @ModelInject(LogEventsService)
   private readonly logEventsService!: LogEventsService;
 
-  private readonly specificationBuilder: SpecificationBuilder = new SpecificationBuilder();
+  protected readonly specificationBuilder: SpecificationBuilder = new SpecificationBuilder();
   private readonly dateCoercer: DateCoercer = new DateCoercer();
 
   public getData(): Observable<WaterfallData[]> {


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Need to update test and fix any lint


<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
