### PR TITLE
fix: scrolling in waterfall fixed

### DIFF
--- a/projects/observability/src/pages/api-trace-detail/api-trace-detail.page.component.ts
+++ b/projects/observability/src/pages/api-trace-detail/api-trace-detail.page.component.ts
@@ -61,17 +61,17 @@ import { ApiTraceDetails, ApiTraceDetailService } from './api-trace-detail.servi
             (click)="this.navigateToFullTrace(traceDetails.traceId, traceDetails.startTime)"
           ></ht-button>
         </div>
+      </div>
 
-        <ht-navigable-tab-group class="tabs">
-          <ht-navigable-tab path="sequence"> Sequence </ht-navigable-tab>
-          <ng-container *ngIf="this.logEvents$ | async as logEvents">
-            <ht-navigable-tab path="logs" [labelTag]="logEvents.length"> Logs </ht-navigable-tab>
-          </ng-container>
-        </ht-navigable-tab-group>
+      <ht-navigable-tab-group class="tabs">
+        <ht-navigable-tab path="sequence"> Sequence </ht-navigable-tab>
+        <ng-container *ngIf="this.logEvents$ | async as logEvents">
+          <ht-navigable-tab path="logs" [labelTag]="logEvents.length"> Logs </ht-navigable-tab>
+        </ng-container>
+      </ht-navigable-tab-group>
 
-        <div class="scrollable-container">
-          <router-outlet></router-outlet>
-        </div>
+      <div class="scrollable-container">
+        <router-outlet></router-outlet>
       </div>
     </div>
   `

--- a/projects/observability/src/pages/trace-detail/trace-detail.page.component.ts
+++ b/projects/observability/src/pages/trace-detail/trace-detail.page.component.ts
@@ -60,17 +60,17 @@ import { TraceDetails, TraceDetailService } from './trace-detail.service';
             htTooltip="Download Trace as Json"
           ></ht-download-json>
         </div>
+      </div>
 
-        <ht-navigable-tab-group class="tabs">
-          <ht-navigable-tab path="sequence"> Sequence </ht-navigable-tab>
-          <ng-container *ngIf="this.logEvents$ | async as logEvents">
-            <ht-navigable-tab path="logs" [labelTag]="logEvents.length"> Logs </ht-navigable-tab>
-          </ng-container>
-        </ht-navigable-tab-group>
+      <ht-navigable-tab-group class="tabs">
+        <ht-navigable-tab path="sequence"> Sequence </ht-navigable-tab>
+        <ng-container *ngIf="this.logEvents$ | async as logEvents">
+          <ht-navigable-tab path="logs" [labelTag]="logEvents.length"> Logs </ht-navigable-tab>
+        </ng-container>
+      </ht-navigable-tab-group>
 
-        <div class="scrollable-container">
-          <router-outlet></router-outlet>
-        </div>
+      <div class="scrollable-container">
+        <router-outlet></router-outlet>
       </div>
     </div>
   `


### PR DESCRIPTION

fixed: scrolling issue in waterfall chart 
when the no of spans are more than the visible area, the expected behaviour is the user can scroll down and see the spans at the bottom. With the latest changes, scrolling is disabled 

-
 Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works


