### PR TITLE
feat: use idScope instead of idType for GraphQlIdFilter

### DIFF
--- a/projects/observability/src/shared/graphql/model/schema/filter/id/graphql-id-filter.ts
+++ b/projects/observability/src/shared/graphql/model/schema/filter/id/graphql-id-filter.ts
@@ -16,7 +16,7 @@ export class GraphQlIdFilter implements GraphQlFilter {
         operator: new GraphQlEnumArgument(this.operator),
         value: this.id,
         type: new GraphQlEnumArgument(GraphQlFilterType.Id),
-        idType: new GraphQlEnumArgument(this.idScope)
+        idScope: this.idScope
       }
     ];
   }
@@ -27,5 +27,5 @@ type GraphQlIdFilterArgument = {
   value: GraphQlArgumentValue;
   operator: GraphQlEnumArgument<GraphQlOperatorType>;
   type: GraphQlEnumArgument<GraphQlFilterType.Id>;
-  idType: GraphQlEnumArgument<string>;
+  idScope: string;
 };

--- a/projects/observability/src/shared/graphql/request/handlers/traces/export-spans-graphql-query-handler.service.test.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/traces/export-spans-graphql-query-handler.service.test.ts
@@ -62,7 +62,7 @@ describe('ExportSpansGraphQlQueryHandlerService', () => {
               operator: new GraphQlEnumArgument('EQUALS'),
               value: 'test-id',
               type: new GraphQlEnumArgument(GraphQlFilterType.Id),
-              idType: new GraphQlEnumArgument(TRACE_SCOPE)
+              idScope: TRACE_SCOPE
             }
           ]
         }
@@ -100,7 +100,7 @@ describe('ExportSpansGraphQlQueryHandlerService', () => {
               operator: new GraphQlEnumArgument('EQUALS'),
               value: 'test-id',
               type: new GraphQlEnumArgument(GraphQlFilterType.Id),
-              idType: new GraphQlEnumArgument(TRACE_SCOPE)
+              idScope: TRACE_SCOPE
             }
           ]
         }

--- a/projects/observability/src/shared/graphql/request/handlers/traces/trace-graphql-query-handler.service.test.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/traces/trace-graphql-query-handler.service.test.ts
@@ -71,7 +71,7 @@ describe('TraceGraphQlQueryHandlerService', () => {
               operator: new GraphQlEnumArgument('EQUALS'),
               value: 'test-id',
               type: new GraphQlEnumArgument(GraphQlFilterType.Id),
-              idType: new GraphQlEnumArgument(TRACE_SCOPE)
+              idScope: TRACE_SCOPE
             }
           ]
         }
@@ -108,7 +108,7 @@ describe('TraceGraphQlQueryHandlerService', () => {
               operator: new GraphQlEnumArgument('EQUALS'),
               value: 'test-id',
               type: new GraphQlEnumArgument(GraphQlFilterType.Id),
-              idType: new GraphQlEnumArgument(TRACE_SCOPE)
+              idScope: TRACE_SCOPE
             }
           ]
         }
@@ -154,7 +154,7 @@ describe('TraceGraphQlQueryHandlerService', () => {
               operator: new GraphQlEnumArgument('EQUALS'),
               value: 'test-id',
               type: new GraphQlEnumArgument(GraphQlFilterType.Id),
-              idType: new GraphQlEnumArgument(TRACE_SCOPE)
+              idScope: TRACE_SCOPE
             }
           ]
         }
@@ -191,7 +191,7 @@ describe('TraceGraphQlQueryHandlerService', () => {
               operator: new GraphQlEnumArgument('EQUALS'),
               value: 'test-id',
               type: new GraphQlEnumArgument(GraphQlFilterType.Id),
-              idType: new GraphQlEnumArgument(TRACE_SCOPE)
+              idScope: TRACE_SCOPE
             }
           ]
         }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
