### PR TITLE
refactor: returning empty array when toggledRow is undefined

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -673,7 +673,7 @@ export class TableComponent
     } else if (this.hasMultiSelect()) {
       this.selections = [...previousSelections, toggledRow];
     } else {
-      this.selections = [toggledRow];
+      this.selections = toggledRow ? [toggledRow] : [];
     }
     this.selectionsChange.emit(this.selections);
     this.indeterminateRowsSelected = this.selections?.length !== this.dataSource?.getAllRows().length;


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
refactor: returning empty array when toggledRow is undefined

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
