### PR TITLE
test: use correct mock functions

### DIFF
--- a/projects/components/src/table/cells/data-renderers/relative-timestamp/relative-timestamp-table-cell-renderer.component.test.ts
+++ b/projects/components/src/table/cells/data-renderers/relative-timestamp/relative-timestamp-table-cell-renderer.component.test.ts
@@ -6,7 +6,7 @@ import {
   TooltipDirective
 } from '@hypertrace/components';
 import { createComponentFactory } from '@ngneat/spectator/jest';
-import { MockComponent, MockPipe } from 'ng-mocks';
+import { MockDirective, MockPipe } from 'ng-mocks';
 import { tableCellDataProvider } from '../../test/cell-providers';
 import {
   RelativeTimestampTableCellRendererComponent,
@@ -24,7 +24,7 @@ describe('relative timestamp table cell renderer component', () => {
         new TableCellNoOpParser(undefined!)
       )
     ],
-    declarations: [MockComponent(TooltipDirective), MockPipe(DisplayDatePipe)],
+    declarations: [MockDirective(TooltipDirective), MockPipe(DisplayDatePipe)],
     shallow: true
   });
 

--- a/projects/observability/src/shared/components/table/data-cell/exit-calls/exit-calls-table-cell-renderer.component.test.ts
+++ b/projects/observability/src/shared/components/table/data-cell/exit-calls/exit-calls-table-cell-renderer.component.test.ts
@@ -5,7 +5,7 @@ import {
   TooltipDirective
 } from '@hypertrace/components';
 import { createComponentFactory } from '@ngneat/spectator/jest';
-import { MockComponent } from 'ng-mocks';
+import { MockDirective } from 'ng-mocks';
 import { ExitCallsTableCellRendererComponent } from './exit-calls-table-cell-renderer.component';
 
 describe('Exit Calls table cell renderer component', () => {
@@ -19,7 +19,7 @@ describe('Exit Calls table cell renderer component', () => {
         new TableCellNoOpParser(undefined!)
       )
     ],
-    declarations: [MockComponent(TooltipDirective)],
+    declarations: [MockDirective(TooltipDirective)],
     shallow: true
   });
 


### PR DESCRIPTION
## Description
Update tests to use appropriate function to mock directives - this is an error as types are fixed in later ng mock.