### PR TITLE
feat: providing functionality to use else template in if feature directive

### DIFF
--- a/projects/components/src/feature-check/if-feature.directive.test.ts
+++ b/projects/components/src/feature-check/if-feature.directive.test.ts
@@ -9,25 +9,39 @@ describe('If feature directive', () => {
   });
 
   const getTestDiv = () => spectator.query('.test-div');
+  const getElseDiv = () => spectator.query('.else-div');
 
   beforeEach(() => {
-    spectator = createHost(`<div class="test-div" *htIfFeature="state as featureState">{{featureState}}</div>`);
+    spectator = createHost(
+      `
+      <ng-container *htIfFeature="state as featureState; else elseTemplate">
+        <div class="test-div">{{featureState}}</div>
+      </ng-container>
+      <ng-template #elseTemplate>
+        <div class="else-div">Else template</div>
+      </ng-template>
+      `
+    );
   });
 
-  test('does not render template if feature disabled', () => {
+  test('does not render template if feature disabled and renders else template if present', () => {
     spectator.setHostInput({
       state: FeatureState.Disabled
     });
     expect(getTestDiv()).not.toExist();
+    expect(getElseDiv()).toExist();
+
     spectator.setHostInput({
       state: FeatureState.Enabled
     });
-
     expect(getTestDiv()).toExist();
+    expect(getElseDiv()).not.toExist();
+
     spectator.setHostInput({
       state: FeatureState.Disabled
     });
     expect(getTestDiv()).not.toExist();
+    expect(getElseDiv()).toExist();
   });
 
   test('provides feature state variable in context when rendered', () => {
@@ -40,9 +54,15 @@ describe('If feature directive', () => {
       state: FeatureState.Preview
     });
     expect(getTestDiv()).toHaveText(FeatureState.Preview);
+
+    spectator.setHostInput({
+      state: FeatureState.Disabled
+    });
+    expect(getElseDiv()).toHaveText('Else template');
   });
 });
 
 interface IfFeatureHost {
   state?: FeatureState;
 }
+//

--- a/projects/components/src/feature-check/if-feature.directive.ts
+++ b/projects/components/src/feature-check/if-feature.directive.ts
@@ -9,7 +9,11 @@ export class IfFeatureDirective implements OnChanges {
   @Input('htIfFeature')
   public featureState?: FeatureState;
 
-  private embeddedViewRef?: EmbeddedViewRef<FeatureFlagsContext>;
+  // tslint:disable-next-line:no-input-rename
+  @Input('htIfFeatureElse')
+  public else?: TemplateRef<unknown>;
+
+  private embeddedViewRef?: EmbeddedViewRef<FeatureFlagsContext | unknown>;
   private readonly context: FeatureFlagsContext = {
     htIfFeature: FeatureState.Disabled,
     $implicit: FeatureState.Disabled
@@ -28,8 +32,12 @@ export class IfFeatureDirective implements OnChanges {
     this.context.$implicit = state;
     this.context.htIfFeature = state;
     if (state === FeatureState.Disabled) {
-      // If shouldn't be rendered, destroy if exists
-      this.clearView();
+      if (!isNil(this.else)) {
+        this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.else);
+      } else {
+        // If shouldn't be rendered, destroy if exists
+        this.clearView();
+      }
     } else if (!this.embeddedViewRef) {
       // Should be rendered but isnt
       this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.templateRef, this.context);

--- a/projects/components/src/feature-check/if-feature.directive.ts
+++ b/projects/components/src/feature-check/if-feature.directive.ts
@@ -10,8 +10,8 @@ export class IfFeatureDirective implements OnChanges {
   public featureState?: FeatureState;
 
   // tslint:disable-next-line:no-input-rename
-  @Input('htIfFeatureElse')
-  public else?: TemplateRef<unknown>;
+  @Input('htIfFeatureElseContent')
+  public elseContent?: TemplateRef<unknown>;
 
   private embeddedViewRef?: EmbeddedViewRef<FeatureFlagsContext | unknown>;
   private readonly context: FeatureFlagsContext = {
@@ -32,8 +32,8 @@ export class IfFeatureDirective implements OnChanges {
     this.context.$implicit = state;
     this.context.htIfFeature = state;
     if (state === FeatureState.Disabled) {
-      if (!isNil(this.else)) {
-        this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.else);
+      if (!isNil(this.elseContent)) {
+        this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.elseContent);
       } else {
         // If shouldn't be rendered, destroy if exists
         this.clearView();

--- a/projects/components/src/feature-check/if-feature.directive.ts
+++ b/projects/components/src/feature-check/if-feature.directive.ts
@@ -10,7 +10,7 @@ export class IfFeatureDirective implements OnChanges {
   public featureState?: FeatureState;
 
   // tslint:disable-next-line:no-input-rename
-  @Input('htIfFeatureElseContent')
+  @Input('htIfFeatureElse')
   public elseContent?: TemplateRef<unknown>;
 
   private embeddedViewRef?: EmbeddedViewRef<FeatureFlagsContext | unknown>;

--- a/projects/components/src/feature-check/if-feature.directive.ts
+++ b/projects/components/src/feature-check/if-feature.directive.ts
@@ -31,22 +31,15 @@ export class IfFeatureDirective implements OnChanges {
   private updateView(state: FeatureState): void {
     this.context.$implicit = state;
     this.context.htIfFeature = state;
+    this.clearView();
     if (state === FeatureState.Disabled) {
       if (!isNil(this.elseContent)) {
         this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.elseContent);
-      } else {
-        // If shouldn't be rendered, destroy if exists
-        this.clearView();
       }
     } else {
-      if (!this.embeddedViewRef) {
-        // Should be rendered but isnt
-        this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.templateRef, this.context);
-      } else {
-        // Already rendered, just update
-        this.embeddedViewRef.markForCheck();
-      }
+      this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.templateRef, this.context);
     }
+    this.embeddedViewRef?.markForCheck();
   }
 
   private clearView(): void {

--- a/projects/components/src/feature-check/if-feature.directive.ts
+++ b/projects/components/src/feature-check/if-feature.directive.ts
@@ -38,12 +38,14 @@ export class IfFeatureDirective implements OnChanges {
         // If shouldn't be rendered, destroy if exists
         this.clearView();
       }
-    } else if (!this.embeddedViewRef) {
-      // Should be rendered but isnt
-      this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.templateRef, this.context);
     } else {
-      // Already rendered, just update
-      this.embeddedViewRef.markForCheck();
+      if (!this.embeddedViewRef) {
+        // Should be rendered but isnt
+        this.embeddedViewRef = this.viewContainer.createEmbeddedView(this.templateRef, this.context);
+      } else {
+        // Already rendered, just update
+        this.embeddedViewRef.markForCheck();
+      }
     }
   }
 


### PR DESCRIPTION
## Description
After this, will be able to provide else template for `*htIfFeature`, similar to `*ngIf`
Example
```
<ng-container *htIfFeature="state as featureState; else elseTemplate">
  <div class="test-div">{{featureState}}</div>
</ng-container>
<ng-template #elseTemplate>
  <div class="else-div">Else template</div>
</ng-template>
```


### Testing
Manual testing done.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
