### PR TITLE
style: add overflow for navigation list

### DIFF
--- a/projects/components/src/navigation/navigation-list.component.scss
+++ b/projects/components/src/navigation/navigation-list.component.scss
@@ -10,6 +10,7 @@
   height: 100%;
   width: 100%;
   justify-content: space-between;
+  overflow-y: auto;
 
   .content {
     .nav-header {


### PR DESCRIPTION
## Description
There was no scroll when the navigation list height exceeds the viewport height. This PR fixes the issue by adding a
`overflow-y` style prop for the navigation list.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
