### PR TITLE
fix: Blocking radio group template option propagation

### DIFF
--- a/projects/components/src/radio/radio-group.component.ts
+++ b/projects/components/src/radio/radio-group.component.ts
@@ -30,6 +30,7 @@ import { RadioOption } from './radio-option';
         [ngClass]="[this.optionsDirection, this.disabled || option.disabled ? 'disabled' : '']"
         [value]="option.value"
         [disabled]="option.disabled"
+        (change)="$event.stopPropagation()"
       >
         <ng-container
           *ngTemplateOutlet="


### PR DESCRIPTION
## Description
Stop propagation from radio group template options fields

### Testing
Tested locally

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
