### PR TITLE
Fix prefix match routing

### DIFF
--- a/projects/common/src/navigation/navigation.service.test.ts
+++ b/projects/common/src/navigation/navigation.service.test.ts
@@ -94,6 +94,12 @@ describe('Navigation Service', () => {
     expect(spectator.service.getRouteConfig(['second/second-second'])).toEqual(secondSecondChildRouteConfig);
   });
 
+  test('skips partial matches', () => {
+    router.navigate(['root']);
+    // Shouldn't match "second-first" or "second-second"
+    expect(spectator.service.getRouteConfig(['second', 'second'])).toBeUndefined();
+  });
+
   test('can build a url tree from segments', () => {
     const path = [new UrlSegment('first', { m1: 'm1v', m2: 'm2v' }), new UrlSegment('second', {})];
 

--- a/projects/common/src/navigation/navigation.service.test.ts
+++ b/projects/common/src/navigation/navigation.service.test.ts
@@ -34,7 +34,7 @@ describe('Navigation Service', () => {
     children: [secondFirstChildRouteConfig]
   };
   const secondSecondChildRouteConfig = {
-    path: 'second-second',
+    path: 'second-second/:id',
     children: []
   };
   const secondChildRouteConfig = {

--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -337,8 +337,7 @@ export class NavigationService {
       .filter(
         // First, filter to anything that potentially matches
         route =>
-          (route.path === pathSegment && route.pathMatch === 'full') || // Exact match
-          (typeof route.path === 'string' && route.path.startsWith(pathSegment) && route.pathMatch !== 'full') || // Prefix match
+          route.path === pathSegment || // Regular match (either full or prefix)
           route.path === '**' || // Wildcard match
           (route.path === '' && route.pathMatch !== 'full') // Pass through
       )

--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -338,6 +338,7 @@ export class NavigationService {
         // First, filter to anything that potentially matches
         route =>
           route.path === pathSegment || // Regular match (either full or prefix)
+          (route.path?.startsWith(`${pathSegment}/`) && route.pathMatch !== 'full') || // Prefix that continues on
           route.path === '**' || // Wildcard match
           (route.path === '' && route.pathMatch !== 'full') // Pass through
       )
@@ -359,6 +360,7 @@ export interface QueryParamObject extends Params {
 export type NavigationPath = string | (string | Dictionary<string>)[];
 
 export type NavigationParams = InAppNavigationParams | ExternalNavigationParams;
+
 export interface InAppNavigationParams {
   navType: NavigationParamsType.InApp;
   path: NavigationPath;


### PR DESCRIPTION
## Description
Fetching the route config previously used a "startsWith" match based on an incorrect assumption on how angular's prefix matching worked. It should actually still match full segments. Prefix instead refers to whether later segments invalidate the match. The logic here isn't perfect (corner case scenarios like a multi segment match like `x/y` against a route configs that merge segments like `path: 'x/y'`didn't work and will continue not to), but it's strictly better than what was there previously. We don't generally declare multiple paths in a single route with the exception of path params, which are correctly handled.

### Testing
Verified E2E, updated unit tests

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
