### PR TITLE
Remove 2 week & 1 month options from time range

### DIFF
--- a/projects/components/src/time-range/predefined-time-duration.service.ts
+++ b/projects/components/src/time-range/predefined-time-duration.service.ts
@@ -22,9 +22,7 @@ export class PredefinedTimeDurationService {
       new TimeDuration(12, TimeUnit.Hour),
       new TimeDuration(1, TimeUnit.Day),
       new TimeDuration(3, TimeUnit.Day),
-      new TimeDuration(1, TimeUnit.Week),
-      new TimeDuration(2, TimeUnit.Week),
-      new TimeDuration(1, TimeUnit.Month)
+      new TimeDuration(1, TimeUnit.Week)
     ];
   }
 


### PR DESCRIPTION
## Description
Remove 2 week & 1 month options from the predefined time range selection for better backend performance. 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
