### PR TITLE
fix: emit correct shape for single select change

### DIFF
--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -67,7 +67,7 @@ import {
             class="control select"
             showBorder="true"
             searchMode="${MultiSelectSearchMode.CaseInsensitive}"
-            (selectedChange)="this.onMultiSelectChange(selectControl, $event)"
+            (selectedChange)="this.onSelectChange(selectControl, $event)"
           >
             <ht-select-option
               *ngFor="let option of selectControl.options"
@@ -238,6 +238,13 @@ export class TableControlsComponent implements OnChanges {
     this.selectChange.emit({
       select: select,
       values: selections
+    });
+  }
+
+  public onSelectChange(select: TableSelectControl, selection: TableSelectControlOption): void {
+    this.selectChange.emit({
+      select: select,
+      values: [selection]
     });
   }
 


### PR DESCRIPTION
## Description
When a single select control was changing, it was emitting an object for its `values` field instead of an array because it was using the same handler.

