### PR TITLE
Tenant based custom page TR default support

### DIFF
--- a/projects/common/src/constants/application-constants.ts
+++ b/projects/common/src/constants/application-constants.ts
@@ -1,4 +1,4 @@
 export const enum ApplicationFeature {
   PageTimeRange = 'ui.page-time-range',
-  TenantDefaultTimeRangeMap = 'ui.feature-default-time-range-map'
+  FeatureDefaultTimeRangeMap = 'ui.feature-default-time-range-map'
 }

--- a/projects/common/src/constants/application-constants.ts
+++ b/projects/common/src/constants/application-constants.ts
@@ -1,4 +1,4 @@
 export const enum ApplicationFeature {
   PageTimeRange = 'ui.page-time-range',
-  FeatureDefaultTimeRange = 'ui.feature-default-time-range-map'
+  TenantDefaultTimeRangeMap = 'ui.feature-default-time-range-map'
 }

--- a/src/app/shared/feature-resolver/feature-resolver.service.ts
+++ b/src/app/shared/feature-resolver/feature-resolver.service.ts
@@ -8,7 +8,7 @@ export class FeatureResolverService extends FeatureStateResolver {
     switch (feature) {
       case ApplicationFeature.PageTimeRange:
         return of(false as T);
-      case ApplicationFeature.TenantDefaultTimeRangeMap:
+      case ApplicationFeature.FeatureDefaultTimeRangeMap:
         // tslint:disable-next-line: no-object-literal-type-assertion
         return of({} as T);
       default:

--- a/src/app/shared/feature-resolver/feature-resolver.service.ts
+++ b/src/app/shared/feature-resolver/feature-resolver.service.ts
@@ -8,7 +8,7 @@ export class FeatureResolverService extends FeatureStateResolver {
     switch (feature) {
       case ApplicationFeature.PageTimeRange:
         return of(false as T);
-      case ApplicationFeature.FeatureDefaultTimeRange:
+      case ApplicationFeature.TenantDefaultTimeRangeMap:
         // tslint:disable-next-line: no-object-literal-type-assertion
         return of({} as T);
       default:


### PR DESCRIPTION
## Description
Allows configuring the page defaults based on the values in the feature flag dictionary map `ApplicationFeature.TenantDefaultTimeRangeMap`.  The page TR defaults now follow the priority: User selected in app -> FF value in the dictionary `map<rootLevelPath, trStringValue>` -> route config define default.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
