### PR TITLE
fix: escape regex reserve characters in highlight pipe

### DIFF
--- a/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
@@ -25,6 +25,12 @@ describe('Highlight pipe', () => {
     );
   });
 
+  test('highlights string with regex reserve chars correctly', () => {
+    expect(pipe.transform(`full text($ to test highlight on`, { text: 'text($', highlightType: 'bold' })).toBe(
+      'full <b>text($</b> to test highlight on'
+    );
+  });
+
   test('highlights with an array of highlightConfig correctly', () => {
     expect(
       pipe.transform('full text to test highlight on', [

--- a/projects/common/src/utilities/formatters/string/highlight.pipe.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.ts
@@ -2,7 +2,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { isArray } from 'lodash-es';
 import { assertUnreachable } from '../../lang/lang-utils';
 
-// TODO: Currently htHighlight does not escape reserved regex characters
 @Pipe({ name: 'htHighlight' })
 export class HighlightPipe implements PipeTransform {
   private escapeReserveRegExpCharacters(str: string): string {

--- a/projects/common/src/utilities/formatters/string/highlight.pipe.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.ts
@@ -5,6 +5,10 @@ import { assertUnreachable } from '../../lang/lang-utils';
 // TODO: Currently htHighlight does not escape reserved regex characters
 @Pipe({ name: 'htHighlight' })
 export class HighlightPipe implements PipeTransform {
+  private escapeRegExp(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+  }
+
   public transform(fullText: string, highlightSnippets: TextHighlightConfig | TextHighlightConfig[]): string {
     const snippetsToHighlight: TextHighlightConfig[] = isArray(highlightSnippets)
       ? highlightSnippets
@@ -14,7 +18,7 @@ export class HighlightPipe implements PipeTransform {
       const highlightHtmlTag = getHtmlTagForHighlightType(highlightConfig.highlightType);
 
       return highlightedText.replace(
-        new RegExp(highlightConfig.text, 'ig'),
+        new RegExp(this.escapeRegExp(highlightConfig.text), 'ig'),
         `<${highlightHtmlTag}>$&</${highlightHtmlTag}>`
       );
     }, fullText);

--- a/projects/common/src/utilities/formatters/string/highlight.pipe.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.ts
@@ -5,7 +5,7 @@ import { assertUnreachable } from '../../lang/lang-utils';
 // TODO: Currently htHighlight does not escape reserved regex characters
 @Pipe({ name: 'htHighlight' })
 export class HighlightPipe implements PipeTransform {
-  private escapeRegExp(str: string): string {
+  private escapeReserveRegExpCharacters(str: string): string {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
   }
 
@@ -18,7 +18,7 @@ export class HighlightPipe implements PipeTransform {
       const highlightHtmlTag = getHtmlTagForHighlightType(highlightConfig.highlightType);
 
       return highlightedText.replace(
-        new RegExp(this.escapeRegExp(highlightConfig.text), 'ig'),
+        new RegExp(this.escapeReserveRegExpCharacters(highlightConfig.text), 'ig'),
         `<${highlightHtmlTag}>$&</${highlightHtmlTag}>`
       );
     }, fullText);


### PR DESCRIPTION
## Description
Highlight pipe uses regex matching to replace strings with corresponding highlight HTML.
This approach fails when the string to be replaced itself is a regex. The regex based matching fails since the method tries to parse it as a string. Hence, escaping reserved regex characters before doing the replacement step.

### Testing
UT added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules