### PR TITLE
feat(explore query): support for using `scope` argument instead of `context`

### DIFF
--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-builder.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-builder.service.ts
@@ -29,10 +29,12 @@ export class ExploreGraphqlQueryBuilderService {
 
   public buildRequestArguments(request: GraphQlExploreRequest): GraphQlArgument[] {
     return [
-      {
-        name: 'context',
-        value: new GraphQlEnumArgument(request.context)
-      },
+      request.useScope
+        ? { name: 'scope', value: request.context }
+        : {
+            name: 'context',
+            value: new GraphQlEnumArgument(request.context)
+          },
       this.argBuilder.forLimit(request.limit),
       this.argBuilder.forTimeRange(request.timeRange),
       ...this.argBuilder.forOffset(request.offset),

--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
@@ -77,6 +77,54 @@ describe('Explore graphql query handler', () => {
     expect(spectator.service.matchesRequest({ requestType: 'other' })).toBe(false);
   });
 
+  test('consumes useScope correctly', () => {
+    const spectator = createService();
+    expect(spectator.service.convertRequest({
+      requestType: EXPLORE_GQL_REQUEST,
+      context: 'SCOPE_VALUE',
+      useScope: true,
+      limit: 1,
+      timeRange: testTimeRange,
+      selections: [
+        specBuilder.exploreSpecificationForKey('duration', MetricAggregationType.Average),
+      ],
+      includeTotal: true,
+    })).toEqual({
+      path: 'explore',
+      arguments: [
+        { name: 'scope', value: 'SCOPE_VALUE' },
+        { name: 'limit', value: 1 },
+        {
+          name: 'between',
+          value: {
+            startTime: new Date(testTimeRange.from),
+            endTime: new Date(testTimeRange.to)
+          }
+        },
+      ],
+      children: [
+        {
+          path: 'results',
+          children: [
+            {
+              path: 'selection',
+              alias: 'avg_duration',
+              arguments: [
+                { name: 'expression', value: { key: 'duration' } },
+                { name: 'aggregation', value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Average) }
+              ],
+              children: [{ path: 'value' }, { path: 'type' }]
+            },
+
+          ]
+        },
+        {
+          path: 'total'
+        }
+      ]
+    })
+  })
+
   test('produces expected graphql', () => {
     const spectator = createService();
 

--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-graphql-query-handler.service.test.ts
@@ -79,17 +79,17 @@ describe('Explore graphql query handler', () => {
 
   test('consumes useScope correctly', () => {
     const spectator = createService();
-    expect(spectator.service.convertRequest({
-      requestType: EXPLORE_GQL_REQUEST,
-      context: 'SCOPE_VALUE',
-      useScope: true,
-      limit: 1,
-      timeRange: testTimeRange,
-      selections: [
-        specBuilder.exploreSpecificationForKey('duration', MetricAggregationType.Average),
-      ],
-      includeTotal: true,
-    })).toEqual({
+    expect(
+      spectator.service.convertRequest({
+        requestType: EXPLORE_GQL_REQUEST,
+        context: 'SCOPE_VALUE',
+        useScope: true,
+        limit: 1,
+        timeRange: testTimeRange,
+        selections: [specBuilder.exploreSpecificationForKey('duration', MetricAggregationType.Average)],
+        includeTotal: true
+      })
+    ).toEqual({
       path: 'explore',
       arguments: [
         { name: 'scope', value: 'SCOPE_VALUE' },
@@ -100,7 +100,7 @@ describe('Explore graphql query handler', () => {
             startTime: new Date(testTimeRange.from),
             endTime: new Date(testTimeRange.to)
           }
-        },
+        }
       ],
       children: [
         {
@@ -114,16 +114,15 @@ describe('Explore graphql query handler', () => {
                 { name: 'aggregation', value: new GraphQlEnumArgument(GraphQlMetricAggregationType.Average) }
               ],
               children: [{ path: 'value' }, { path: 'type' }]
-            },
-
+            }
           ]
         },
         {
           path: 'total'
         }
       ]
-    })
-  })
+    });
+  });
 
   test('produces expected graphql', () => {
     const spectator = createService();

--- a/projects/observability/src/shared/graphql/request/handlers/explore/explore-query.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/explore/explore-query.ts
@@ -23,6 +23,7 @@ export interface GraphQlExploreRequest {
   filters?: GraphQlFilter[];
   groupBy?: GraphQlGroupBy;
   ignoreGlobalFilters?: boolean;
+  useScope?: boolean;
 }
 
 export interface GraphQlExploreResponse {


### PR DESCRIPTION
## Description
Newer explore queries need a `scope` argument instead of `context`. Adding support for that, controlled by an optional input field to the request object.

### Testing
UT added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules