### PR TITLE
Feat/checkbox control value accessor

### DIFF
--- a/projects/components/src/checkbox/checkbox.component.test.ts
+++ b/projects/components/src/checkbox/checkbox.component.test.ts
@@ -1,4 +1,5 @@
 import { fakeAsync } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { createHostFactory, Spectator } from '@ngneat/spectator/jest';
 import { CheckboxComponent } from './checkbox.component';
@@ -9,7 +10,7 @@ describe('Checkbox component', () => {
 
   const createHost = createHostFactory({
     component: CheckboxComponent,
-    imports: [TraceCheckboxModule, RouterTestingModule],
+    imports: [TraceCheckboxModule, RouterTestingModule, ReactiveFormsModule],
     providers: [],
     declareComponent: false
   });
@@ -52,12 +53,32 @@ describe('Checkbox component', () => {
 
     // Click will toggle the values to true
     spectator.click(inputElement);
-    expect(spectator.component.checked).toBe(true);
+    expect(spectator.component.isChecked).toBe(true);
     expect(checkboxChangeSpy).toHaveBeenCalledWith(true);
 
     // Click will toggle the values to false
     spectator.click(inputElement);
-    expect(spectator.component.checked).toBe(false);
+    expect(spectator.component.isChecked).toBe(false);
     expect(checkboxChangeSpy).toHaveBeenCalledWith(false);
   }));
+
+  test('should work correctly with control value accessor', () => {
+    const formControl = new FormControl(false);
+    spectator = createHost(
+      `<ht-checkbox [label]="label" [formControl]="formControl">
+    </ht-checkbox>`,
+      {
+        hostProps: {
+          formControl: formControl
+        }
+      }
+    );
+    expect(spectator.component.isChecked).toBe(false);
+
+    formControl.setValue(true);
+    expect(spectator.component.isChecked).toBe(true);
+
+    formControl.disable();
+    expect(spectator.component.isDisabled).toBe(true);
+  });
 });

--- a/projects/components/src/checkbox/checkbox.component.ts
+++ b/projects/components/src/checkbox/checkbox.component.ts
@@ -43,6 +43,10 @@ export class CheckboxComponent implements ControlValueAccessor {
   @Output()
   public readonly checkedChange: EventEmitter<boolean> = new EventEmitter();
 
+  public get checked(): boolean {
+    return this.isChecked;
+  }
+
   public isChecked: boolean = false;
   public isDisabled: boolean = false;
 

--- a/projects/components/src/checkbox/checkbox.component.ts
+++ b/projects/components/src/checkbox/checkbox.component.ts
@@ -47,6 +47,10 @@ export class CheckboxComponent implements ControlValueAccessor {
     return this.isChecked;
   }
 
+  public get disabled(): boolean {
+    return this.isDisabled;
+  }
+
   public isChecked: boolean = false;
   public isDisabled: boolean = false;
 

--- a/projects/components/src/checkbox/checkbox.component.ts
+++ b/projects/components/src/checkbox/checkbox.component.ts
@@ -68,7 +68,7 @@ export class CheckboxComponent implements ControlValueAccessor {
     this.isDisabled = isDisabled;
   }
 
-  public writeValue(isChecked: boolean): void {
-    this.isChecked = isChecked;
+  public writeValue(isChecked: boolean | undefined): void {
+    this.isChecked = isChecked ?? false;
   }
 }

--- a/projects/components/src/checkbox/checkbox.component.ts
+++ b/projects/components/src/checkbox/checkbox.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 
@@ -49,6 +49,8 @@ export class CheckboxComponent implements ControlValueAccessor {
   private onTouched!: () => void;
   private onChanged!: (value: boolean) => void;
 
+  public constructor(private readonly cdr: ChangeDetectorRef) {}
+
   public onCheckboxChange(event: MatCheckboxChange): void {
     this.isChecked = event.checked;
     this.checkedChange.emit(this.isChecked);
@@ -66,9 +68,11 @@ export class CheckboxComponent implements ControlValueAccessor {
 
   public setDisabledState(isDisabled: boolean): void {
     this.isDisabled = isDisabled;
+    this.cdr.markForCheck();
   }
 
   public writeValue(isChecked: boolean | undefined): void {
     this.isChecked = isChecked ?? false;
+    this.cdr.markForCheck();
   }
 }

--- a/projects/components/src/checkbox/checkbox.component.ts
+++ b/projects/components/src/checkbox/checkbox.component.ts
@@ -35,21 +35,21 @@ export class CheckboxComponent implements ControlValueAccessor {
     this.isChecked = checked ?? false;
   }
 
+  public get checked(): boolean {
+    return this.isChecked;
+  }
+
   @Input()
   public set disabled(disabled: boolean | undefined) {
     this.isDisabled = disabled ?? false;
   }
 
-  @Output()
-  public readonly checkedChange: EventEmitter<boolean> = new EventEmitter();
-
-  public get checked(): boolean {
-    return this.isChecked;
-  }
-
   public get disabled(): boolean {
     return this.isDisabled;
   }
+
+  @Output()
+  public readonly checkedChange: EventEmitter<boolean> = new EventEmitter();
 
   public isChecked: boolean = false;
   public isDisabled: boolean = false;

--- a/projects/components/src/checkbox/checkbox.component.ts
+++ b/projects/components/src/checkbox/checkbox.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 
 @Component({
@@ -8,31 +9,66 @@ import { MatCheckboxChange } from '@angular/material/checkbox';
   template: `
     <mat-checkbox
       labelPosition="after"
-      [checked]="this.checked"
-      [disabled]="this.disabled"
-      (change)="onCheckboxChange($event)"
+      [checked]="this.isChecked"
+      [disabled]="this.isDisabled"
+      (change)="this.onCheckboxChange($event)"
       class="ht-checkbox"
-      [ngClass]="{ disabled: this.disabled }"
+      [ngClass]="{ disabled: this.isDisabled }"
     >
       <ht-label class="label" *ngIf="this.label !== undefined && this.label !== ''" [label]="this.label"></ht-label>
     </mat-checkbox>
-  `
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: CheckboxComponent,
+      multi: true
+    }
+  ]
 })
-export class CheckboxComponent {
+export class CheckboxComponent implements ControlValueAccessor {
   @Input()
   public label?: string;
 
   @Input()
-  public checked: boolean | undefined;
+  public set checked(checked: boolean | undefined) {
+    this.isChecked = checked ?? false;
+  }
 
   @Input()
-  public disabled: boolean | undefined;
+  public set disabled(disabled: boolean | undefined) {
+    this.isDisabled = disabled ?? false;
+  }
 
   @Output()
   public readonly checkedChange: EventEmitter<boolean> = new EventEmitter();
 
+  public isChecked: boolean = false;
+  public isDisabled: boolean = false;
+
+  private onTouched: () => void = () => {};
+  private onChanged: (value: boolean) => void = () => {};
+
   public onCheckboxChange(event: MatCheckboxChange): void {
-    this.checked = event.checked;
-    this.checkedChange.emit(this.checked);
+    this.isChecked = event.checked;
+    this.checkedChange.emit(this.isChecked);
+    this.onChanged(this.isChecked);
+    this.onTouched();
+  }
+
+  public registerOnChange(fn: any): void {
+    this.onChanged = fn;
+  }
+
+  public registerOnTouched(fn: any): void {
+    this.onTouched = fn;
+  }
+
+  public setDisabledState(isDisabled: boolean): void {
+    this.isDisabled = isDisabled;
+  }
+
+  public writeValue(isChecked: boolean): void {
+    this.isChecked = isChecked;
   }
 }

--- a/projects/components/src/checkbox/checkbox.component.ts
+++ b/projects/components/src/checkbox/checkbox.component.ts
@@ -46,8 +46,8 @@ export class CheckboxComponent implements ControlValueAccessor {
   public isChecked: boolean = false;
   public isDisabled: boolean = false;
 
-  private onTouched: () => void = () => {};
-  private onChanged: (value: boolean) => void = () => {};
+  private onTouched!: () => void;
+  private onChanged!: (value: boolean) => void;
 
   public onCheckboxChange(event: MatCheckboxChange): void {
     this.isChecked = event.checked;
@@ -56,11 +56,11 @@ export class CheckboxComponent implements ControlValueAccessor {
     this.onTouched();
   }
 
-  public registerOnChange(fn: any): void {
+  public registerOnChange(fn: (value: boolean) => void): void {
     this.onChanged = fn;
   }
 
-  public registerOnTouched(fn: any): void {
+  public registerOnTouched(fn: () => void): void {
     this.onTouched = fn;
   }
 


### PR DESCRIPTION
## Description
Checkboxes were not working with the Forms API before. With the implementation of Control Value Accessor, the checkbox can be used with Angular Forms API.

### Testing
Tests have been added to check the working with `formControl`

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
