### PR TITLE
fix: make border configurable in form field

### DIFF
--- a/projects/components/src/form-field/form-field.component.scss
+++ b/projects/components/src/form-field/form-field.component.scss
@@ -32,10 +32,12 @@
   .content {
     flex: 1 1 auto;
     width: 100%;
-    border: 1px solid $gray-2;
-    border-radius: 6px;
-    width: 100%;
     background: white;
+
+    &.show-border {
+      border: 1px solid $gray-2;
+      border-radius: 6px;
+    }
 
     &.error-border {
       border: 1px solid $red-3;

--- a/projects/components/src/form-field/form-field.component.test.ts
+++ b/projects/components/src/form-field/form-field.component.test.ts
@@ -28,6 +28,10 @@ describe('Form Field Component', () => {
         }
       }
     );
+
+    expect(spectator.query('.content')).not.toHaveClass(['show-border', 'error-border']);
+    expect(spectator.query('.content')).toExist();
+
     const labels = spectator.queryAll(LabelComponent);
     expect(labels[0].label).toEqual('Label');
     expect(labels[1].label).toEqual('Error message');
@@ -55,19 +59,21 @@ describe('Form Field Component', () => {
     expect(labels[1].label).toEqual('(Optional)');
   });
 
-  test('should show error when showFormError and errorLabel is present', () => {
+  test('should show error when showFormError, errorLabel and showBorder is present', () => {
     const spectator = hostFactory(
       `
-    <ht-form-field [label]="label" [showFormError]="showFormError" [errorLabel]="errorLabel">
+    <ht-form-field [label]="label" [showFormError]="showFormError" [errorLabel]="errorLabel" [showBorder]="showBorder">
     </ht-form-field>`,
       {
         hostProps: {
           label: 'Label',
           errorLabel: 'Invalid Form element',
-          showFormError: true
+          showFormError: true,
+          showBorder: true
         }
       }
     );
+    expect(spectator.query('.content')).toHaveClass(['content', 'show-border', 'error-border']);
 
     expect(spectator.query('.error')).toExist();
 
@@ -81,5 +87,6 @@ describe('Form Field Component', () => {
     });
 
     expect(spectator.query('.error')).not.toExist();
+    expect(spectator.query('.content')).toHaveClass(['show-border']);
   });
 });

--- a/projects/components/src/form-field/form-field.component.ts
+++ b/projects/components/src/form-field/form-field.component.ts
@@ -19,7 +19,13 @@ import { IconSize } from '../icon/icon-size';
           [htTooltip]="this.iconTooltip"
         ></ht-icon>
       </div>
-      <div class="content" [ngClass]="{ 'error-border': this.showFormError && this.errorLabel }">
+      <div
+        class="content"
+        [ngClass]="{
+          'show-border': this.showBorder,
+          'error-border': this.showFormError && this.errorLabel
+        }"
+      >
         <ng-content></ng-content>
       </div>
       <!-- For Backward Compatibility: Start -->
@@ -55,6 +61,9 @@ export class FormFieldComponent {
 
   @Input()
   public errorLabel?: string = '';
+
+  @Input()
+  public showBorder: boolean = false;
 
   @Input()
   public showFormError?: boolean = true;


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
fix: make border configurable in form field
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
