### PR TITLE
Fix date picker timezone issue

### DIFF
--- a/projects/components/src/datetime-picker/datetime-picker.component.test.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.test.ts
@@ -1,15 +1,12 @@
 import { Time } from '@hypertrace/common';
+import { DatetimePickerComponent, InputComponent, LabelComponent, TimePickerComponent } from '@hypertrace/components';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
-import { InputComponent } from '../input/input.component';
-import { LabelComponent } from './../label/label.component';
-import { TimePickerComponent } from './../time-picker/time-picker.component';
-import { DatetimePickerComponent } from './datetime-picker.component';
 
 describe('Date Time Picker Component', () => {
   let spectator: SpectatorHost<DatetimePickerComponent>;
-  let onDateChangeSpy = jest.fn();
-  let initDate = new Date();
+  const onDateChangeSpy = jest.fn();
+  const initDate = new Date();
   const createHost = createHostFactory({
     component: DatetimePickerComponent,
     shallow: true,
@@ -74,7 +71,7 @@ describe('Date Time Picker Component', () => {
     ];
 
     validationSet.forEach(({ date, time, expected }) => {
-      spectator.setHostInput({ date });
+      spectator.setHostInput({ date: date });
       spectator.triggerEventHandler(TimePickerComponent, 'timeChange', time);
       const changedDate = new Date(date.valueOf());
       changedDate.setHours(time.hours, time.minutes);

--- a/projects/components/src/datetime-picker/datetime-picker.component.test.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.test.ts
@@ -50,22 +50,22 @@ describe('Date Time Picker Component', () => {
     const validationSet = [
       {
         date: new Date('2020-10-10'),
-        time: new Time(18, 10),
+        time: new Time(18, 10, 0, 0, true),
         expected: '2020-10-10'
       },
       {
         date: new Date('2020-1-1'),
-        time: new Time(0, 30),
+        time: new Time(0, 30, 0, 0, true),
         expected: '2020-01-01'
       },
       {
         date: new Date('2020-1-1'),
-        time: new Time(23, 59),
+        time: new Time(23, 59, 0, 0, true),
         expected: '2020-01-01'
       },
       {
         date: new Date('2020-1-1'),
-        time: new Time(0, 0),
+        time: new Time(0, 0, 0, 0, true),
         expected: '2020-01-01'
       }
     ];

--- a/projects/components/src/datetime-picker/datetime-picker.component.test.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.test.ts
@@ -8,34 +8,34 @@ import { DatetimePickerComponent } from './datetime-picker.component';
 
 describe('Date Time Picker Component', () => {
   let spectator: SpectatorHost<DatetimePickerComponent>;
-
+  let onDateChangeSpy = jest.fn();
+  let initDate = new Date();
   const createHost = createHostFactory({
     component: DatetimePickerComponent,
     shallow: true,
     declarations: [MockComponent(LabelComponent), MockComponent(InputComponent), MockComponent(TimePickerComponent)]
   });
 
-  test('should render all elements correctly', () => {
-    const onDateChangeSpy = jest.fn();
-    const date = new Date();
-
+  beforeEach(() => {
     spectator = createHost(
       `<ht-datetime-picker [date]="date" [showTimeTriggerIcon]="showTimeTriggerIcon" (dateChange)="onDateChange($event)"></ht-datetime-picker>`,
       {
         hostProps: {
-          date: date,
+          date: initDate,
           showTimeTriggerIcon: false,
           onDateChange: onDateChangeSpy
         }
       }
     );
+  });
 
+  test('should render all elements correctly', () => {
     expect(spectator.query(LabelComponent)).not.toExist();
-    expect(spectator.query(InputComponent)?.value).toEqual(date.toISOString().slice(0, 10));
+    expect(spectator.query(InputComponent)?.value).toEqual(initDate.toISOString().slice(0, 10));
 
     const timePicker = spectator.query(TimePickerComponent);
     expect(timePicker).toExist();
-    expect(timePicker?.time).toEqual(new Time(date.getHours(), date.getMinutes()));
+    expect(timePicker?.time).toEqual(new Time(initDate.getHours(), initDate.getMinutes()));
     expect(timePicker?.showTimeTriggerIcon).toEqual(false);
 
     spectator.triggerEventHandler(InputComponent, 'valueChange', '2020-10-10');
@@ -47,5 +47,39 @@ describe('Date Time Picker Component', () => {
     changedDate.setHours(changedTime.hours);
     changedDate.setMinutes(changedTime.minutes);
     expect(onDateChangeSpy).toHaveBeenCalledWith(changedDate);
+  });
+
+  test('date should not get effected when time is updated', () => {
+    const validationSet = [
+      {
+        date: new Date('2020-10-10'),
+        time: new Time(18, 10),
+        expected: '2020-10-10'
+      },
+      {
+        date: new Date('2020-1-1'),
+        time: new Time(0, 30),
+        expected: '2020-01-01'
+      },
+      {
+        date: new Date('2020-1-1'),
+        time: new Time(23, 59),
+        expected: '2020-01-01'
+      },
+      {
+        date: new Date('2020-1-1'),
+        time: new Time(0, 0),
+        expected: '2020-01-01'
+      }
+    ];
+
+    validationSet.forEach(({ date, time, expected }) => {
+      spectator.setHostInput({ date });
+      spectator.triggerEventHandler(TimePickerComponent, 'timeChange', time);
+      const changedDate = new Date(date.valueOf());
+      changedDate.setHours(time.hours, time.minutes);
+      expect(onDateChangeSpy).toHaveBeenCalledWith(changedDate);
+      expect(spectator.component.getInputDate()).toEqual(expected);
+    });
   });
 });

--- a/projects/components/src/datetime-picker/datetime-picker.component.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.ts
@@ -53,11 +53,14 @@ export class DatetimePickerComponent implements OnChanges {
   }
 
   public getInputDate(): string {
-    if (!this.date) return '';
+    if (!this.date) {
+      return '';
+    }
     const d = this.date;
     const YEAR = d.getFullYear();
     const MONTH = d.getMonth() + 1 > 9 ? d.getMonth() + 1 : `0${d.getMonth() + 1}`;
     const DATE = d.getDate() > 9 ? d.getDate() : `0${d.getDate()}`;
+
     return `${YEAR}-${MONTH}-${DATE}`;
   }
 

--- a/projects/components/src/datetime-picker/datetime-picker.component.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.ts
@@ -53,7 +53,9 @@ export class DatetimePickerComponent implements OnChanges {
   }
 
   public getInputDate(): string {
-    return this.date?.toISOString().slice(0, 10) ?? '';
+    if (!this.date) return '';
+    const d = this.date;
+    return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate() > 9 ? d.getDate() : `0${d.getDate()}`}`;
   }
 
   private getInputTime(date: Date): Time {

--- a/projects/components/src/datetime-picker/datetime-picker.component.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.ts
@@ -53,15 +53,7 @@ export class DatetimePickerComponent implements OnChanges {
   }
 
   public getInputDate(): string {
-    if (!this.date) {
-      return '';
-    }
-    const d = this.date;
-    const YEAR = d.getFullYear();
-    const MONTH = d.getMonth() + 1 > 9 ? d.getMonth() + 1 : `0${d.getMonth() + 1}`;
-    const DATE = d.getDate() > 9 ? d.getDate() : `0${d.getDate()}`;
-
-    return `${YEAR}-${MONTH}-${DATE}`;
+    return this.date?.toISOString().slice(0, 10) ?? '';
   }
 
   private getInputTime(date: Date): Time {
@@ -79,7 +71,7 @@ export class DatetimePickerComponent implements OnChanges {
 
   public onTimeChange(time: Time): void {
     this.time = time;
-    this.date?.setHours(time.hours, time.minutes, time.seconds, time.milliseconds);
+    this.date?.setUTCHours(time.hours, time.minutes, time.seconds, time.milliseconds);
     this.dateChange.emit(this.date);
   }
 }

--- a/projects/components/src/datetime-picker/datetime-picker.component.ts
+++ b/projects/components/src/datetime-picker/datetime-picker.component.ts
@@ -55,7 +55,10 @@ export class DatetimePickerComponent implements OnChanges {
   public getInputDate(): string {
     if (!this.date) return '';
     const d = this.date;
-    return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate() > 9 ? d.getDate() : `0${d.getDate()}`}`;
+    const YEAR = d.getFullYear();
+    const MONTH = d.getMonth() + 1 > 9 ? d.getMonth() + 1 : `0${d.getMonth() + 1}`;
+    const DATE = d.getDate() > 9 ? d.getDate() : `0${d.getDate()}`;
+    return `${YEAR}-${MONTH}-${DATE}`;
   }
 
   private getInputTime(date: Date): Time {

--- a/projects/components/src/time-range/predefined-time.service.ts
+++ b/projects/components/src/time-range/predefined-time.service.ts
@@ -16,8 +16,8 @@ export class PredefinedTimeService {
 
     for (let hour = 0; hour < 24; hour++) {
       // Could have an inner loop here, but this seems fine.
-      times.push(new Time(hour, 0));
-      times.push(new Time(hour, 30));
+      times.push(new Time(hour, 0, 0, 0, true));
+      times.push(new Time(hour, 30, 0, 0, true));
     }
 
     return times;


### PR DESCRIPTION
## Description
Updating the time sometimes changes the date due to timezone issues. The date string was constructed using `toISOString()` method which uses the UTC timezone as seen:

```ts
const date = new Date();  // Thu Dec 09 2021 23:25:27 GMT+0530 (India Standard Time)
date.toISOString(); // 2021-12-09T17:55:27.051Z
```
So if the timeframe is in the range of the user's timezone, the date can change
![timezone](https://user-images.githubusercontent.com/29002760/145451119-4b88ac50-f236-404e-b2e0-ed4c9432d2b7.png)

This PR fixes the issue by replacing the `toISOString()` method for getting the date value.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

