### PR TITLE
fix: multi select scroll

### DIFF
--- a/projects/components/src/multi-select/multi-select.component.scss
+++ b/projects/components/src/multi-select/multi-select.component.scss
@@ -118,6 +118,8 @@
   }
 
   .multi-select-options {
+    min-height: 0;
+    flex: 1 1 auto;
     overflow: auto;
   }
 

--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -115,28 +115,30 @@ import { MultiSelectJustify } from './multi-select-justify';
               </ng-container>
             </ng-container>
 
-            <div class="multi-select-options" *htLoadAsync="this.filteredOptions$ as filteredOptions">
-              <div
-                *ngFor="let item of filteredOptions"
-                (click)="this.onSelectionChange(item)"
-                class="multi-select-option"
-                [ngClass]="{ disabled: item.disabled }"
-              >
-                <ht-checkbox
-                  class="checkbox"
-                  (click)="this.preventClickDefault($event)"
-                  [checked]="this.isSelectedItem(item)"
-                  [disabled]="item.disabled"
-                ></ht-checkbox>
-                <ht-icon
-                  class="icon"
-                  *ngIf="item.icon"
-                  [icon]="item.icon"
-                  size="${IconSize.ExtraSmall}"
-                  [color]="item.iconColor"
-                ></ht-icon>
-                <span class="label">{{ item.label }}</span>
-              </div>
+            <div class="multi-select-options">
+              <ng-container *htLoadAsync="this.filteredOptions$ as filteredOptions">
+                <div
+                  *ngFor="let item of filteredOptions"
+                  (click)="this.onSelectionChange(item)"
+                  class="multi-select-option"
+                  [ngClass]="{ disabled: item.disabled }"
+                >
+                  <ht-checkbox
+                    class="checkbox"
+                    (click)="this.preventClickDefault($event)"
+                    [checked]="this.isSelectedItem(item)"
+                    [disabled]="item.disabled"
+                  ></ht-checkbox>
+                  <ht-icon
+                    class="icon"
+                    *ngIf="item.icon"
+                    [icon]="item.icon"
+                    size="${IconSize.ExtraSmall}"
+                    [color]="item.iconColor"
+                  ></ht-icon>
+                  <span class="label">{{ item.label }}</span>
+                </div>
+              </ng-container>
             </div>
           </div>
         </ht-popover-content>


### PR DESCRIPTION
## Description
Before this, in multi-select content, all of the content used to scroll including the search bar and select-all button. After this, Only options will scroll.

### Testing
Local testing is done.

### Checklist:
- [x] My changes generate no new warnings
