### PR TITLE
fix: avoid dupe columns, clear group name from url on none

### DIFF
--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -518,9 +518,26 @@ export class ExplorerDashboardBuilder {
   protected getAttributesToExcludeFromUserDisplay(context: ExplorerGeneratedDashboardContext): Set<string> {
     switch (context) {
       case ObservabilityTraceType.Api:
-        return new Set(['protocol', 'apiName', 'statusCode', 'duration', 'startTime', 'calls']);
+        return new Set([
+          'protocol',
+          'serviceName',
+          'apiName',
+          'statusCode',
+          'apiTraceErrorSpanCount',
+          'duration',
+          'startTime',
+          'calls'
+        ]);
       case SPAN_SCOPE:
-        return new Set(['protocolName', 'displaySpanName', 'statusCode', 'duration', 'startTime']);
+        return new Set([
+          'protocolName',
+          'serviceName',
+          'displaySpanName',
+          'statusCode',
+          'errorCount',
+          'duration',
+          'startTime'
+        ]);
       default:
         return assertUnreachable(context);
     }

--- a/projects/observability/src/pages/explorer/explorer.component.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.ts
@@ -195,7 +195,12 @@ export class ExplorerComponent {
   private getGroupByQueryParams(groupBy?: GraphQlGroupBy): QueryParamObject {
     const key = groupBy?.keys[0];
     if (key === undefined) {
-      return {};
+      return {
+        // Clear existing selection
+        [ExplorerQueryParam.Group]: undefined,
+        [ExplorerQueryParam.OtherGroup]: undefined,
+        [ExplorerQueryParam.GroupLimit]: undefined
+      };
     }
 
     return {


### PR DESCRIPTION
## Description
Fixing two separate bugs.

In dev mode, material warns if duplicate columns are being added to a table. We attempt to avoid that in explorer, but the pre-defined keys got out of sync with the pre-defined columns. That needs a better design, this is a quick bandaid until we come back to this with some upcoming work on selectable columns.

Explorer state is captured in the url, but when the group selection changes from a group key to none, it was not removed from the URL. This is because we always merge parameters, and the none state has no representation in the url. Updated to explicitly remove those parameters.

### Testing
Ran tests and manually verified. 
