### PR TITLE
fix: y axis tick truncation for cartesian chart

### DIFF
--- a/projects/observability/src/shared/components/cartesian/d3/axis/cartesian-axis.ts
+++ b/projects/observability/src/shared/components/cartesian/d3/axis/cartesian-axis.ts
@@ -21,6 +21,7 @@ export class CartesianAxis<TData = {}> {
 
   public constructor(
     configuration: Axis,
+    private readonly axisDimension: AxisDimension,
     protected readonly scaleBuilder: CartesianScaleBuilder<TData>,
     protected readonly svgUtilService: SvgUtilService
   ) {
@@ -79,7 +80,7 @@ export class CartesianAxis<TData = {}> {
       selection.selectAll('.tick text').remove();
     }
 
-    if (this.configuration.location === AxisLocation.Bottom) {
+    if (this.configuration.location === AxisLocation.Bottom || this.configuration.location === AxisLocation.Top) {
       const maxTextTickTextLength = this.getMaxTickTextLength(selection);
       const isLabelRotated = this.rotateAxisTicks(selection, maxTextTickTextLength);
       this.removeOverflowedTicks(selection, maxTextTickTextLength, isLabelRotated);
@@ -102,10 +103,9 @@ export class CartesianAxis<TData = {}> {
 
   private maybeTruncateAxisTicks(axisSvgSelection: Selection<SVGGElement, unknown, null, undefined>): void {
     const ticksSelection = axisSvgSelection.selectAll('text');
-    const tickBandwidth = Math.abs(this.scale.getRangeEnd() - this.scale.getRangeStart()) / ticksSelection.size();
 
     ticksSelection.each((_, index, nodes) =>
-      this.svgUtilService.truncateText(nodes[index] as SVGTextElement, tickBandwidth)
+      this.svgUtilService.truncateText(nodes[index] as SVGTextElement, this.axisDimension.yAxisWidth)
     );
   }
 
@@ -240,3 +240,9 @@ export class CartesianAxis<TData = {}> {
 }
 
 type DefaultedAxisConfig = Axis & Omit<Required<Axis>, 'scale' | 'crosshair' | 'min' | 'max' | 'tickCount'>;
+
+export interface AxisDimension {
+  xAxisHeight: number;
+  yAxisWidth: number;
+  margin: number;
+}

--- a/projects/observability/src/shared/components/cartesian/d3/chart/cartesian-chart.ts
+++ b/projects/observability/src/shared/components/cartesian/d3/chart/cartesian-chart.ts
@@ -21,7 +21,7 @@ import {
   Summary
 } from '../../chart';
 import { ChartEvent, ChartEventListener, ChartTooltipTrackingOptions } from '../../chart-interactivty';
-import { CartesianAxis } from '../axis/cartesian-axis';
+import { AxisDimension, CartesianAxis } from '../axis/cartesian-axis';
 import { CartesianNoDataMessage } from '../cartesian-no-data-message';
 import { CartesianBand } from '../data/band/cartesian-band';
 import { CartesianData } from '../data/cartesian-data';
@@ -41,9 +41,12 @@ export class DefaultCartesianChart<TData> implements CartesianChart<TData> {
   public static DATA_SERIES_CLASS: string = 'data-series';
   public static CHART_VISUALIZATION_CLASS: string = 'chart-visualization';
 
-  protected readonly margin: number = 16;
-  protected readonly axisHeight: number = 16;
-  protected readonly axisWidth: number = 32; // Untested. We don't use Y-Axis anywhere and the number should really be dynamic
+  // Using these as default, can be taken as property in future.
+  protected readonly axisDimension: AxisDimension = {
+    xAxisHeight: 16,
+    yAxisWidth: 48,
+    margin: 16
+  };
 
   // Updated on draw
   protected chartContainerElement?: Element;
@@ -298,10 +301,15 @@ export class DefaultCartesianChart<TData> implements CartesianChart<TData> {
 
     switch (axisType) {
       case AxisType.Y:
-        return [this.hasXAxis() ? height - (this.margin + this.axisHeight) : height - this.margin, this.margin];
+        return [
+          this.hasXAxis()
+            ? height - (this.axisDimension.margin + this.axisDimension.xAxisHeight)
+            : height - this.axisDimension.margin,
+          this.axisDimension.margin
+        ];
       default:
       case AxisType.X:
-        return [this.hasYAxis() ? this.axisWidth : 0, width];
+        return [this.hasYAxis() ? this.axisDimension.yAxisWidth : 0, width];
     }
   }
 
@@ -412,7 +420,8 @@ export class DefaultCartesianChart<TData> implements CartesianChart<TData> {
     select(this.chartBackgroundSvgElement).selectAll(CartesianAxis.CSS_SELECTOR).remove();
 
     this.renderedAxes = this.requestedAxes.map(
-      requestedAxis => new CartesianAxis<TData>(requestedAxis, this.scaleBuilder, this.svgUtilService)
+      requestedAxis =>
+        new CartesianAxis<TData>(requestedAxis, this.axisDimension, this.scaleBuilder, this.svgUtilService)
     );
 
     const axisElements = select(this.chartBackgroundSvgElement)


### PR DESCRIPTION
## Description
`Bug`: Sometimes we get an empty string for y-axis ticks.
`Fix`: Used the axis width to calculate the tick truncation instead of tickBancWidth

### Testing
Local testing is done.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
