### PR TITLE
fix: parser should only match full filter keys

### DIFF
--- a/projects/components/src/filtering/filter/parser/parsed-filter.test.ts
+++ b/projects/components/src/filtering/filter/parser/parsed-filter.test.ts
@@ -1,0 +1,45 @@
+import { FilterAttribute } from '../filter-attribute';
+import { FilterAttributeType } from '../filter-attribute-type';
+import { tryParseStringForAttribute } from './parsed-filter';
+
+describe('Filter Parsing utilities', () => {
+  const testStatusAttribute: FilterAttribute = {
+    name: 'status',
+    displayName: 'Status',
+    type: FilterAttributeType.String
+  };
+
+  const testStatusCodeAttribute: FilterAttribute = {
+    name: 'statusCode',
+    displayName: 'Status Code',
+    type: FilterAttributeType.String
+  };
+
+  test('should match if full name match', () => {
+    expect(tryParseStringForAttribute(testStatusAttribute, 'status', ['name'])).toEqual({
+      attribute: testStatusAttribute
+    });
+
+    expect(tryParseStringForAttribute(testStatusAttribute, 'status ', ['name'])).toEqual({
+      attribute: testStatusAttribute
+    });
+
+    expect(tryParseStringForAttribute(testStatusCodeAttribute, 'statusCode', ['name'])).toEqual({
+      attribute: testStatusCodeAttribute
+    });
+  });
+
+  test('should match if followed by beginning of operator', () => {
+    expect(tryParseStringForAttribute(testStatusAttribute, 'status !', ['name'])).toEqual({
+      attribute: testStatusAttribute
+    });
+  });
+
+  test('should not match if partial name match', () => {
+    expect(tryParseStringForAttribute(testStatusCodeAttribute, 'status', ['name'])).toBe(undefined);
+  });
+
+  test('should not match if text starts with attribute name and continues', () => {
+    expect(tryParseStringForAttribute(testStatusAttribute, 'statusCode', ['name'])).toBe(undefined);
+  });
+});

--- a/projects/components/src/filtering/filter/parser/parsed-filter.ts
+++ b/projects/components/src/filtering/filter/parser/parsed-filter.ts
@@ -62,6 +62,11 @@ export const tryParseStringForAttribute = (
   // Now, we know that it does match. Remove the attribute name from the beginning and try to determine the subpath next.
   const stringAfterAttributeName = text.slice(attributeToTest[matchingNameField].length).trim();
 
+  // If the string continues with more alphanumeric characters directly after this attribute name, it's no longer a match
+  if (stringAfterAttributeName.match(/^\w/)) {
+    return undefined;
+  }
+
   if (stringAfterAttributeName.startsWith(MAP_LHS_DELIMITER)) {
     if (attributeToTest.type !== FilterAttributeType.StringMap) {
       // Can't have a subpath if not a map


### PR DESCRIPTION
## Description
This fixes the parsing of an attribute whose name is a superset of another attribute's name (e.g. `attrName` and `attrNameOther`). Because the parser is also meant to support cases like `attrName !` where an attribute name is followed by more characters that will eventually become an operator, it previously discarded any extra characters after a successful match. Now, we update it to ensure the following character is non alphanumeric (and thus is not a continuation of the key name). This will allow spaces, partial operators etc. but prevent a match of a different key.

### Testing
Both E2E and new/existing unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

