### PR TITLE
fix: setting filterable to true for string array

### DIFF
--- a/projects/observability/src/shared/dashboard/widgets/table/services/table-widget-column.service.test.ts
+++ b/projects/observability/src/shared/dashboard/widgets/table/services/table-widget-column.service.test.ts
@@ -61,7 +61,7 @@ describe('Table Widget Column service', () => {
             alignment: 'left',
             display: 'text',
             editable: true,
-            filterable: false,
+            filterable: true,
             id: 'stringArrayAttribute',
             name: 'stringArrayAttribute',
             specification: expect.objectContaining({


### PR DESCRIPTION
fix: setting filterable to true for string array
- The string array is a new filter that we started supporting

## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
