### PR TITLE
fix(bug): brush should not be there for cartesian chart if there is no selection handler

### DIFF
--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
@@ -105,7 +105,7 @@ export class CartesianChartComponent<TData> implements OnChanges, OnDestroy {
         )
       );
 
-    if (this.isSelectionHandlerAvailable) {
+    if (this. isRangeSelectionEnabled) {
       this.chart.withEventListener(ChartEvent.Select, selectedData => {
         this.selectionChange.emit(selectedData);
       });

--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
@@ -58,7 +58,7 @@ export class CartesianChartComponent<TData> implements OnChanges, OnDestroy {
   public timeRange?: TimeRange;
 
   @Input()
-  public isRangeSelectionEnabled: boolean = false;
+  public rangeSelectionEnabled: boolean = false;
 
   @Input()
   public intervalOptions?: IntervalValue[];

--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
@@ -105,7 +105,7 @@ export class CartesianChartComponent<TData> implements OnChanges, OnDestroy {
         )
       );
 
-    if (this. isRangeSelectionEnabled) {
+    if (this.isRangeSelectionEnabled) {
       this.chart.withEventListener(ChartEvent.Select, selectedData => {
         this.selectionChange.emit(selectedData);
       });

--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
@@ -105,7 +105,7 @@ export class CartesianChartComponent<TData> implements OnChanges, OnDestroy {
         )
       );
 
-    if (this.isRangeSelectionEnabled) {
+    if (this.rangeSelectionEnabled) {
       this.chart.withEventListener(ChartEvent.Select, selectedData => {
         this.selectionChange.emit(selectedData);
       });

--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
@@ -58,6 +58,9 @@ export class CartesianChartComponent<TData> implements OnChanges, OnDestroy {
   public timeRange?: TimeRange;
 
   @Input()
+  public isSelectionHandlerAvailable: boolean = false;
+
+  @Input()
   public intervalOptions?: IntervalValue[];
 
   @Input()
@@ -100,10 +103,13 @@ export class CartesianChartComponent<TData> implements OnChanges, OnDestroy {
         this.chartTooltipBuilderService.constructTooltip<TData, Series<TData>>(data =>
           this.convertToDefaultTooltipRenderData(data)
         )
-      )
-      .withEventListener(ChartEvent.Select, selectedData => {
+      );
+
+    if (this.isSelectionHandlerAvailable) {
+      this.chart.withEventListener(ChartEvent.Select, selectedData => {
         this.selectionChange.emit(selectedData);
       });
+    }
 
     if (this.bands) {
       this.chart.withBands(...this.bands);

--- a/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
+++ b/projects/observability/src/shared/components/cartesian/cartesian-chart.component.ts
@@ -58,7 +58,7 @@ export class CartesianChartComponent<TData> implements OnChanges, OnDestroy {
   public timeRange?: TimeRange;
 
   @Input()
-  public isSelectionHandlerAvailable: boolean = false;
+  public isRangeSelectionEnabled: boolean = false;
 
   @Input()
   public intervalOptions?: IntervalValue[];

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
@@ -27,7 +27,7 @@ import { CartesianDataFetcher, CartesianResult, CartesianWidgetModel } from './c
         [showXAxis]="this.model.showXAxis"
         [showYAxis]="this.model.showYAxis"
         [timeRange]="this.timeRange"
-        [isSelectionHandlerAvailable]="!!this.model.selectionHandler"
+        [isRangeSelectionEnabled]="!!this.model.selectionHandler"
         [selectedInterval]="this.selectedInterval"
         [intervalOptions]="this.intervalOptions"
         [legend]="this.model.legendPosition"

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
@@ -27,7 +27,7 @@ import { CartesianDataFetcher, CartesianResult, CartesianWidgetModel } from './c
         [showXAxis]="this.model.showXAxis"
         [showYAxis]="this.model.showYAxis"
         [timeRange]="this.timeRange"
-        [isRangeSelectionEnabled]="!!this.model.selectionHandler"
+        [rangeSelectionEnabled]="!!this.model.selectionHandler"
         [selectedInterval]="this.selectedInterval"
         [intervalOptions]="this.intervalOptions"
         [legend]="this.model.legendPosition"

--- a/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/charts/cartesian-widget/cartesian-widget-renderer.component.ts
@@ -27,6 +27,7 @@ import { CartesianDataFetcher, CartesianResult, CartesianWidgetModel } from './c
         [showXAxis]="this.model.showXAxis"
         [showYAxis]="this.model.showYAxis"
         [timeRange]="this.timeRange"
+        [isSelectionHandlerAvailable]="!!this.model.selectionHandler"
         [selectedInterval]="this.selectedInterval"
         [intervalOptions]="this.intervalOptions"
         [legend]="this.model.legendPosition"


### PR DESCRIPTION
## Description
fix(bug): brush should not be there for cartesian chart if there is no selection handler

### Testing
Local testing done.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules