### PR TITLE
Bugfix: Prevent empty `LIKE` clause for search parameters

### DIFF
--- a/projects/observability/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -470,12 +470,18 @@ export class TableWidgetRendererComponent
   }
 
   public onSearchChange(text: string): void {
-    const searchFilter: TableFilter = {
-      field: this.api.model.getSearchAttribute()!,
-      operator: FilterOperator.Like,
-      value: text
-    };
-    this.searchFilterSubject.next([searchFilter]);
+    let searchFilters: TableFilter[] = [];
+    // In case of empty string, avoid sending LIKE operator with empty value
+    if (isNonEmptyString(text)) {
+      searchFilters = [
+        {
+          field: this.api.model.getSearchAttribute()!,
+          operator: FilterOperator.Like,
+          value: text
+        }
+      ];
+    }
+    this.searchFilterSubject.next(searchFilters);
   }
 
   public onViewChange(view: string): void {


### PR DESCRIPTION
Fixes hypertrace/hypertrace-ui#1344

## Description
- Currently when a typed search parameter is cleared out, an `""` is sent as a parameter in the GraphQL query as referenced in https://github.com/hypertrace/hypertrace-ui/issues/1344.
- This PR checks in case the search parameter is empty and avoids sending an empty `LIKE` parameter.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules