### PR TITLE
fix(group-by): fixing error while changing the group by from a key to none

### DIFF
--- a/projects/observability/src/shared/components/explore-query-editor/group-by/explore-query-group-by-editor.component.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/group-by/explore-query-group-by-editor.component.ts
@@ -83,7 +83,7 @@ export class ExploreQueryGroupByEditorComponent implements OnChanges {
       .pipe(
         filter(expression => this.isValidExpressionToEmit(expression)),
         debounceTime(500),
-        map(expression => omit(expression, 'metadata'))
+        map(expression => (isEmpty(expression) ? undefined : omit(expression, 'metadata')))
       )
       .subscribe(this.groupByExpressionChange);
   }


### PR DESCRIPTION
## Description
Whenever we go from group by [any key] to None, query errors out, it is due to `omit(undefined, 'metadata')`
Since this return an empty object and we are only handling `undefined` value

### Testing
Local testing done.

### Checklist:
- [x] My changes generate no new warnings