### PR TITLE
fix: in filter parser should support string array

### DIFF
--- a/projects/components/src/filtering/filter/parser/filter-parser-lookup.service.test.ts
+++ b/projects/components/src/filtering/filter/parser/filter-parser-lookup.service.test.ts
@@ -182,6 +182,18 @@ describe('Filter Parser Lookup service', () => {
 
     expect(
       spectator.service.lookup(FilterOperator.In).parseSplitFilter({
+        attribute: getTestFilterAttribute(FilterAttributeType.StringArray),
+        operator: FilterOperator.In,
+        rhs: 'myStr, myString'
+      })
+    ).toEqual({
+      field: 'stringArrayAttribute',
+      operator: FilterOperator.In,
+      value: ['myStr', 'myString']
+    });
+
+    expect(
+      spectator.service.lookup(FilterOperator.In).parseSplitFilter({
         attribute: getTestFilterAttribute(FilterAttributeType.String),
         operator: FilterOperator.In,
         rhs: 'myStr, myString'

--- a/projects/components/src/filtering/filter/parser/types/in-filter-parser.ts
+++ b/projects/components/src/filtering/filter/parser/types/in-filter-parser.ts
@@ -22,7 +22,8 @@ export class InFilterParser extends AbstractFilterParser<PossibleValuesTypes> {
       case FilterAttributeType.Number:
         return this.parseNumberArrayValue(splitFilter.rhs);
       case FilterAttributeType.Boolean: // Unsupported
-      case FilterAttributeType.StringArray: // Unsupported
+      case FilterAttributeType.StringArray:
+        return this.parseStringArrayValue(splitFilter.rhs);
       case FilterAttributeType.Timestamp: // Unsupported
         return undefined;
       default:


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
fix: in filter parser should support string array
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
