### PR TITLE
Increase default debounce

### DIFF
--- a/projects/components/src/table/controls/table-controls.component.test.ts
+++ b/projects/components/src/table/controls/table-controls.component.test.ts
@@ -53,11 +53,6 @@ describe('Table Controls component', () => {
     });
 
     spectator.triggerEventHandler(SearchBoxComponent, 'valueChange', 'testing');
-    spectator.tick(200);
-
-    expect(onChangeSpy).not.toHaveBeenCalledWith('testing');
-    // 400 ms debounce
-    spectator.tick(200);
     expect(onChangeSpy).toHaveBeenCalledWith('testing');
   }));
 

--- a/projects/components/src/table/controls/table-controls.component.test.ts
+++ b/projects/components/src/table/controls/table-controls.component.test.ts
@@ -55,6 +55,9 @@ describe('Table Controls component', () => {
     spectator.triggerEventHandler(SearchBoxComponent, 'valueChange', 'testing');
     spectator.tick(200);
 
+    expect(onChangeSpy).not.toHaveBeenCalledWith('testing');
+    // 400 ms debounce
+    spectator.tick(200);
     expect(onChangeSpy).toHaveBeenCalledWith('testing');
   }));
 

--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -161,7 +161,7 @@ export class TableControlsComponent implements OnChanges {
     this.checkboxDiffer = this.differFactory.find([]).create();
 
     this.subscriptionLifecycle.add(
-      this.searchDebounceSubject.pipe(debounceTime(200)).subscribe(text => this.searchChange.emit(text))
+      this.searchDebounceSubject.pipe(debounceTime(400)).subscribe(text => this.searchChange.emit(text))
     );
   }
 


### PR DESCRIPTION
## Description
Update table search debounce from 200ms to 400ms to reduce api calls.

### Testing
Manual, updated UT

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

https://github.com/hypertrace/hypertrace-ui/issues/1072