### PR TITLE
Added RudderStack Telemetry Provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "lodash-es": "^4.17.21",
         "mixpanel-browser": "^2.45.0",
         "ngx-color": "7.0.0",
+        "rudder-sdk-js": "^2.3.0",
         "rxjs": "~6.6.7",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2",
@@ -26226,6 +26227,11 @@
         "node": "6.* || >= 7.*"
       }
     },
+    "node_modules/rudder-sdk-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.3.0.tgz",
+      "integrity": "sha512-xGMj4hthuI26N2JNl8NdJxXfTOnriZ3mlzv2ohwWP7XvZWBcQlaZP6R1MFUbTVVMNPi0lxcc3+VaxcdXdf4Rwg=="
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -50918,6 +50924,11 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
+    },
+    "rudder-sdk-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-2.3.0.tgz",
+      "integrity": "sha512-xGMj4hthuI26N2JNl8NdJxXfTOnriZ3mlzv2ohwWP7XvZWBcQlaZP6R1MFUbTVVMNPi0lxcc3+VaxcdXdf4Rwg=="
     },
     "run-async": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lodash-es": "^4.17.21",
     "mixpanel-browser": "^2.45.0",
     "ngx-color": "7.0.0",
+    "rudder-sdk-js": "^2.3.0",
     "rxjs": "~6.6.7",
     "tslib": "^2.3.1",
     "uuid": "^8.3.2",

--- a/projects/common/package.json
+++ b/projects/common/package.json
@@ -22,7 +22,8 @@
     "d3-interpolate": "^2.0.1",
     "d3-color": "^1.4.0",
     "@fullstory/browser": "^1.4.9",
-    "mixpanel-browser": "^2.41.0"
+    "mixpanel-browser": "^2.41.0",
+    "rudder-sdk-js": "^2.3.0"
   },
   "devDependencies": {
     "@hypertrace/test-utils": "^0.0.0"

--- a/projects/common/src/public-api.ts
+++ b/projects/common/src/public-api.ts
@@ -107,6 +107,7 @@ export * from './telemetry/telemetry';
 export { FullStoryTelemetry } from './telemetry/providers/fullstory/full-story-provider';
 export { FreshPaintTelemetry } from './telemetry/providers/freshpaint/freshpaint-provider';
 export { MixPanelTelemetry } from './telemetry/providers/mixpanel/mixpanel-provider';
+export { RudderStackTelemetry } from './telemetry/providers/rudderstack/rudderstack-provider';
 export { TrackDirective } from './telemetry/track/track.directive';
 
 // Time

--- a/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
+++ b/projects/common/src/telemetry/providers/rudderstack/rudderstack-provider.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Dictionary } from '../../../utilities/types/types';
+
+import * as rudderanalytics from 'rudder-sdk-js';
+import { TelemetryProviderConfig, UserTelemetryProvider, UserTraits } from '../../telemetry';
+
+@Injectable({ providedIn: 'root' })
+export class RudderStackTelemetry<InitConfig extends TelemetryProviderConfig>
+  implements UserTelemetryProvider<InitConfig> {
+  public initialize(config: InitConfig): void {
+    rudderanalytics.load(config.orgId, config.orgTrackingURL!);
+  }
+
+  public identify(userTraits: UserTraits): void {
+    rudderanalytics.identify(undefined, userTraits as rudderanalytics.apiObject);
+  }
+
+  public trackEvent(name: string, eventData: Dictionary<unknown>): void {
+    rudderanalytics.track(name, eventData as rudderanalytics.apiObject);
+  }
+
+  public trackPage(name: string, eventData: Dictionary<unknown>): void {
+    rudderanalytics.page(name, name, eventData as rudderanalytics.apiObject);
+  }
+
+  public trackError(name: string, eventData: Dictionary<unknown>): void {
+    this.trackEvent(name, eventData);
+  }
+}

--- a/projects/common/src/telemetry/telemetry.ts
+++ b/projects/common/src/telemetry/telemetry.ts
@@ -20,6 +20,7 @@ export interface UserTelemetryProvider<TInitConfig = unknown> {
 
 export interface TelemetryProviderConfig {
   orgId: string;
+  orgTrackingURL?: string;
 }
 
 export interface UserTraits extends Dictionary<unknown> {

--- a/src/app/config.module.ts
+++ b/src/app/config.module.ts
@@ -1,5 +1,11 @@
 import { NgModule } from '@angular/core';
-import { ALTERNATE_COLOR_PALETTES, APP_TITLE, DEFAULT_COLOR_PALETTE, GLOBAL_HEADER_HEIGHT } from '@hypertrace/common';
+import {
+  ALTERNATE_COLOR_PALETTES,
+  APP_TITLE,
+  DEFAULT_COLOR_PALETTE,
+  GLOBAL_HEADER_HEIGHT,
+  UserTelemetryModule
+} from '@hypertrace/common';
 import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
 import { ENTITY_METADATA, RED_COLOR_PALETTE } from '@hypertrace/observability';
 import { environment } from '../environments/environment';
@@ -7,7 +13,7 @@ import { entityMetadata } from './entity-metadata';
 import { FeatureResolverModule } from './shared/feature-resolver/feature-resolver.module';
 
 @NgModule({
-  imports: [FeatureResolverModule],
+  imports: [FeatureResolverModule, UserTelemetryModule.forRoot([])],
   providers: [
     {
       provide: GRAPHQL_OPTIONS,


### PR DESCRIPTION
- Added [RudderStack](rudderstack.com) Telemetry provider implementation with it's respective npm dependency.
- Imported `UserTelemetryModule` into `config.module.ts` with`[]` as default value for providers. (bug fix).
- Added one more field `orgTrackingURL` to `TelemetryProviderConfig` interface as Rudderstack requires a `orgId` and one more additional field.