### PR TITLE
fix: pull applied filter logic into table controls so consumer doesn't have to manage

### DIFF
--- a/projects/components/src/table/controls/table-controls.component.ts
+++ b/projects/components/src/table/controls/table-controls.component.ts
@@ -238,11 +238,19 @@ export class TableControlsComponent implements OnChanges {
   }
 
   public onMultiSelectChange(selectControl: TableSelectControl, selections: TableSelectControlOption[]): void {
+    this.applySelections(selectControl, selections);
+
     this.selectChange.emit({
       select: selectControl,
       values: selections
     });
     this.diffSelections();
+  }
+
+  private applySelections(selectControl: TableSelectControl, selections: TableSelectControlOption[]): void {
+    selectControl.options.forEach(
+      option => (option.applied = selections.find(selection => isEqual(selection, option)) !== undefined)
+    );
   }
 
   public onSelectChange(selectControl: TableSelectControl, selection: TableSelectControlOption): void {


### PR DESCRIPTION
The logic to apply the filter selections has been left to the consumer of the table control header. This is not intuitive and is often forgotten so pulling that code into the table control component.

Spot tested this on a few table pages and found no issues. Any logic on the consumer side is now redundant, but should have no side effects.