### PR TITLE
fix: remove pagination from log-event-table

### DIFF
--- a/projects/observability/src/shared/components/log-events/log-events-table.component.test.ts
+++ b/projects/observability/src/shared/components/log-events/log-events-table.component.test.ts
@@ -51,7 +51,7 @@ describe('LogEventsTableComponent', () => {
         id: 'summary'
       })
     ]);
-    expect(spectator.query(TableComponent)!.pageable).toBe(true);
+    expect(spectator.query(TableComponent)!.pageable).toBe(false);
     expect(spectator.query(TableComponent)!.detailContent).not.toBeNull();
 
     runFakeRxjs(({ expectObservable }) => {

--- a/projects/observability/src/shared/components/log-events/log-events-table.component.ts
+++ b/projects/observability/src/shared/components/log-events/log-events-table.component.ts
@@ -29,7 +29,7 @@ export const enum LogEventsTableViewType {
       <ht-table
         [columnConfigs]="this.columnConfigs"
         [data]="this.dataSource"
-        [pageable]="true"
+        [pageable]="false"
         [resizable]="false"
         mode=${TableMode.Detail}
         [detailContent]="detailContent"


### PR DESCRIPTION
This change removes pagination from the log-event-table as it is unnecessary.