### PR TITLE
fix: running telemetry methods on initialized list only

### DIFF
--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -7,7 +7,8 @@ import { UserTelemetryService } from './user-telemetry.service';
 
 @Injectable({ providedIn: 'root' })
 export class UserTelemetryImplService extends UserTelemetryService {
-  private telemetryProviders: UserTelemetryInternalConfig[] = [];
+  private allTelemetryProviders: UserTelemetryInternalConfig[] = [];
+  private initializedTelemetryProviders: UserTelemetryInternalConfig[] = [];
 
   public constructor(private readonly injector: Injector, @Optional() private readonly router?: Router) {
     super();
@@ -17,7 +18,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
   public register(...configs: UserTelemetryRegistrationConfig<unknown>[]): void {
     try {
       const providers = configs.map(config => this.buildTelemetryProvider(config));
-      this.telemetryProviders = [...this.telemetryProviders, ...providers];
+      this.allTelemetryProviders = [...this.allTelemetryProviders, ...providers];
     } catch (error) {
       /**
        * Fail silently
@@ -29,31 +30,32 @@ export class UserTelemetryImplService extends UserTelemetryService {
   }
 
   public initialize(): void {
-    this.telemetryProviders.forEach(provider => provider.telemetryProvider.initialize(provider.initConfig));
+    this.allTelemetryProviders.forEach(provider => provider.telemetryProvider.initialize(provider.initConfig));
+    this.initializedTelemetryProviders = [...this.allTelemetryProviders];
   }
 
   public identify(userTraits: UserTraits): void {
-    this.telemetryProviders.forEach(provider => provider.telemetryProvider.identify(userTraits));
+    this.initializedTelemetryProviders.forEach(provider => provider.telemetryProvider.identify(userTraits));
   }
 
   public shutdown(): void {
-    this.telemetryProviders.forEach(provider => provider.telemetryProvider.shutdown?.());
+    this.initializedTelemetryProviders.forEach(provider => provider.telemetryProvider.shutdown?.());
   }
 
   public trackEvent(name: string, data: Dictionary<unknown>): void {
-    this.telemetryProviders
+    this.initializedTelemetryProviders
       .filter(provider => provider.enableEventTracking)
       .forEach(provider => provider.telemetryProvider.trackEvent?.(name, data));
   }
 
   public trackPageEvent(url: string, data: Dictionary<unknown>): void {
-    this.telemetryProviders
+    this.initializedTelemetryProviders
       .filter(provider => provider.enablePageTracking)
       .forEach(provider => provider.telemetryProvider.trackPage?.(url, data));
   }
 
   public trackErrorEvent(error: string, data: Dictionary<unknown>): void {
-    this.telemetryProviders
+    this.initializedTelemetryProviders
       .filter(provider => provider.enableErrorTracking)
       .forEach(provider => provider.telemetryProvider.trackError?.(`Error: ${error}`, data));
   }

--- a/projects/common/src/telemetry/user-telemetry-impl.service.ts
+++ b/projects/common/src/telemetry/user-telemetry-impl.service.ts
@@ -40,6 +40,7 @@ export class UserTelemetryImplService extends UserTelemetryService {
 
   public shutdown(): void {
     this.initializedTelemetryProviders.forEach(provider => provider.telemetryProvider.shutdown?.());
+    this.initializedTelemetryProviders = [];
   }
 
   public trackEvent(name: string, data: Dictionary<unknown>): void {


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
fix: running telemetry methods on initialized list only
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
