### PR TITLE
fix: could not find Angular Material core theme

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -35,7 +35,7 @@
                 "output": "./assets"
               }
             ],
-            "styles": ["./node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css", "src/styles/main.scss"],
+            "styles": ["src/styles/main.scss"],
             "stylePreprocessorOptions": {
               "includePaths": ["./projects/assets-library/assets/styles", "./node_modules"]
             },

--- a/angular.json
+++ b/angular.json
@@ -35,7 +35,7 @@
                 "output": "./assets"
               }
             ],
-            "styles": ["src/styles/main.scss"],
+            "styles": ["./node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css", "src/styles/main.scss"],
             "stylePreprocessorOptions": {
               "includePaths": ["./projects/assets-library/assets/styles", "./node_modules"]
             },

--- a/src/app/config.module.ts
+++ b/src/app/config.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { MATERIAL_SANITY_CHECKS } from '@angular/material/core';
 import { ALTERNATE_COLOR_PALETTES, APP_TITLE, DEFAULT_COLOR_PALETTE } from '@hypertrace/common';
 import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
 import { ENTITY_METADATA, RED_COLOR_PALETTE } from '@hypertrace/observability';
@@ -38,6 +39,14 @@ import { FeatureResolverModule } from './shared/feature-resolver/feature-resolve
     {
       provide: APP_TITLE,
       useValue: environment.appTitle
+    },
+    {
+      provide: MATERIAL_SANITY_CHECKS,
+      useValue: {
+        doctype: true,
+        theme: false,
+        version: true
+      }
     }
   ]
 })


### PR DESCRIPTION
## Description
Fixes #1676 

This is the recommended approach from the [Angular docs][1] as discussed in [this StackOverflow thread][2].

### Testing
- Run `npm start`
- Warnings are gone from the console logs

### Checklist:
- [x] My changes generate no new warnings

[1]: https://material.angular.io/guide/theming#using-a-pre-built-theme
[2]: https://stackoverflow.com/a/50927106/7435656

### Screenshots

#### Before

<img width="1170" alt="Screenshot 2022-06-10 at 6 29 36 AM" src="https://user-images.githubusercontent.com/29686866/172972223-5fc538da-beeb-4608-a7c4-d300f1ec08ce.png">

#### After

<img width="1180" alt="Screenshot 2022-06-10 at 6 36 11 AM" src="https://user-images.githubusercontent.com/29686866/172972236-3f5d66ae-37c7-4769-a87f-db4e31bf0066.png">