### PR TITLE
fix(entity-renderer): added null checks

### DIFF
--- a/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
+++ b/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { InAppNavigationParams, TypedSimpleChanges } from '@hypertrace/common';
 import { IconSize } from '@hypertrace/components';
-import { Entity } from '../../graphql/model/schema/entity';
+import { Entity, entityIdKey } from '../../graphql/model/schema/entity';
 import { EntityIconLookupService } from '../../services/entity/entity-icon-lookup.service';
 import { EntityNavigationService } from '../../services/navigation/entity/entity-navigation.service';
 
@@ -14,7 +14,7 @@ import { EntityNavigationService } from '../../services/navigation/entity/entity
       *ngIf="this.name"
       class="ht-entity-renderer"
       [ngClass]="{ 'default-text-style': !this.inheritTextStyle }"
-      [htTooltip]="this.name"
+      [htTooltip]="this.getTooltipText | htMemoize: this.name"
     >
       <div *ngIf="this.navigationParams; then nameWithLinkTemplate; else nameTemplate"></div>
     </div>
@@ -85,6 +85,10 @@ export class EntityRendererComponent implements OnChanges {
     }
   }
 
+  public getTooltipText(name: string): string {
+    return name !== 'null' ? name : 'unknown';
+  }
+
   private setName(): void {
     this.name = this.entity?.name as string;
   }
@@ -96,7 +100,7 @@ export class EntityRendererComponent implements OnChanges {
 
   private setNavigationParams(): void {
     this.navigationParams =
-      this.navigable && this.entity !== undefined
+      this.navigable && this.entity !== undefined && this.entity[entityIdKey] !== 'null'
         ? this.entityNavService.buildEntityDetailNavigationParams(this.entity, this.inactive)
         : undefined;
   }

--- a/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
+++ b/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
@@ -14,7 +14,7 @@ import { EntityNavigationService } from '../../services/navigation/entity/entity
       *ngIf="this.name"
       class="ht-entity-renderer"
       [ngClass]="{ 'default-text-style': !this.inheritTextStyle }"
-      [htTooltip]="this.getTooltipText | htMemoize: this.name"
+      [htTooltip]="this.name | htDisplayString: 'unknown'"
     >
       <div *ngIf="this.navigationParams; then nameWithLinkTemplate; else nameTemplate"></div>
     </div>
@@ -83,10 +83,6 @@ export class EntityRendererComponent implements OnChanges {
     if (changes.icon) {
       this.setIconType();
     }
-  }
-
-  public getTooltipText(name: string): string {
-    return name !== 'null' ? name : 'unknown';
   }
 
   private setName(): void {

--- a/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
+++ b/projects/observability/src/shared/components/entity-renderer/entity-renderer.component.ts
@@ -14,7 +14,7 @@ import { EntityNavigationService } from '../../services/navigation/entity/entity
       *ngIf="this.name"
       class="ht-entity-renderer"
       [ngClass]="{ 'default-text-style': !this.inheritTextStyle }"
-      [htTooltip]="this.name | htDisplayString: 'unknown'"
+      [htTooltip]="this.name | htDisplayString: 'Unknown'"
     >
       <div *ngIf="this.navigationParams; then nameWithLinkTemplate; else nameTemplate"></div>
     </div>

--- a/projects/observability/src/shared/components/entity-renderer/entity-renderer.module.ts
+++ b/projects/observability/src/shared/components/entity-renderer/entity-renderer.module.ts
@@ -1,11 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormattingModule, MemoizeModule } from '@hypertrace/common';
+import { FormattingModule } from '@hypertrace/common';
 import { IconModule, LinkModule, TooltipModule } from '@hypertrace/components';
 import { EntityRendererComponent } from './entity-renderer.component';
 
 @NgModule({
-  imports: [CommonModule, TooltipModule, IconModule, LinkModule, FormattingModule, MemoizeModule],
+  imports: [CommonModule, TooltipModule, IconModule, LinkModule, FormattingModule],
   declarations: [EntityRendererComponent],
   exports: [EntityRendererComponent]
 })

--- a/projects/observability/src/shared/components/entity-renderer/entity-renderer.module.ts
+++ b/projects/observability/src/shared/components/entity-renderer/entity-renderer.module.ts
@@ -1,12 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormattingModule } from '@hypertrace/common';
-
+import { FormattingModule, MemoizeModule } from '@hypertrace/common';
 import { IconModule, LinkModule, TooltipModule } from '@hypertrace/components';
 import { EntityRendererComponent } from './entity-renderer.component';
 
 @NgModule({
-  imports: [CommonModule, TooltipModule, IconModule, LinkModule, FormattingModule],
+  imports: [CommonModule, TooltipModule, IconModule, LinkModule, FormattingModule, MemoizeModule],
   declarations: [EntityRendererComponent],
   exports: [EntityRendererComponent]
 })


### PR DESCRIPTION
Made Entities non navigable and tooltip text to be `unknown` for the null cases.

<img width="193" alt="Screenshot 2022-06-08 at 4 16 04 PM" src="https://user-images.githubusercontent.com/45289002/172598213-d2205f68-107c-490b-b28b-ef0852a41f3a.png">


## Description
Please include a summary of the change, motivation and context.
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
