### PR TITLE
fix: add empty telemetry module

### DIFF
--- a/src/app/root.module.ts
+++ b/src/app/root.module.ts
@@ -2,6 +2,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { UserTelemetryModule } from '@hypertrace/common';
 import { ObservabilityDashboardModule } from '@hypertrace/observability';
 import { ApplicationFrameModule } from './application-frame/application-frame.module';
 import { ConfigModule } from './config.module';
@@ -18,7 +19,8 @@ import { NavigationModule } from './shared/navigation/navigation.module';
     NavigationModule,
     HttpClientModule,
     ApplicationFrameModule,
-    ObservabilityDashboardModule
+    ObservabilityDashboardModule,
+    UserTelemetryModule.forRoot([])
   ],
   declarations: [RootComponent],
   bootstrap: [RootComponent]


### PR DESCRIPTION
## Description
Telemetry orchestration added without registering the module. This sets up the no-op module.