### PR TITLE
fix(entity query): ignore global fitlers for single entity query

### DIFF
--- a/projects/observability/src/shared/graphql/request/handlers/entities/query/entity/entity-graphql-query-handler.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/entities/query/entity/entity-graphql-query-handler.service.ts
@@ -59,7 +59,9 @@ export class EntityGraphQlQueryHandlerService implements GraphQlQueryHandler<Gra
       properties: request.properties,
       filters: [new GraphQlEntityFilter(request.id, request.entityType)],
       // If querying for a single API by ID, then usually want to includeInactive
-      includeInactive: request.includeInactive !== false
+      includeInactive: request.includeInactive !== false,
+      // If querying for a single API by ID, ignore all global filters on entities query
+      ignoreGlobalFilters: true
     };
   }
 }


### PR DESCRIPTION
## Description
Ignore global filters on the entities query when the request is for a single entity.
When a request for a single entity is made with an ID, expectation is that the user is taking an action to view that data deliberately. Global filters that might conflict with this ID based selection should be ignored.

### Testing
N/A

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules