### PR TITLE
fix: setting baseline as 0 when data points are missing

### DIFF
--- a/projects/observability/src/shared/components/cartesian/d3/scale/state/cartesian-stacking-state.ts
+++ b/projects/observability/src/shared/components/cartesian/d3/scale/state/cartesian-stacking-state.ts
@@ -1,6 +1,7 @@
 import { Dictionary } from '@hypertrace/common';
 import { Numeric } from 'd3-array';
 import { stack, stackOffsetNone, stackOrderNone } from 'd3-shape';
+import { isNil } from 'lodash-es';
 import { Series } from '../../../chart';
 import { SeriesState } from './series-state';
 
@@ -35,8 +36,21 @@ export class CartesianStackingState<TData> implements SeriesState<TData> {
 
     this.stackingSeriesList.forEach((series, index) => {
       series.data.forEach((datum: TData, dataIndex) => {
-        this.baselineMap.set(datum, dataset[index][dataIndex][0]);
-        this.maxValue = Math.max(this.maxValue, dataset[index][dataIndex][1]);
+        let baseline = 0;
+        let value = 0;
+
+        if (
+          !isNaN(dataset[index][dataIndex][1]) &&
+          !isNil(dataset[index][dataIndex][1]) &&
+          !isNaN(dataset[index][dataIndex][0]) &&
+          !isNil(dataset[index][dataIndex][0])
+        ) {
+          baseline = dataset[index][dataIndex][0];
+          value = dataset[index][dataIndex][1];
+        }
+
+        this.baselineMap.set(datum, baseline);
+        this.maxValue = Math.max(this.maxValue, value);
       });
     });
   }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
fix: setting baseline as 0 when data points are missing
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
