### PR TITLE
Add plain text filter operator to escape special chars

### DIFF
--- a/projects/components/src/filtering/filter-bar/filter-chip/filter-chip.service.test.ts
+++ b/projects/components/src/filtering/filter-bar/filter-chip/filter-chip.service.test.ts
@@ -57,6 +57,7 @@ describe('Filter Chip service', () => {
             case FilterOperator.LessThanOrEqualTo:
             case FilterOperator.GreaterThan:
             case FilterOperator.GreaterThanOrEqualTo:
+            case FilterOperator.Contains:
             case FilterOperator.Like:
               return new ComparisonFilterParser();
             case FilterOperator.In:
@@ -248,6 +249,12 @@ describe('Filter Chip service', () => {
         field: attribute.name,
         operator: FilterOperator.Like,
         userString: `${attribute.displayName} ${FilterOperator.Like}`
+      },
+      {
+        metadata: attribute,
+        field: attribute.name,
+        operator: FilterOperator.Contains,
+        userString: `${attribute.displayName} ${FilterOperator.Contains}`
       }
     ]);
   });

--- a/projects/components/src/filtering/filter/builder/filter-builder-lookup.service.test.ts
+++ b/projects/components/src/filtering/filter/builder/filter-builder-lookup.service.test.ts
@@ -166,6 +166,14 @@ describe('Filter Builder Lookup service', () => {
         value: 'test value',
         userString: 'String Attribute ~ test value',
         urlString: 'stringAttribute_lk_test%20value'
+      },
+      {
+        metadata: getTestFilterAttribute(FilterAttributeType.String),
+        field: getTestFilterAttribute(FilterAttributeType.String).name,
+        operator: FilterOperator.Contains,
+        value: 'test value',
+        userString: 'String Attribute CONTAINS test value',
+        urlString: 'stringAttribute_c_test%20value'
       }
     ]);
 

--- a/projects/components/src/filtering/filter/builder/types/string-filter-builder.ts
+++ b/projects/components/src/filtering/filter/builder/types/string-filter-builder.ts
@@ -9,7 +9,13 @@ export class StringFilterBuilder extends AbstractFilterBuilder<string | string[]
   }
 
   public supportedTopLevelOperators(): FilterOperator[] {
-    return [FilterOperator.Equals, FilterOperator.NotEquals, FilterOperator.In, FilterOperator.Like];
+    return [
+      FilterOperator.Equals,
+      FilterOperator.NotEquals,
+      FilterOperator.In,
+      FilterOperator.Like,
+      FilterOperator.Contains
+    ];
   }
 
   public supportedSubpathOperators(): FilterOperator[] {

--- a/projects/components/src/filtering/filter/filter-operators.ts
+++ b/projects/components/src/filtering/filter/filter-operators.ts
@@ -9,6 +9,12 @@ export const enum FilterOperator {
   GreaterThanOrEqualTo = '>=',
   Like = '~',
   In = 'IN',
+  /**
+   * The difference between 'Contains' and 'Like' is that 'Like' will be treated as a regex filter, not escaping
+   * special characters. Whereas 'Contains' will escape special characters in order to treat it as plain text - currently
+   * this assumes no backend support and is done clientside, which is why FilterOperator.Contains gets mapped to
+   * GraphQlOperatorType.Like
+   */
   Contains = 'CONTAINS',
   ContainsKey = 'CONTAINS_KEY',
   ContainsKeyLike = 'CONTAINS_KEY_LIKE'

--- a/projects/components/src/filtering/filter/filter-operators.ts
+++ b/projects/components/src/filtering/filter/filter-operators.ts
@@ -9,6 +9,7 @@ export const enum FilterOperator {
   GreaterThanOrEqualTo = '>=',
   Like = '~',
   In = 'IN',
+  Contains = 'CONTAINS',
   ContainsKey = 'CONTAINS_KEY',
   ContainsKeyLike = 'CONTAINS_KEY_LIKE'
 }
@@ -22,6 +23,7 @@ export const enum UrlFilterOperator {
   GreaterThanOrEqualTo = '_gte_',
   Like = '_lk_',
   In = '_in_',
+  Contains = '_c_',
   ContainsKey = '_ck_',
   ContainsKeyLike = '_ckl_'
 }
@@ -44,6 +46,8 @@ export const toUrlFilterOperator = (operator: FilterOperator): UrlFilterOperator
       return UrlFilterOperator.Like;
     case FilterOperator.In:
       return UrlFilterOperator.In;
+    case FilterOperator.Contains:
+      return UrlFilterOperator.Contains;
     case FilterOperator.ContainsKey:
       return UrlFilterOperator.ContainsKey;
     case FilterOperator.ContainsKeyLike:
@@ -71,6 +75,8 @@ export const fromUrlFilterOperator = (operator: UrlFilterOperator): FilterOperat
       return FilterOperator.Like;
     case UrlFilterOperator.In:
       return FilterOperator.In;
+    case UrlFilterOperator.Contains:
+      return FilterOperator.Contains;
     case UrlFilterOperator.ContainsKey:
       return FilterOperator.ContainsKey;
     case UrlFilterOperator.ContainsKeyLike:
@@ -93,8 +99,10 @@ export const incompatibleOperators = (operator: FilterOperator): FilterOperator[
         FilterOperator.GreaterThan,
         FilterOperator.GreaterThanOrEqualTo,
         FilterOperator.Like,
+        FilterOperator.Contains,
         FilterOperator.ContainsKey
       ];
+    case FilterOperator.Contains:
     case FilterOperator.ContainsKey:
     case FilterOperator.ContainsKeyLike:
     case FilterOperator.NotEquals:

--- a/projects/components/src/filtering/filter/parser/filter-parser-lookup.service.ts
+++ b/projects/components/src/filtering/filter/parser/filter-parser-lookup.service.ts
@@ -23,6 +23,7 @@ export class FilterParserLookupService {
       case FilterOperator.LessThanOrEqualTo:
       case FilterOperator.GreaterThan:
       case FilterOperator.GreaterThanOrEqualTo:
+      case FilterOperator.Contains:
       case FilterOperator.Like:
         return new ComparisonFilterParser();
       case FilterOperator.In:

--- a/projects/observability/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
+++ b/projects/observability/src/shared/dashboard/widgets/table/table-widget-renderer.component.ts
@@ -476,7 +476,7 @@ export class TableWidgetRendererComponent
       searchFilters = [
         {
           field: this.api.model.getSearchAttribute()!,
-          operator: FilterOperator.Like,
+          operator: FilterOperator.Contains,
           value: text
         }
       ];

--- a/projects/observability/src/shared/services/filter-builder/graphql-filter-builder.service.ts
+++ b/projects/observability/src/shared/services/filter-builder/graphql-filter-builder.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { assertUnreachable } from '@hypertrace/common';
 import { FieldFilter, Filter, FilterOperator, FilterValue, TableFilter } from '@hypertrace/components';
 import { GraphQlArgumentValue } from '@hypertrace/graphql-client';
+import { escapeRegExp } from 'lodash-es';
 import { GraphQlFieldFilter } from '../../graphql/model/schema/filter/field/graphql-field-filter';
 import { GraphQlFilter, GraphQlOperatorType } from '../../graphql/model/schema/filter/graphql-filter';
 
@@ -26,7 +27,7 @@ export class GraphQlFilterBuilderService {
         new GraphQlFieldFilter(
           { key: filter.field, subpath: filter.subpath },
           toGraphQlOperator(filter.operator!), // Todo : Very weird
-          filter.value as GraphQlArgumentValue
+          this.transformValueIfOperatorIsContains(filter)
         )
     );
   }
@@ -37,9 +38,15 @@ export class GraphQlFilterBuilderService {
         new GraphQlFieldFilter(
           { key: filter.field, subpath: filter.subpath },
           toGraphQlOperator(filter.operator),
-          filter.value as GraphQlArgumentValue
+          this.transformValueIfOperatorIsContains(filter)
         )
     );
+  }
+
+  private transformValueIfOperatorIsContains(filter: Filter | FieldFilter | TableFilter): GraphQlArgumentValue {
+    return (filter.operator === FilterOperator.Contains && typeof filter.value === 'string'
+      ? escapeRegExp(filter.value).toString()
+      : filter.value) as GraphQlArgumentValue;
   }
 }
 
@@ -61,6 +68,8 @@ export const toGraphQlOperator = (operator: FilterOperator): GraphQlOperatorType
       return GraphQlOperatorType.Like;
     case FilterOperator.In:
       return GraphQlOperatorType.In;
+    case FilterOperator.Contains:
+      return GraphQlOperatorType.Like;
     case FilterOperator.ContainsKey:
       return GraphQlOperatorType.ContainsKey;
     case FilterOperator.ContainsKeyLike:

--- a/projects/observability/src/shared/services/filter-builder/graphql-filter-builder.service.ts
+++ b/projects/observability/src/shared/services/filter-builder/graphql-filter-builder.service.ts
@@ -27,7 +27,7 @@ export class GraphQlFilterBuilderService {
         new GraphQlFieldFilter(
           { key: filter.field, subpath: filter.subpath },
           toGraphQlOperator(filter.operator!), // Todo : Very weird
-          this.transformValueIfOperatorIsContains(filter)
+          this.extractGraphQlFilterValue(filter)
         )
     );
   }
@@ -38,12 +38,12 @@ export class GraphQlFilterBuilderService {
         new GraphQlFieldFilter(
           { key: filter.field, subpath: filter.subpath },
           toGraphQlOperator(filter.operator),
-          this.transformValueIfOperatorIsContains(filter)
+          this.extractGraphQlFilterValue(filter)
         )
     );
   }
 
-  private transformValueIfOperatorIsContains(filter: Filter | FieldFilter | TableFilter): GraphQlArgumentValue {
+  private extractGraphQlFilterValue(filter: Filter | FieldFilter | TableFilter): GraphQlArgumentValue {
     return (filter.operator === FilterOperator.Contains && typeof filter.value === 'string'
       ? escapeRegExp(filter.value).toString()
       : filter.value) as GraphQlArgumentValue;


### PR DESCRIPTION
## Description
Search input would generally use the `FilterOperator.Like` , which is the regex filter operator. Because of this, you were unable to search with special characters, because they were not escaped. This PR introduces the `FilterOperator.Contains` in order to escape the special characters and treat the string as plain text.

In this PR, we look for the `FilterOperator.Contains` filters and do two things:
1. Transform the value of the filter to escape the special character's, allowing the GQL to treat it as plain text
2. Change the operator type from: `FilterOperator.Contains` to: `FilterOperator.Like`
  - This is because the backend doesn't support a plain text field yet, so we transform the regex string, to act like plain text, then pass it to the query as a `FilterOperator.Like`.  This way In the future when backend support is in for this, we just correct the mapping and remove the string transformation and its working.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
