### PR TITLE
feat: table filters now always show their placeholder even when a sel…

### DIFF
--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -146,6 +146,9 @@ export class MultiSelectComponent<V> implements ControlValueAccessor, AfterConte
   public placeholder?: string;
 
   @Input()
+  public prefix?: string;
+
+  @Input()
   public disabled: boolean = false;
 
   @Input()
@@ -275,11 +278,19 @@ export class MultiSelectComponent<V> implements ControlValueAccessor, AfterConte
         const selectedItems: SelectOptionComponent<V>[] = options.filter(item => this.isSelectedItem(item));
 
         return {
-          label: selectedItems.length === 0 ? this.placeholder : selectedItems[0]?.label,
+          label: this.getLabel(selectedItems),
           selectedItemsCount: selectedItems.length
         };
       })
     );
+  }
+
+  private getLabel(selectedItems: SelectOptionComponent<V>[]): string {
+    if (selectedItems.length === 0) {
+      return this.placeholder === undefined ? '' : this.placeholder;
+    }
+
+    return this.prefix === undefined ? selectedItems[0]?.label : `${this.prefix}${selectedItems[0]?.label}`.trim();
   }
 
   private propagateValueChangeToFormControl(value: V[] | undefined): void {

--- a/projects/components/src/table/controls/table-controls-api.ts
+++ b/projects/components/src/table/controls/table-controls-api.ts
@@ -37,6 +37,7 @@ export interface TablePropertyControlOption {
 
 export interface TableSelectControl {
   placeholder: string;
+  prefix?: string;
   isMultiSelect: boolean;
   options: TableSelectControlOption[];
 }

--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -48,6 +48,7 @@ import {
             *ngIf="selectControl.isMultiSelect"
             [selected]="this.appliedFilters(selectControl)"
             [placeholder]="selectControl.placeholder"
+            [prefix]="selectControl.prefix"
             class="control select"
             [ngClass]="{ applied: this.appliedFilters(selectControl).length > 0 }"
             showBorder="true"


### PR DESCRIPTION
Currently, when a filter is selected we only show the value and remove the placeholder text. This change will keep the placeholder text as a prefix for the selected values.

<img width="579" alt="Screen Shot 2021-11-30 at 3 27 28 PM" src="https://user-images.githubusercontent.com/45181984/144144336-d99a49ad-2b38-4e2c-9270-b3d2bf26a3cb.png">
.
