### PR TITLE
fix: highlight pipe improvements

### DIFF
--- a/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
@@ -42,13 +42,7 @@ describe('Highlight pipe', () => {
       'full text to test highlight on'
     );
   });
-
-  test('works as expected when source text is undefined', () => {
-    expect(pipe.transform(undefined, { text: '', highlightType: 'bold' })).toBe(
-      ''
-    );
-  });
-
+  
   test('highlights with an array of highlightConfig correctly', () => {
     expect(
       pipe.transform('full text to test highlight on', [

--- a/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
@@ -42,7 +42,7 @@ describe('Highlight pipe', () => {
       'full text to test highlight on'
     );
   });
-  
+
   test('highlights with an array of highlightConfig correctly', () => {
     expect(
       pipe.transform('full text to test highlight on', [

--- a/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.test.ts
@@ -31,6 +31,24 @@ describe('Highlight pipe', () => {
     );
   });
 
+  test('works as expected when text to highlight is empty', () => {
+    expect(pipe.transform(`full text to test highlight on`, { text: '', highlightType: 'bold' })).toBe(
+      'full text to test highlight on'
+    );
+  });
+
+  test('works as expected when text to highlight is undefined', () => {
+    expect(pipe.transform(`full text to test highlight on`, { text: undefined, highlightType: 'bold' })).toBe(
+      'full text to test highlight on'
+    );
+  });
+
+  test('works as expected when source text is undefined', () => {
+    expect(pipe.transform(undefined, { text: '', highlightType: 'bold' })).toBe(
+      ''
+    );
+  });
+
   test('highlights with an array of highlightConfig correctly', () => {
     expect(
       pipe.transform('full text to test highlight on', [

--- a/projects/common/src/utilities/formatters/string/highlight.pipe.ts
+++ b/projects/common/src/utilities/formatters/string/highlight.pipe.ts
@@ -1,11 +1,11 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { isArray } from 'lodash-es';
+import { isArray, isEmpty } from 'lodash-es';
 import { assertUnreachable } from '../../lang/lang-utils';
 
 @Pipe({ name: 'htHighlight' })
 export class HighlightPipe implements PipeTransform {
-  private escapeReserveRegExpCharacters(str?: string): string {
-    return str === undefined ? '' : str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+  private escapeReserveRegExpCharacters(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
   }
 
   public transform(fullText: string, highlightSnippets: TextHighlightConfig | TextHighlightConfig[]): string {
@@ -15,6 +15,10 @@ export class HighlightPipe implements PipeTransform {
 
     return snippetsToHighlight.reduce((highlightedText, highlightConfig) => {
       const highlightHtmlTag = getHtmlTagForHighlightType(highlightConfig.highlightType);
+
+      if (highlightConfig.text === undefined || isEmpty(highlightConfig.text)) {
+        return highlightedText;
+      }
 
       return highlightedText.replace(
         new RegExp(this.escapeReserveRegExpCharacters(highlightConfig.text), 'ig'),


### PR DESCRIPTION
## Description
Moving the undefined check for highlight config text up in the flow.
Skipping regex matching/replacement logic when highlight config text is empty/undefined.

### Testing
UT added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules