### PR TITLE
Query params resetting on nav item click

### DIFF
--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -128,7 +128,7 @@ export class NavigationService {
     return {
       path: params.path,
       extras: {
-        queryParams: params?.queryParams ?? this.buildQueryParam(),
+        queryParams: { ...this.buildQueryParam(), ...(params?.queryParams ?? {}) },
         queryParamsHandling: params?.queryParamsHandling,
         replaceUrl: params?.replaceCurrentHistory,
         relativeTo: params?.relativeTo

--- a/projects/components/src/navigation/nav-item/nav-item.component.ts
+++ b/projects/components/src/navigation/nav-item/nav-item.component.ts
@@ -45,8 +45,6 @@ import { NavItemLinkConfig, NavViewStyle } from '../navigation.config';
   `
 })
 export class NavItemComponent {
-  private static readonly QUERY_PARAM_HANDLING_STRATEGY = 'merge';
-
   @Input()
   public config!: NavItemLinkConfig;
 
@@ -70,7 +68,6 @@ export class NavItemComponent {
     if (this.config.pageLevelTimeRangeIsEnabled && this.config.timeRangeResolver) {
       return {
         ...navParams,
-        queryParamsHandling: NavItemComponent.QUERY_PARAM_HANDLING_STRATEGY,
         queryParams: this.timeRangeService.toQueryParams(this.config.timeRangeResolver(), true)
       };
     }

--- a/projects/components/src/navigation/nav-item/nav-item.component.ts
+++ b/projects/components/src/navigation/nav-item/nav-item.component.ts
@@ -45,6 +45,8 @@ import { NavItemLinkConfig, NavViewStyle } from '../navigation.config';
   `
 })
 export class NavItemComponent {
+  private static readonly QUERY_PARAM_HANDLING_STRATEGY = 'merge';
+
   @Input()
   public config!: NavItemLinkConfig;
 
@@ -68,6 +70,7 @@ export class NavItemComponent {
     if (this.config.pageLevelTimeRangeIsEnabled && this.config.timeRangeResolver) {
       return {
         ...navParams,
+        queryParamsHandling: NavItemComponent.QUERY_PARAM_HANDLING_STRATEGY,
         queryParams: this.timeRangeService.toQueryParams(this.config.timeRangeResolver(), true)
       };
     }


### PR DESCRIPTION
## Description
When navigating with nav items, the selected environment would reset due to it's query params being removed from the nav event. Before TR changes this wasn't an issue because there was no query params in the nav item link. 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
