### PR TITLE
refactor: adding filters and make largest auto value as default

### DIFF
--- a/projects/common/src/time/interval-duration.service.ts
+++ b/projects/common/src/time/interval-duration.service.ts
@@ -71,7 +71,8 @@ export class IntervalDurationService {
       throw Error('No intervals supported at requested time range');
     }
 
-    return durations[0];
+    // Get largest supported duration
+    return durations[durations.length - 1];
   }
 
   private getAvailableIntervals(timeRange: TimeRange, minDataPoints: number, maxDataPoints: number): TimeDuration[] {

--- a/projects/observability/src/shared/dashboard/data/graphql/trace/trace-series-values-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/trace/trace-series-values-data-source.model.ts
@@ -1,3 +1,4 @@
+import { GraphQlFilter } from './../../../../graphql/model/schema/filter/graphql-filter';
 import { TimeDuration } from '@hypertrace/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -15,17 +16,18 @@ export abstract class TraceSeriesValuesDataSourceModel<TData> extends GraphQlDat
   protected abstract specification: ExploreSpecification;
 
   protected fetchSpecificationData(interval: TimeDuration): Observable<GraphQlExploreResult[]> {
-    return this.query<ExploreGraphQlQueryHandlerService>(() => this.buildRequest(interval)).pipe(
-      map(response => response.results)
-    );
+    return this.query<ExploreGraphQlQueryHandlerService>(inheritedFilters =>
+      this.buildRequest(interval, inheritedFilters)
+    ).pipe(map(response => response.results));
   }
 
-  private buildRequest(interval: TimeDuration): GraphQlExploreRequest {
+  private buildRequest(interval: TimeDuration, inheritedFilters: GraphQlFilter[] = []): GraphQlExploreRequest {
     return {
       requestType: EXPLORE_GQL_REQUEST,
       timeRange: this.getTimeRangeOrThrow(),
       context: ObservabilityTraceType.Api,
       interval: interval,
+      filters: [...inheritedFilters],
       limit: 10000,
       selections: [this.specification]
     };


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
refactor: adding filters and make largest auto value as default
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
