### PR TITLE
refactor: use string scope for explorer - enum is deprecated

### DIFF
--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-builder.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-builder.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { DateCoercer, Dictionary } from '@hypertrace/common';
-import { GraphQlArgument, GraphQlEnumArgument, GraphQlSelection } from '@hypertrace/graphql-client';
+import { GraphQlArgument, GraphQlSelection } from '@hypertrace/graphql-client';
 import { INTERVAL_START_QUERY_KEY } from '../../../model/schema/explore';
 import { GlobalGraphQlFilterService } from '../../../model/schema/filter/global-graphql-filter.service';
 import { GraphQlGroupBy } from '../../../model/schema/groupby/graphql-group-by';
@@ -30,8 +30,8 @@ export class ExploreGraphqlQueryBuilderService {
   public buildRequestArguments(request: GraphQlExploreRequest): GraphQlArgument[] {
     return [
       {
-        name: 'context',
-        value: new GraphQlEnumArgument(request.context)
+        name: 'scope',
+        value: request.context
       },
       this.argBuilder.forLimit(request.limit),
       this.argBuilder.forTimeRange(request.timeRange),

--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
@@ -83,7 +83,7 @@ describe('Explore graphql query handler', () => {
     expect(spectator.service.convertRequest(buildRequest())).toEqual({
       path: 'explore',
       arguments: [
-        { name: 'context', value: new GraphQlEnumArgument(ObservabilityTraceType.Api) },
+        { name: 'scope', value: ObservabilityTraceType.Api },
         { name: 'limit', value: 4 },
         {
           name: 'between',
@@ -93,7 +93,10 @@ describe('Explore graphql query handler', () => {
           }
         },
         { name: 'offset', value: 0 },
-        { name: 'interval', value: { size: 1, units: new GraphQlEnumArgument(GraphQlIntervalUnit.Minutes) } },
+        {
+          name: 'interval',
+          value: { size: 1, units: new GraphQlEnumArgument(GraphQlIntervalUnit.Minutes) }
+        },
         {
           name: 'filterBy',
           value: [
@@ -146,7 +149,10 @@ describe('Explore graphql query handler', () => {
               alias: 'avg_duration',
               arguments: [
                 { name: 'expression', value: { key: 'duration' } },
-                { name: 'aggregation', value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Average) }
+                {
+                  name: 'aggregation',
+                  value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Average)
+                }
               ],
               children: [{ path: 'value' }, { path: 'type' }]
             },
@@ -155,7 +161,10 @@ describe('Explore graphql query handler', () => {
               alias: 'avgrate_min_duration',
               arguments: [
                 { name: 'expression', value: { key: 'duration' } },
-                { name: 'aggregation', value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Avgrate) },
+                {
+                  name: 'aggregation',
+                  value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Avgrate)
+                },
                 { name: 'units', value: new GraphQlEnumArgument(GraphQlIntervalUnit.Minutes) },
                 { name: 'size', value: 1 }
               ],
@@ -178,7 +187,7 @@ describe('Explore graphql query handler', () => {
     expect(spectator.service.convertRequest(request)).toEqual({
       path: 'explore',
       arguments: [
-        { name: 'context', value: new GraphQlEnumArgument(ObservabilityEntityType.Api) },
+        { name: 'scope', value: ObservabilityEntityType.Api },
         { name: 'limit', value: 4 },
         {
           name: 'between',
@@ -188,7 +197,10 @@ describe('Explore graphql query handler', () => {
           }
         },
         { name: 'offset', value: 0 },
-        { name: 'interval', value: { size: 1, units: new GraphQlEnumArgument(GraphQlIntervalUnit.Minutes) } },
+        {
+          name: 'interval',
+          value: { size: 1, units: new GraphQlEnumArgument(GraphQlIntervalUnit.Minutes) }
+        },
         {
           name: 'filterBy',
           value: [
@@ -241,7 +253,10 @@ describe('Explore graphql query handler', () => {
               alias: 'avg_duration',
               arguments: [
                 { name: 'expression', value: { key: 'duration' } },
-                { name: 'aggregation', value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Average) }
+                {
+                  name: 'aggregation',
+                  value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Average)
+                }
               ],
               children: [{ path: 'value' }, { path: 'type' }]
             },
@@ -250,7 +265,10 @@ describe('Explore graphql query handler', () => {
               alias: 'avgrate_min_duration',
               arguments: [
                 { name: 'expression', value: { key: 'duration' } },
-                { name: 'aggregation', value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Avgrate) },
+                {
+                  name: 'aggregation',
+                  value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Avgrate)
+                },
                 { name: 'units', value: new GraphQlEnumArgument(GraphQlIntervalUnit.Minutes) },
                 { name: 'size', value: 1 }
               ],


### PR DESCRIPTION
## Description
Enum scope for explorer was deprecated long ago, updating UI to use string.

### Testing
Verified E2E
