### PR TITLE
Fix: corrected nested styling for `titled-content` component's footer

### DIFF
--- a/projects/components/src/titled-content/titled-content.component.scss
+++ b/projects/components/src/titled-content/titled-content.component.scss
@@ -71,14 +71,14 @@
   .footer {
     .title {
       margin-top: 8px;
-    }
 
-    &.regular {
-      @include overline($gray-4);
-    }
+      &.regular {
+        @include overline($gray-4);
+      }
 
-    &.grayed-out {
-      @include overline($gray-5);
+      &.grayed-out {
+        @include overline($gray-5);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
Addresses the issue referenced in https://github.com/hypertrace/hypertrace-ui/issues/1298.
The current styling file had the `regular` and other corresponding classes outside of `footer`.
Moved those inside of `footer` to correct the styling.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules