### PR TITLE
fix: common project should not depend on components project

### DIFF
--- a/projects/common/src/navigation/navigation.config.ts
+++ b/projects/common/src/navigation/navigation.config.ts
@@ -1,23 +1,4 @@
 import { Observable } from 'rxjs';
-import { Color } from '../color/color';
-import { FeatureState} from '../feature/state/feature.state';
-
-export type NavItemConfig = NavItemLinkConfig | NavItemHeaderConfig | NavItemDividerConfig;
-
-export interface NavItemLinkConfig {
-  type: NavItemType.Link;
-  icon: string;
-  iconSize?: string;
-  label: string;
-  matchPaths: string[]; // For now, default path is index 0
-  features?: string[];
-  replaceCurrentHistory?: boolean;
-  isBeta?: boolean;
-  trailingIcon?: string;
-  trailingIconTooltip?: string;
-  trailingIconColor?: Color;
-  featureState$?: Observable<FeatureState>;
-}
 
 export type FooterItemConfig = FooterItemLinkConfig;
 

--- a/projects/common/src/navigation/navigation.config.ts
+++ b/projects/common/src/navigation/navigation.config.ts
@@ -1,13 +1,13 @@
-import { Color, FeatureState } from '@hypertrace/common';
 import { Observable } from 'rxjs';
-import { IconSize } from '../../../components/src/icon/icon-size';
+import { Color } from '../color/color';
+import { FeatureState} from '../feature/state/feature.state';
 
 export type NavItemConfig = NavItemLinkConfig | NavItemHeaderConfig | NavItemDividerConfig;
 
 export interface NavItemLinkConfig {
   type: NavItemType.Link;
   icon: string;
-  iconSize?: IconSize;
+  iconSize?: string;
   label: string;
   matchPaths: string[]; // For now, default path is index 0
   features?: string[];

--- a/projects/common/src/navigation/navigation.config.ts
+++ b/projects/common/src/navigation/navigation.config.ts
@@ -1,6 +1,6 @@
 import { Color, FeatureState } from '@hypertrace/common';
 import { Observable } from 'rxjs';
-import { IconSize } from '../icon/icon-size';
+import { IconSize } from '../../../components/src/icon/icon-size';
 
 export type NavItemConfig = NavItemLinkConfig | NavItemHeaderConfig | NavItemDividerConfig;
 

--- a/projects/common/src/navigation/navigation.service.test.ts
+++ b/projects/common/src/navigation/navigation.service.test.ts
@@ -2,10 +2,9 @@ import { Location } from '@angular/common';
 import { Title } from '@angular/platform-browser';
 import { Router, UrlSegment } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { IconType } from '@hypertrace/assets-library';
-import { APP_TITLE, NavItemType } from '@hypertrace/common';
 import { patchRouterNavigateForTest } from '@hypertrace/test-utils';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
+import { APP_TITLE } from './ht-route';
 import {
   ExternalNavigationPathParams,
   ExternalNavigationWindowHandling,
@@ -69,6 +68,7 @@ describe('Navigation Service', () => {
     patchRouterNavigateForTest(spectator);
     router = spectator.inject(Router);
   });
+
   test('can retrieve a route config relative to the current route', () => {
     router.navigate(['root']);
     expect(spectator.service.getRouteConfig(['child'])).toEqual(firstChildRouteConfig);
@@ -295,36 +295,6 @@ describe('Navigation Service', () => {
         `/some/internal/path/of/app?type=json&time=1h&environment=development`
       );
     }
-  });
-
-  test('decorating navItem with features work as expected', () => {
-    expect(
-      spectator.service.decorateNavItem(
-        {
-          type: NavItemType.Header,
-          label: 'Label'
-        },
-        spectator.service.getCurrentActivatedRoute()
-      )
-    ).toEqual({ type: NavItemType.Header, label: 'Label' });
-
-    expect(
-      spectator.service.decorateNavItem(
-        {
-          type: NavItemType.Link,
-          label: 'Label',
-          icon: IconType.None,
-          matchPaths: ['root']
-        },
-        spectator.service.rootRoute()
-      )
-    ).toEqual({
-      type: NavItemType.Link,
-      label: 'Label',
-      icon: IconType.None,
-      matchPaths: ['root'],
-      features: ['test-feature']
-    });
   });
 
   test('setting title should work as expected', () => {

--- a/projects/common/src/navigation/navigation.service.test.ts
+++ b/projects/common/src/navigation/navigation.service.test.ts
@@ -3,8 +3,7 @@ import { Title } from '@angular/platform-browser';
 import { Router, UrlSegment } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IconType } from '@hypertrace/assets-library';
-import { APP_TITLE } from '@hypertrace/common';
-import { NavItemType } from '@hypertrace/components';
+import { APP_TITLE, NavItemType } from '@hypertrace/common';
 import { patchRouterNavigateForTest } from '@hypertrace/test-utils';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import {

--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -14,13 +14,13 @@ import {
   UrlSegment,
   UrlTree
 } from '@angular/router';
-import { NavItemConfig, NavItemType } from '@hypertrace/components';
 import { uniq } from 'lodash-es';
 import { from, Observable, of } from 'rxjs';
 import { distinctUntilChanged, filter, map, share, skip, startWith, switchMap, take, tap } from 'rxjs/operators';
 import { isEqualIgnoreFunctions, throwIfNil } from '../utilities/lang/lang-utils';
 import { Dictionary } from '../utilities/types/types';
 import { APP_TITLE, HtRoute } from './ht-route';
+import { NavItemConfig, NavItemType } from './navigation.config';
 
 @Injectable({ providedIn: 'root' })
 export class NavigationService {

--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -14,13 +14,11 @@ import {
   UrlSegment,
   UrlTree
 } from '@angular/router';
-import { uniq } from 'lodash-es';
 import { from, Observable, of } from 'rxjs';
 import { distinctUntilChanged, filter, map, share, skip, startWith, switchMap, take, tap } from 'rxjs/operators';
 import { isEqualIgnoreFunctions, throwIfNil } from '../utilities/lang/lang-utils';
 import { Dictionary } from '../utilities/types/types';
 import { APP_TITLE, HtRoute } from './ht-route';
-import { NavItemConfig, NavItemType } from './navigation.config';
 
 @Injectable({ providedIn: 'root' })
 export class NavigationService {
@@ -241,26 +239,6 @@ export class NavigationService {
       relativeTo === this.rootRoute() ? this.router.config : relativeTo.routeConfig && relativeTo.routeConfig.children;
 
     return this.findRouteConfig(path, childRoutes ? childRoutes : []);
-  }
-
-  public decorateNavItem(navItem: NavItemConfig, activatedRoute: ActivatedRoute): NavItemConfig {
-    if (navItem.type !== NavItemType.Link) {
-      return { ...navItem };
-    }
-    const features = navItem.matchPaths
-      .map(path => this.getRouteConfig([path], activatedRoute))
-      .filter((maybeRoute): maybeRoute is HtRoute => maybeRoute !== undefined)
-      .flatMap(route => this.getFeaturesForRoute(route))
-      .concat(navItem.features || []);
-
-    return {
-      ...navItem,
-      features: uniq(features)
-    };
-  }
-
-  private getFeaturesForRoute(route: HtRoute): string[] {
-    return (route.data && route.data.features) || [];
   }
 
   public rootRoute(): ActivatedRoute {

--- a/projects/common/src/public-api.ts
+++ b/projects/common/src/public-api.ts
@@ -83,6 +83,7 @@ export * from './navigation/breadcrumb';
 export * from './navigation/navigation.service';
 export * from './navigation/ht-route-data';
 export * from './navigation/ht-route';
+export * from './navigation/navigation.config';
 
 // Operations
 export * from './utilities/operations/operation-utilities';

--- a/projects/components/src/navigation/nav-item/nav-item.component.test.ts
+++ b/projects/components/src/navigation/nav-item/nav-item.component.test.ts
@@ -5,13 +5,12 @@ import {
   FeatureStateResolver,
   MemoizeModule,
   NavigationParamsType,
-  NavigationService
+  NavigationService, NavItemConfig, NavItemType
 } from '@hypertrace/common';
 import { BetaTagComponent, IconComponent, LinkComponent } from '@hypertrace/components';
 import { createHostFactory, mockProvider, SpectatorHost } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
-import { NavItemConfig, NavItemType } from '../navigation.config';
 import { FeatureConfigCheckModule } from './../../feature-check/feature-config-check.module';
 import { NavItemComponent } from './nav-item.component';
 

--- a/projects/components/src/navigation/nav-item/nav-item.component.ts
+++ b/projects/components/src/navigation/nav-item/nav-item.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { FeatureState, NavigationParams, NavigationParamsType, NavItemLinkConfig } from '@hypertrace/common';
+import { FeatureState, NavigationParams, NavigationParamsType } from '@hypertrace/common';
 import { IconSize } from '../../icon/icon-size';
+import { NavItemLinkConfig} from '../navigation-list.service';
 
 @Component({
   selector: 'ht-nav-item',

--- a/projects/components/src/navigation/nav-item/nav-item.component.ts
+++ b/projects/components/src/navigation/nav-item/nav-item.component.ts
@@ -1,8 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { FeatureState, NavigationParams, NavigationParamsType } from '@hypertrace/common';
+import { FeatureState, NavigationParams, NavigationParamsType, NavItemLinkConfig } from '@hypertrace/common';
 import { IconSize } from '../../icon/icon-size';
-import { NavItemLinkConfig } from '../navigation.config';
 
 @Component({
   selector: 'ht-nav-item',

--- a/projects/components/src/navigation/navigation-list-component.service.test.ts
+++ b/projects/components/src/navigation/navigation-list-component.service.test.ts
@@ -1,10 +1,8 @@
-import { FeatureState, FeatureStateResolver } from '@hypertrace/common';
-import { NavItemConfig, NavItemType } from '@hypertrace/components';
+import { FeatureState, FeatureStateResolver , NavItemConfig, NavItemHeaderConfig, NavItemType } from '@hypertrace/common';
 import { runFakeRxjs } from '@hypertrace/test-utils';
 import { createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 import { NavigationListComponentService } from './navigation-list-component.service';
-import { NavItemHeaderConfig } from './navigation.config';
 
 describe('Navigation List Component Service', () => {
   const navItems: NavItemConfig[] = [

--- a/projects/components/src/navigation/navigation-list-component.service.ts
+++ b/projects/components/src/navigation/navigation-list-component.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
-import { FeatureState, FeatureStateResolver } from '@hypertrace/common';
+import { FeatureState, FeatureStateResolver, NavItemConfig, NavItemHeaderConfig, NavItemLinkConfig, NavItemType } from '@hypertrace/common';
 import { isEmpty } from 'lodash-es';
 import { combineLatest, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { NavItemConfig, NavItemHeaderConfig, NavItemLinkConfig, NavItemType } from './navigation.config';
 
 @Injectable({ providedIn: 'root' })
 export class NavigationListComponentService {

--- a/projects/components/src/navigation/navigation-list-component.service.ts
+++ b/projects/components/src/navigation/navigation-list-component.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { FeatureState, FeatureStateResolver, NavItemConfig, NavItemHeaderConfig, NavItemLinkConfig, NavItemType } from '@hypertrace/common';
+import { FeatureState, FeatureStateResolver,  NavItemHeaderConfig, NavItemType } from '@hypertrace/common';
 import { isEmpty } from 'lodash-es';
 import { combineLatest, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { NavItemConfig, NavItemLinkConfig, } from './navigation-list.service';
 
 @Injectable({ providedIn: 'root' })
 export class NavigationListComponentService {

--- a/projects/components/src/navigation/navigation-list.component.test.ts
+++ b/projects/components/src/navigation/navigation-list.component.test.ts
@@ -1,6 +1,6 @@
 import { ActivatedRoute } from '@angular/router';
 import { IconType } from '@hypertrace/assets-library';
-import { MemoizeModule, NavigationService } from '@hypertrace/common';
+import { FooterItemConfig, MemoizeModule, NavigationService, NavItemConfig, NavItemType } from '@hypertrace/common';
 import { createHostFactory, mockProvider, SpectatorHost } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 import { EMPTY, of } from 'rxjs';
@@ -10,7 +10,6 @@ import { LinkComponent } from './../link/link.component';
 import { NavItemComponent } from './nav-item/nav-item.component';
 import { NavigationListComponentService } from './navigation-list-component.service';
 import { NavigationListComponent } from './navigation-list.component';
-import { FooterItemConfig, NavItemConfig, NavItemType } from './navigation.config';
 describe('Navigation List Component', () => {
   let spectator: SpectatorHost<NavigationListComponent>;
   const activatedRoute = {

--- a/projects/components/src/navigation/navigation-list.component.ts
+++ b/projects/components/src/navigation/navigation-list.component.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { IconType } from '@hypertrace/assets-library';
-import { FooterItemConfig, NavigationService, NavItemConfig, NavItemLinkConfig, NavItemType } from '@hypertrace/common';
+import { FooterItemConfig, NavigationService, NavItemType } from '@hypertrace/common';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { IconSize } from '../icon/icon-size';
 import { NavigationListComponentService } from './navigation-list-component.service';
+import { NavItemConfig, NavItemLinkConfig } from './navigation-list.service';
 
 @Component({
   selector: 'ht-navigation-list',

--- a/projects/components/src/navigation/navigation-list.component.ts
+++ b/projects/components/src/navigation/navigation-list.component.ts
@@ -1,12 +1,11 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { IconType } from '@hypertrace/assets-library';
-import { NavigationService } from '@hypertrace/common';
+import { FooterItemConfig, NavigationService, NavItemConfig, NavItemLinkConfig, NavItemType } from '@hypertrace/common';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { IconSize } from '../icon/icon-size';
 import { NavigationListComponentService } from './navigation-list-component.service';
-import { FooterItemConfig, NavItemConfig, NavItemLinkConfig, NavItemType } from './navigation.config';
 
 @Component({
   selector: 'ht-navigation-list',

--- a/projects/components/src/navigation/navigation-list.service.test.ts
+++ b/projects/components/src/navigation/navigation-list.service.test.ts
@@ -1,0 +1,55 @@
+import { ActivatedRoute } from '@angular/router';
+import { IconType } from '@hypertrace/assets-library';
+import { NavigationService, NavItemType } from '@hypertrace/common';
+import { NavigationListService } from '@hypertrace/components';
+import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
+
+describe('Navigation List Service', () => {
+  let spectator: SpectatorService<NavigationListService>;
+
+  const buildService = createServiceFactory({
+    service: NavigationListService,
+    providers: [
+      mockProvider(ActivatedRoute),
+      mockProvider(NavigationService, { getRouteConfig: jest.fn().mockReturnValue({
+          path: 'root',
+          data: { features: ['test-feature'] },
+          children: []
+        })}),
+    ]
+  });
+
+  beforeEach(() => {
+    spectator = buildService();
+  });
+
+  test('decorating navItem with features work as expected', () => {
+    expect(
+      spectator.service.decorateNavItem(
+        {
+          type: NavItemType.Header,
+          label: 'Label'
+        },
+        spectator.inject(ActivatedRoute)
+      )
+    ).toEqual({ type: NavItemType.Header, label: 'Label' });
+
+    expect(
+      spectator.service.decorateNavItem(
+        {
+          type: NavItemType.Link,
+          label: 'Label',
+          icon: IconType.None,
+          matchPaths: ['root']
+        },
+        spectator.inject(ActivatedRoute)
+      )
+    ).toEqual({
+      type: NavItemType.Link,
+      label: 'Label',
+      icon: IconType.None,
+      matchPaths: ['root'],
+      features: ['test-feature']
+    });
+  });
+});

--- a/projects/components/src/navigation/navigation-list.service.ts
+++ b/projects/components/src/navigation/navigation-list.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import {
+  Color,
+  FeatureState,
+  HtRoute,
+  NavigationService,
+  NavItemDividerConfig,
+  NavItemHeaderConfig,
+  NavItemType
+} from '@hypertrace/common';
+import { uniq } from 'lodash-es';
+import { Observable } from 'rxjs';
+import { IconSize } from '../icon/icon-size';
+
+@Injectable({ providedIn: 'root'})
+export class NavigationListService {
+  public constructor(private readonly navigationService: NavigationService) {}
+
+  public decorateNavItem(navItem: NavItemConfig, activatedRoute: ActivatedRoute): NavItemConfig {
+    if (navItem.type !== NavItemType.Link) {
+      return { ...navItem };
+    }
+    const features = navItem.matchPaths
+      .map(path => this.navigationService.getRouteConfig([path], activatedRoute))
+      .filter((maybeRoute): maybeRoute is HtRoute => maybeRoute !== undefined)
+      .flatMap(route => this.getFeaturesForRoute(route))
+      .concat(navItem.features || []);
+
+    return {
+      ...navItem,
+      features: uniq(features)
+    };
+  }
+
+  private getFeaturesForRoute(route: HtRoute): string[] {
+    return (route.data && route.data.features) || [];
+  }
+}
+
+export type NavItemConfig = NavItemLinkConfig | NavItemHeaderConfig | NavItemDividerConfig;
+
+export interface NavItemLinkConfig {
+  type: NavItemType.Link;
+  icon: string;
+  iconSize?: IconSize;
+  label: string;
+  matchPaths: string[]; // For now, default path is index 0
+  features?: string[];
+  replaceCurrentHistory?: boolean;
+  isBeta?: boolean;
+  trailingIcon?: string;
+  trailingIconTooltip?: string;
+  trailingIconColor?: Color;
+  featureState$?: Observable<FeatureState>;
+}

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -156,6 +156,7 @@ export * from './navigation/navigation-list.component';
 export * from './navigation/navigation-list.module';
 export * from './navigation/nav-item/nav-item.component';
 export * from './navigation/navigation-list-component.service';
+export * from './navigation/navigation-list.service';
 
 // Let async
 export { LetAsyncDirective } from './let-async/let-async.directive';

--- a/projects/components/src/public-api.ts
+++ b/projects/components/src/public-api.ts
@@ -155,7 +155,6 @@ export { LayoutChangeModule } from './layout/layout-change.module';
 export * from './navigation/navigation-list.component';
 export * from './navigation/navigation-list.module';
 export * from './navigation/nav-item/nav-item.component';
-export * from './navigation/navigation.config';
 export * from './navigation/navigation-list-component.service';
 
 // Let async

--- a/src/app/shared/navigation/navigation.component.ts
+++ b/src/app/shared/navigation/navigation.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { IconType } from '@hypertrace/assets-library';
-import { NavigationService, NavItemConfig, NavItemType, PreferenceService } from '@hypertrace/common';
+import { NavItemType, PreferenceService } from '@hypertrace/common';
+import { NavigationListService, NavItemConfig } from '@hypertrace/components';
 import { ObservabilityIconType } from '@hypertrace/observability';
 import { Observable } from 'rxjs';
 
@@ -73,12 +74,12 @@ export class NavigationComponent {
   ];
 
   public constructor(
-    private readonly navigationService: NavigationService,
+    private readonly navigationListService: NavigationListService,
     private readonly preferenceService: PreferenceService,
     private readonly activatedRoute: ActivatedRoute
   ) {
     this.navItems = this.navItemDefinitions.map(definition =>
-      this.navigationService.decorateNavItem(definition, this.activatedRoute)
+      this.navigationListService.decorateNavItem(definition, this.activatedRoute)
     );
     this.isCollapsed$ = this.preferenceService.get(NavigationComponent.COLLAPSED_PREFERENCE, false);
   }

--- a/src/app/shared/navigation/navigation.component.ts
+++ b/src/app/shared/navigation/navigation.component.ts
@@ -1,8 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { IconType } from '@hypertrace/assets-library';
-import { NavigationService, PreferenceService } from '@hypertrace/common';
-import { NavItemConfig, NavItemType } from '@hypertrace/components';
+import { NavigationService, NavItemConfig, NavItemType, PreferenceService } from '@hypertrace/common';
 import { ObservabilityIconType } from '@hypertrace/observability';
 import { Observable } from 'rxjs';
 


### PR DESCRIPTION
## Description
This PR -> https://github.com/hypertrace/hypertrace-ui/pull/969 introduced a change where the common project depends on components project. That should not happen. Refactoring code to avoid that unintended dependency.

### Testing
Verified with build. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules