### PR TITLE
fix: retain previous filters in span-tags-detail filter link

### DIFF
--- a/projects/observability/src/shared/components/span-detail/tags/span-tags-detail.component.test.ts
+++ b/projects/observability/src/shared/components/span-detail/tags/span-tags-detail.component.test.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MemoizeModule } from '@hypertrace/common';
+import { MemoizeModule, NavigationService } from '@hypertrace/common';
 import {
   JsonViewerModule,
   LabelModule,
@@ -31,7 +31,10 @@ describe('Span Tags Detail Component', () => {
       MemoizeModule
     ],
     declarations: [MockComponent(ExploreFilterLinkComponent)],
-    providers: [mockProvider(ExplorerService)]
+    providers: [
+      mockProvider(ExplorerService),
+      mockProvider(NavigationService, { getAllValuesForQueryParameter: () => [] })
+    ]
   });
 
   test('should display tag records', () => {

--- a/projects/observability/src/shared/components/span-detail/tags/span-tags-detail.component.ts
+++ b/projects/observability/src/shared/components/span-detail/tags/span-tags-detail.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
-import { Dictionary, NavigationParams, TypedSimpleChanges } from '@hypertrace/common';
+import { Dictionary, NavigationParams, NavigationService, TypedSimpleChanges } from '@hypertrace/common';
 import { FilterOperator, ListViewDisplay, ListViewRecord } from '@hypertrace/components';
 import { isNil } from 'lodash-es';
 import { EMPTY, Observable, of } from 'rxjs';
@@ -34,7 +34,10 @@ export class SpanTagsDetailComponent implements OnChanges {
 
   public tagRecords$?: Observable<ListViewRecord[]>;
 
-  public constructor(private readonly explorerService: ExplorerService) {}
+  public constructor(
+    private readonly explorerService: ExplorerService,
+    private readonly navigationService: NavigationService
+  ) {}
 
   public ngOnChanges(changes: TypedSimpleChanges<this>): void {
     if (changes.tags && this.tags) {
@@ -44,6 +47,7 @@ export class SpanTagsDetailComponent implements OnChanges {
 
   public getExploreNavigationParams = (tag: ListViewRecord): Observable<NavigationParams> =>
     this.explorerService.buildNavParamsWithFilters(ScopeQueryParam.EndpointTraces, [
+      ...this.navigationService.getAllValuesForQueryParameter('filter'),
       { field: 'tags', subpath: tag.key, operator: FilterOperator.Equals, value: tag.value }
     ]);
 


### PR DESCRIPTION
## Description

Fixes #1641

### Testing

- Add some filters to the Explorer screen search
- Expand one of the results
- Add one of the attributes to the search using the filter button
- Previous filters should be kept intact and the new attribute filter should be added to the search bar

<img width="1313" alt="Screenshot_2022-07-26_at_9_31_09_AM" src="https://user-images.githubusercontent.com/29686866/180920529-feb8a4c2-b55c-43e7-bfff-b89c2960a94d.png">

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Bugfix, N/A