### PR TITLE
fix: close on escape for triggered sheet

### DIFF
--- a/projects/components/src/overlay/sheet/sheet-overlay.component.ts
+++ b/projects/components/src/overlay/sheet/sheet-overlay.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, HostListener, Inject, Injector, TemplateRef, Type } from '@angular/core';
 import { IconType } from '@hypertrace/assets-library';
 import { ExternalNavigationParams, GlobalHeaderHeightProviderService, LayoutChangeService } from '@hypertrace/common';
+import { isNil } from 'lodash-es';
 import { ButtonStyle } from '../../button/button';
 import { IconSize } from '../../icon/icon-size';
 import { PopoverFixedPositionLocation, POPOVER_DATA } from '../../popover/popover';
@@ -106,7 +107,7 @@ export class SheetOverlayComponent {
   @HostListener('document:keydown.escape', ['$event'])
   public onKeydownHandler(): void {
     if (this.closeOnEscape) {
-      this.close();
+      this.handleCloseOnEscape();
     }
   }
 
@@ -123,6 +124,14 @@ export class SheetOverlayComponent {
 
   private setWidth(): void {
     this.popoverRef.width(this.isViewCollapsed ? '0px' : this.getWidthForPopover());
+  }
+
+  private handleCloseOnEscape(): void {
+    if (!isNil(this.attachedTriggerTemplate) && !this.isViewCollapsed) {
+      this.toggleCollapseExpand();
+    } else {
+      this.close();
+    }
   }
 
   private getWidthForPopover(): string {

--- a/projects/components/src/overlay/sheet/sheet-overlay.component.ts
+++ b/projects/components/src/overlay/sheet/sheet-overlay.component.ts
@@ -127,8 +127,10 @@ export class SheetOverlayComponent {
   }
 
   private handleCloseOnEscape(): void {
-    if (!isNil(this.attachedTriggerTemplate) && !this.isViewCollapsed) {
-      this.toggleCollapseExpand();
+    if (!isNil(this.attachedTriggerTemplate)) {
+      if (!this.isViewCollapsed) {
+        this.toggleCollapseExpand();
+      }
     } else {
       this.close();
     }


### PR DESCRIPTION
## Description
While using the trigger template, whenever the sheet is open, after clicking escape, the sheet goes away, instead it should collapse.

### Testing
Local testing is done.

### Checklist:
- [x] My changes generate no new warnings
