### PR TITLE
fix(sheet overlay): break-word for header

### DIFF
--- a/projects/components/src/overlay/sheet/sheet-overlay.component.scss
+++ b/projects/components/src/overlay/sheet/sheet-overlay.component.scss
@@ -19,12 +19,12 @@ $box-shadow: -3px 0px 24px rgba(0, 0, 0, 0.12), -1px 0px 8px rgba(0, 0, 0, 0.08)
     display: flex;
     justify-content: space-between;
     align-items: center;
-    flex-wrap: wrap-reverse;
-
     padding-bottom: 20px;
 
     .header-title {
       @include header-4($gray-7);
+      padding-right: 8px;
+      word-break: break-word;
       margin: 0;
     }
 


### PR DESCRIPTION
## Description
If the header text is too long, the sheet overlay component header becomes messed up. Fixing it by breaking the header text for really long text.

### Testing
<img width="787" alt="Screenshot 2022-06-03 at 10 48 37 AM" src="https://user-images.githubusercontent.com/63222211/171791156-04af06c1-fd54-4091-bb82-66c2321a0277.png">


### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules