### PR TITLE
style(page-header): vertically center timerange

### DIFF
--- a/projects/components/src/header/page/page-header.component.scss
+++ b/projects/components/src/header/page/page-header.component.scss
@@ -2,9 +2,10 @@
 @import 'font';
 
 .page-header {
-  margin: 24px 24px 0;
   display: flex;
   flex-direction: column;
+  margin: 24px 24px 0;
+
   .column-alignment {
     display: flex;
     flex-direction: column;
@@ -22,8 +23,8 @@
   }
 
   .breadcrumb-container {
-    margin-right: auto;
     align-items: center;
+    margin-right: auto;
 
     .breadcrumb-separator {
       padding: 0 20px;
@@ -31,8 +32,8 @@
 
     .title {
       @include font-subtitle-medium($gray-7);
-      display: flex;
       align-items: center;
+      display: flex;
 
       .icon {
         padding-right: 12px;
@@ -45,6 +46,8 @@
   }
 
   .time-range {
+    align-items: center;
+    display: flex;
     margin-left: 10px;
   }
 
@@ -54,8 +57,8 @@
   }
 
   &.bottom-border {
-    padding-bottom: 16px;
     border-bottom: 1px solid $color-border;
+    padding-bottom: 16px;
   }
 
   .tabs {


### PR DESCRIPTION
## Description
Vertically center the time range. Because adding additional controls in the page header causes the controls and time range to be mis-aligned.