### PR TITLE
refactor: allow async config for storage

### DIFF
--- a/projects/common/src/public-api.ts
+++ b/projects/common/src/public-api.ts
@@ -9,6 +9,7 @@ export { DynamicComponentService } from './utilities/angular/dynamic-component.s
 // Browser
 export { CookieService } from './utilities/browser/cookies/cookie.service';
 export { LocalStorage } from './utilities/browser/storage/local-storage';
+export * from './utilities/browser/storage/abstract-storage';
 
 // Coercers
 export * from './utilities/coercers/boolean-coercer';

--- a/projects/common/src/public-api.ts
+++ b/projects/common/src/public-api.ts
@@ -9,6 +9,7 @@ export { DynamicComponentService } from './utilities/angular/dynamic-component.s
 // Browser
 export { CookieService } from './utilities/browser/cookies/cookie.service';
 export { LocalStorage } from './utilities/browser/storage/local-storage';
+export { SessionStorage } from './utilities/browser/storage/session-storage';
 export * from './utilities/browser/storage/abstract-storage';
 
 // Coercers

--- a/projects/common/src/utilities/browser/storage/abstract-storage.test.ts
+++ b/projects/common/src/utilities/browser/storage/abstract-storage.test.ts
@@ -1,4 +1,5 @@
 import { runFakeRxjs } from '@hypertrace/test-utils';
+import { of } from 'rxjs';
 import { AbstractStorage } from './abstract-storage';
 import { DictionaryStorageImpl } from './dictionary-storage-impl';
 
@@ -38,9 +39,12 @@ describe('Abstract storage', () => {
   test('should support scoped storage with no fallback', () => {
     const globalDictionary = new DictionaryStorageImpl({ foo: 'bad-foo' });
 
-    const scopedStorage = new (class extends AbstractStorage {})(globalDictionary, {
-      scopeKey: 'test-scope'
-    });
+    const scopedStorage = new (class extends AbstractStorage {})(
+      globalDictionary,
+      of({
+        scopeKey: 'test-scope'
+      })
+    );
 
     expect(scopedStorage.get('foo')).toBeUndefined();
     expect(scopedStorage.contains('foo')).toBe(false);
@@ -58,10 +62,13 @@ describe('Abstract storage', () => {
   test('should support scoped storage with readonly fallback', () => {
     const globalDictionary = new DictionaryStorageImpl({ foo: 'original-foo' });
 
-    const scopedStorage = new (class extends AbstractStorage {})(globalDictionary, {
-      scopeKey: 'test-scope',
-      fallbackPolicy: 'read-only'
-    });
+    const scopedStorage = new (class extends AbstractStorage {})(
+      globalDictionary,
+      of({
+        scopeKey: 'test-scope',
+        fallbackPolicy: 'read-only'
+      })
+    );
 
     expect(scopedStorage.get('foo')).toBe('original-foo');
     expect(scopedStorage.contains('foo')).toBe(true);
@@ -77,10 +84,13 @@ describe('Abstract storage', () => {
   test('should migrate on read if configured', () => {
     const globalDictionary = new DictionaryStorageImpl({ foo: 'original-foo' });
 
-    const scopedStorage = new (class extends AbstractStorage {})(globalDictionary, {
-      scopeKey: 'test-scope',
-      fallbackPolicy: 'read-and-migrate'
-    });
+    const scopedStorage = new (class extends AbstractStorage {})(
+      globalDictionary,
+      of({
+        scopeKey: 'test-scope',
+        fallbackPolicy: 'read-and-migrate'
+      })
+    );
 
     expect(scopedStorage.get('foo')).toBe('original-foo');
     expect(scopedStorage.contains('foo')).toBe(true);

--- a/projects/common/src/utilities/browser/storage/abstract-storage.ts
+++ b/projects/common/src/utilities/browser/storage/abstract-storage.ts
@@ -5,11 +5,18 @@ import { DictionaryStorageImpl } from './dictionary-storage-impl';
 // A small abstraction on browser's storage for mocking and cleaning up the API a bit
 export abstract class AbstractStorage {
   private readonly changeSubject: Subject<string> = new Subject();
-  private readonly scopedStorage?: DictionaryStorageImpl;
+  private scopeConfig?: ScopedStorageConfiguration;
+  private scopedStorage?: DictionaryStorageImpl;
 
-  public constructor(private readonly storage: Storage, private readonly scopeConfig?: ScopedStorageConfiguration) {
-    if (scopeConfig) {
-      this.scopedStorage = DictionaryStorageImpl.fromString(storage.getItem(scopeConfig.scopeKey) ?? '{}');
+  public constructor(
+    private readonly storage: Storage,
+    private readonly scopeConfig$?: Observable<ScopedStorageConfiguration>
+  ) {
+    if (this.scopeConfig$) {
+      this.scopeConfig$.subscribe(scopeConfig => {
+        this.scopeConfig = scopeConfig;
+        this.scopedStorage = DictionaryStorageImpl.fromString(storage.getItem(scopeConfig.scopeKey) ?? '{}');
+      });
     }
   }
 

--- a/projects/common/src/utilities/browser/storage/local-storage.ts
+++ b/projects/common/src/utilities/browser/storage/local-storage.ts
@@ -1,6 +1,6 @@
 import { Injectable, Optional } from '@angular/core';
-import { AbstractStorage, ScopedStorageConfiguration } from './abstract-storage';
 import { Observable } from 'rxjs';
+import { AbstractStorage, ScopedStorageConfiguration } from './abstract-storage';
 
 @Injectable({ providedIn: 'root' })
 export class LocalStorage extends AbstractStorage {

--- a/projects/common/src/utilities/browser/storage/local-storage.ts
+++ b/projects/common/src/utilities/browser/storage/local-storage.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@angular/core';
-import { AbstractStorage } from './abstract-storage';
+import { Injectable, Optional } from '@angular/core';
+import { AbstractStorage, ScopedStorageConfiguration } from './abstract-storage';
+import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class LocalStorage extends AbstractStorage {
-  public constructor() {
-    super(localStorage);
+  public constructor(@Optional() scopeConfig$?: Observable<ScopedStorageConfiguration>) {
+    super(localStorage, scopeConfig$);
   }
 }

--- a/projects/common/src/utilities/browser/storage/session-storage.ts
+++ b/projects/common/src/utilities/browser/storage/session-storage.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@angular/core';
-import { AbstractStorage } from './abstract-storage';
+import { Injectable, Optional } from '@angular/core';
+import { Observable } from 'rxjs';
+import { AbstractStorage, ScopedStorageConfiguration } from './abstract-storage';
 
 @Injectable({ providedIn: 'root' })
 export class SessionStorage extends AbstractStorage {
-  public constructor() {
-    super(sessionStorage);
+  public constructor(@Optional() scopeConfig$?: Observable<ScopedStorageConfiguration>) {
+    super(sessionStorage, scopeConfig$);
   }
 }


### PR DESCRIPTION
## Description
This change extends on the functionality added in https://github.com/hypertrace/hypertrace-ui/pull/1517 . In the first PR, the functionality was added, but was not used. Now, an optional late-resolving config can be provided to the local and session storage services to support either config or runtime assignment for the entire application.


### Testing
Updated existing tests, verified E2E

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
