### PR TITLE
fix: support anything coercer supports for date parsing

### DIFF
--- a/projects/common/src/utilities/coercers/date-coercer.ts
+++ b/projects/common/src/utilities/coercers/date-coercer.ts
@@ -1,19 +1,20 @@
+import { TimeDuration } from '../../time/time-duration';
+import { TimeUnit } from '../../time/time-unit.type';
 import { Coercer, CoercerOptions } from './coercer';
 
 export class DateCoercer extends Coercer<Date, DateCoercerOptions> {
+  private static readonly DEFAULT_TIME_WINDOW: DateCoercerOptions = {
+    earliestDate: new Date(Date.now() - new TimeDuration(10, TimeUnit.Year).toMillis()),
+    latestDate: new Date(Date.now() + new TimeDuration(10, TimeUnit.Year).toMillis())
+  };
+
   public constructor(options: DateCoercerOptions = {}) {
     super(options);
   }
 
   protected assignDefaults(options: DateCoercerOptions): DateCoercerOptions {
-    const tenYearsInMillis = 10 * 365 * 24 * 60 * 60 * 1000;
-    const now = Date.now();
-    const tenYearsAgo = new Date(now - tenYearsInMillis);
-    const tenYearsFuture = new Date(now + tenYearsInMillis);
-
     return {
-      earliestDate: tenYearsAgo,
-      latestDate: tenYearsFuture,
+      ...DateCoercer.DEFAULT_TIME_WINDOW,
       ...super.assignDefaults(options)
     };
   }

--- a/projects/common/src/utilities/formatters/date/date-formatter.test.ts
+++ b/projects/common/src/utilities/formatters/date/date-formatter.test.ts
@@ -1,0 +1,9 @@
+import { DateFormatter } from './date-formatter';
+
+describe('Date formatter', () => {
+  const dateString = '2021-08-19T23:35:45.861Z';
+
+  test('can format a date string', () => {
+    expect(new DateFormatter().format(dateString)).toEqual('19 Aug 2021 11:35 PM');
+  });
+});

--- a/projects/common/src/utilities/formatters/date/date-formatter.ts
+++ b/projects/common/src/utilities/formatters/date/date-formatter.ts
@@ -1,5 +1,6 @@
 import { formatDate } from '@angular/common';
 import { defaults } from 'lodash-es';
+import { DateCoercer } from '../../coercers/date-coercer';
 
 export const enum DateFormatMode {
   TimeOnly,
@@ -16,13 +17,14 @@ export class DateFormatter {
   };
 
   protected readonly options: Readonly<Required<DateFormatOptions>>;
+  private readonly dateCoercer: DateCoercer = new DateCoercer();
 
   // Temporary placeholder, need to flesh this out
   public constructor(options: DateFormatOptions = {}) {
     this.options = this.applyOptionDefaults(options);
   }
 
-  public format(value: Date | number | undefined): string {
+  public format(value: Date | number | undefined | string): string {
     return this.convertDateToString(value);
   }
 
@@ -32,12 +34,13 @@ export class DateFormatter {
     return newOptions;
   }
 
-  protected convertDateToString(value: Date | number | undefined): string {
-    if (value === undefined) {
+  protected convertDateToString(value: Date | number | string | undefined): string {
+    const coercedValue = this.dateCoercer.coerce(value);
+    if (coercedValue === undefined) {
       return '-';
     }
 
-    return formatDate(value, this.getFormatString(), 'en_US');
+    return formatDate(coercedValue, this.getFormatString(), 'en_US');
   }
 
   private getFormatString(): string {

--- a/projects/common/src/utilities/formatters/date/display-date.pipe.test.ts
+++ b/projects/common/src/utilities/formatters/date/display-date.pipe.test.ts
@@ -1,0 +1,9 @@
+import { DisplayDatePipe } from './display-date.pipe';
+
+describe('Display date pipe', () => {
+  const dateString = '2021-08-19T23:35:45.861Z';
+
+  test('can render a formatted string', () => {
+    expect(new DisplayDatePipe().transform(dateString)).toEqual('19 Aug 2021 11:35 PM');
+  });
+});

--- a/projects/common/src/utilities/formatters/date/display-date.pipe.test.ts
+++ b/projects/common/src/utilities/formatters/date/display-date.pipe.test.ts
@@ -1,9 +1,0 @@
-import { DisplayDatePipe } from './display-date.pipe';
-
-describe('Display date pipe', () => {
-  const dateString = '2021-08-19T23:35:45.861Z';
-
-  test('can render a formatted string', () => {
-    expect(new DisplayDatePipe().transform(dateString)).toEqual('19 Aug 2021 11:35 PM');
-  });
-});

--- a/projects/common/src/utilities/formatters/date/display-date.pipe.ts
+++ b/projects/common/src/utilities/formatters/date/display-date.pipe.ts
@@ -1,11 +1,14 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { isNil } from 'lodash-es';
+import { DateCoercer } from '../../coercers/date-coercer';
 import { DateFormatOptions, DateFormatter } from './date-formatter';
 
 @Pipe({
   name: 'htDisplayDate'
 })
 export class DisplayDatePipe implements PipeTransform {
-  public transform(value?: Date | number | null, options: DateFormatOptions = {}): string {
-    return value !== null ? new DateFormatter(options).format(value) : '-';
+  private readonly dateCoercer: DateCoercer = new DateCoercer();
+  public transform(value?: string | Date | number | null, options: DateFormatOptions = {}): string {
+    return isNil(value) ? '-' : new DateFormatter(options).format(this.dateCoercer.coerce(value));
   }
 }

--- a/projects/common/src/utilities/formatters/date/display-date.pipe.ts
+++ b/projects/common/src/utilities/formatters/date/display-date.pipe.ts
@@ -9,6 +9,8 @@ import { DateFormatOptions, DateFormatter } from './date-formatter';
 export class DisplayDatePipe implements PipeTransform {
   private readonly dateCoercer: DateCoercer = new DateCoercer();
   public transform(value?: string | Date | number | null, options: DateFormatOptions = {}): string {
-    return isNil(value) ? '-' : new DateFormatter(options).format(this.dateCoercer.coerce(value));
+    const coercedDate = this.dateCoercer.coerce(value);
+
+    return isNil(coercedDate) ? '-' : new DateFormatter(options).format(coercedDate);
   }
 }

--- a/projects/common/src/utilities/formatters/date/display-date.pipe.ts
+++ b/projects/common/src/utilities/formatters/date/display-date.pipe.ts
@@ -1,16 +1,12 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { isNil } from 'lodash-es';
-import { DateCoercer } from '../../coercers/date-coercer';
 import { DateFormatOptions, DateFormatter } from './date-formatter';
 
 @Pipe({
   name: 'htDisplayDate'
 })
 export class DisplayDatePipe implements PipeTransform {
-  private readonly dateCoercer: DateCoercer = new DateCoercer();
   public transform(value?: string | Date | number | null, options: DateFormatOptions = {}): string {
-    const coercedDate = this.dateCoercer.coerce(value);
-
-    return isNil(coercedDate) ? '-' : new DateFormatter(options).format(coercedDate);
+    return isNil(value) ? '-' : new DateFormatter(options).format(value);
   }
 }

--- a/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.test.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.test.ts
@@ -1,0 +1,20 @@
+import { Injector } from '@angular/core';
+import { TableCellTimestampParser } from './table-cell-timestamp-parser';
+
+describe('table cell timestamp parser', () => {
+  const dateString = '2021-08-19T23:35:45.861Z';
+  const date = new Date(dateString);
+  const dateMillis = date.getTime();
+
+  test('can parse date strings', () => {
+    expect(new TableCellTimestampParser({} as Injector).parseValue(dateString)).toEqual(date);
+  });
+
+  test('can parse numbers', () => {
+    expect(new TableCellTimestampParser({} as Injector).parseValue(dateMillis)).toEqual(dateMillis);
+  });
+
+  test('can parse date objects', () => {
+    expect(new TableCellTimestampParser({} as Injector).parseValue(date)).toEqual(date);
+  });
+});

--- a/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.test.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.test.ts
@@ -7,14 +7,17 @@ describe('table cell timestamp parser', () => {
   const dateMillis = date.getTime();
 
   test('can parse date strings', () => {
+    // tslint:disable-next-line: no-object-literal-type-assertion
     expect(new TableCellTimestampParser({} as Injector).parseValue(dateString)).toEqual(date);
   });
 
   test('can parse numbers', () => {
+    // tslint:disable-next-line: no-object-literal-type-assertion
     expect(new TableCellTimestampParser({} as Injector).parseValue(dateMillis)).toEqual(dateMillis);
   });
 
   test('can parse date objects', () => {
+    // tslint:disable-next-line: no-object-literal-type-assertion
     expect(new TableCellTimestampParser({} as Injector).parseValue(date)).toEqual(date);
   });
 });

--- a/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.ts
@@ -24,5 +24,5 @@ export class TableCellTimestampParser extends TableCellParserBase<CellData, Valu
   }
 }
 
-type CellData = Date | number | { value: Date | number };
+type CellData = Date | number | string | { value: Date | number };
 type Value = Date | number | undefined;

--- a/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.ts
+++ b/projects/components/src/table/cells/data-parsers/table-cell-timestamp-parser.ts
@@ -1,3 +1,4 @@
+import { DateCoercer } from '@hypertrace/common';
 import { TableCellParser } from '../table-cell-parser';
 import { TableCellParserBase } from '../table-cell-parser-base';
 import { CoreTableCellParserType } from '../types/core-table-cell-parser-type';
@@ -6,6 +7,7 @@ import { CoreTableCellParserType } from '../types/core-table-cell-parser-type';
   type: CoreTableCellParserType.Timestamp
 })
 export class TableCellTimestampParser extends TableCellParserBase<CellData, Value, Value> {
+  private readonly dateCoercer: DateCoercer = new DateCoercer();
   public parseValue(cellData: CellData): Value {
     switch (typeof cellData) {
       case 'number':
@@ -13,7 +15,7 @@ export class TableCellTimestampParser extends TableCellParserBase<CellData, Valu
       case 'object':
         return cellData instanceof Date ? cellData : cellData.value;
       default:
-        return undefined;
+        return this.dateCoercer.coerce(cellData);
     }
   }
 


### PR DESCRIPTION
## Description
Dates coming through as strings, even though we have the tools to parse them, are not supported today in the table parser or the date display pipe. This adds that support.


### Testing
Manual, added UTs