### PR TITLE
fix: Group by Response Alias special characters

### DIFF
--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
@@ -7,7 +7,7 @@ import {
   TimeRangeService
 } from '@hypertrace/common';
 import { Filter } from '@hypertrace/components';
-import { uniqBy } from 'lodash-es';
+import { camelCase, uniqBy } from 'lodash-es';
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { debounceTime, defaultIfEmpty, distinctUntilChanged, map, shareReplay, takeUntil } from 'rxjs/operators';
 import { AttributeMetadata } from '../../graphql/model/metadata/attribute-metadata';
@@ -84,7 +84,7 @@ export class ExploreVisualizationBuilder implements OnDestroy {
 
   public groupBy(groupBy?: GraphQlGroupBy): this {
     return this.updateState({
-      groupBy: groupBy
+      groupBy: groupBy && this.encodeGroupBy(groupBy)
     });
   }
 
@@ -233,6 +233,18 @@ export class ExploreVisualizationBuilder implements OnDestroy {
     }
 
     return of(interval);
+  }
+
+  private encodeGroupBy(groupBy: GraphQlGroupBy): GraphQlGroupBy {
+    return {
+      ...groupBy,
+      keyExpressions: [
+        {
+          ...groupBy.keyExpressions[0],
+          subpath: camelCase(groupBy.keyExpressions[0].subpath)
+        }
+      ]
+    };
   }
 }
 

--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
@@ -238,14 +238,15 @@ export class ExploreVisualizationBuilder implements OnDestroy {
   private encodeGroupBy(groupBy: GraphQlGroupBy): GraphQlGroupBy {
     return {
       ...groupBy,
-      keyExpressions: groupBy.keyExpressions[0]
-        ? [
-            {
-              ...groupBy.keyExpressions[0],
-              subpath: groupBy.keyExpressions[0].subpath && camelCase(groupBy.keyExpressions[0].subpath)
-            }
-          ]
-        : []
+      keyExpressions:
+        groupBy.keyExpressions.length > 0
+          ? [
+              {
+                ...groupBy.keyExpressions[0],
+                subpath: camelCase(groupBy.keyExpressions[0].subpath)
+              }
+            ]
+          : []
     };
   }
 }

--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
@@ -7,7 +7,7 @@ import {
   TimeRangeService
 } from '@hypertrace/common';
 import { Filter } from '@hypertrace/components';
-import { camelCase, uniqBy } from 'lodash-es';
+import { uniqBy } from 'lodash-es';
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { debounceTime, defaultIfEmpty, distinctUntilChanged, map, shareReplay, takeUntil } from 'rxjs/operators';
 import { AttributeMetadata } from '../../graphql/model/metadata/attribute-metadata';
@@ -84,7 +84,7 @@ export class ExploreVisualizationBuilder implements OnDestroy {
 
   public groupBy(groupBy?: GraphQlGroupBy): this {
     return this.updateState({
-      groupBy: groupBy && this.encodeGroupBy(groupBy)
+      groupBy: groupBy
     });
   }
 
@@ -233,21 +233,6 @@ export class ExploreVisualizationBuilder implements OnDestroy {
     }
 
     return of(interval);
-  }
-
-  private encodeGroupBy(groupBy: GraphQlGroupBy): GraphQlGroupBy {
-    return {
-      ...groupBy,
-      keyExpressions:
-        groupBy.keyExpressions.length > 0
-          ? [
-              {
-                ...groupBy.keyExpressions[0],
-                subpath: camelCase(groupBy.keyExpressions[0].subpath)
-              }
-            ]
-          : []
-    };
   }
 }
 

--- a/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-visualization-builder.ts
@@ -238,12 +238,14 @@ export class ExploreVisualizationBuilder implements OnDestroy {
   private encodeGroupBy(groupBy: GraphQlGroupBy): GraphQlGroupBy {
     return {
       ...groupBy,
-      keyExpressions: [
-        {
-          ...groupBy.keyExpressions[0],
-          subpath: camelCase(groupBy.keyExpressions[0].subpath)
-        }
-      ]
+      keyExpressions: groupBy.keyExpressions[0]
+        ? [
+            {
+              ...groupBy.keyExpressions[0],
+              subpath: groupBy.keyExpressions[0].subpath && camelCase(groupBy.keyExpressions[0].subpath)
+            }
+          ]
+        : []
     };
   }
 }

--- a/projects/observability/src/shared/components/explore-query-editor/series/explore-query-series-editor.component.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/series/explore-query-series-editor.component.test.ts
@@ -41,8 +41,8 @@ describe('Explore Query Series Editor component', () => {
   beforeEach(() => {
     attributeMetadata.mockReset();
     attributeMetadata.mockReturnValue([
-      { name: 'test value', allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Max] },
-      { name: 'foo bar', allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Max] }
+      { name: 'test_value', allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Max] },
+      { name: 'foo_bar', allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Max] }
     ]);
   });
   test('updates on series change', fakeAsync(() => {
@@ -52,15 +52,15 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value')
+          series: buildSeries('test_value')
         }
       }
     );
     spectator.tick();
-    expect(spectator.element).toHaveText('test value');
+    expect(spectator.element).toHaveText('test_value');
 
-    spectator.setHostInput({ series: buildSeries('foo bar') });
-    expect(spectator.element).toHaveText('foo bar');
+    spectator.setHostInput({ series: buildSeries('foo_bar') });
+    expect(spectator.element).toHaveText('foo_bar');
   }));
 
   test('shows remove button only if removable', () => {
@@ -71,7 +71,7 @@ describe('Explore Query Series Editor component', () => {
       {
         hostProps: {
           removable: false,
-          series: buildSeries('test value')
+          series: buildSeries('test_value')
         }
       }
     );
@@ -91,7 +91,7 @@ describe('Explore Query Series Editor component', () => {
       {
         hostProps: {
           removable: true,
-          series: buildSeries('test value'),
+          series: buildSeries('test_value'),
           onRemove: onRemove
         }
       }
@@ -108,28 +108,28 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value')
+          series: buildSeries('test_value')
         }
       }
     );
 
     spectator.tick();
-    spectator.click(spectator.query(byText('test value'))!);
+    spectator.click(spectator.query(byText('test_value'))!);
     const options = spectator.queryAll('.select-option', { root: true });
 
     expect(options.length).toBe(2);
-    expect(options[0]).toHaveText('test value');
-    expect(options[1]).toHaveText('foo bar');
+    expect(options[0]).toHaveText('test_value');
+    expect(options[1]).toHaveText('foo_bar');
   }));
 
   test('displays aggregation options based on attribute selection', fakeAsync(() => {
     attributeMetadata.mockReturnValue([
       {
-        name: 'test value',
+        name: 'test_value',
         allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Min, MetricAggregationType.Sum]
       },
       {
-        name: 'foo bar'
+        name: 'foo_bar'
       }
     ]);
 
@@ -139,7 +139,7 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value', MetricAggregationType.Average)
+          series: buildSeries('test_value', MetricAggregationType.Average)
         }
       }
     );
@@ -163,7 +163,7 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value', MetricAggregationType.Average),
+          series: buildSeries('test_value', MetricAggregationType.Average),
           onChange: onChange
         }
       }
@@ -176,7 +176,7 @@ describe('Explore Query Series Editor component', () => {
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         specification: expect.objectContaining({
-          name: 'test value',
+          name: 'test_value',
           aggregation: MetricAggregationType.Max
         })
       })
@@ -192,7 +192,7 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value', MetricAggregationType.Average),
+          series: buildSeries('test_value', MetricAggregationType.Average),
           onChange: onChange
         }
       }
@@ -200,12 +200,12 @@ describe('Explore Query Series Editor component', () => {
 
     spectator.tick();
 
-    spectator.click(spectator.query(byText('test value'))!);
+    spectator.click(spectator.query(byText('test_value'))!);
     spectator.click(spectator.queryAll('.select-option', { root: true })[1]);
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         specification: expect.objectContaining({
-          name: 'foo bar',
+          name: 'foo_bar',
           aggregation: MetricAggregationType.Average
         })
       })
@@ -216,11 +216,11 @@ describe('Explore Query Series Editor component', () => {
   test("defaults to first aggregation when changing to an attribute that doesn't support existing aggregation", fakeAsync(() => {
     attributeMetadata.mockReturnValue([
       {
-        name: 'test value',
+        name: 'test_value',
         allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Max]
       },
       {
-        name: 'foo bar',
+        name: 'foo_bar',
         allowedAggregations: [MetricAggregationType.Min, MetricAggregationType.Max]
       }
     ]);
@@ -232,7 +232,7 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value', MetricAggregationType.Average),
+          series: buildSeries('test_value', MetricAggregationType.Average),
           onChange: onChange
         }
       }
@@ -240,12 +240,12 @@ describe('Explore Query Series Editor component', () => {
 
     spectator.tick();
 
-    spectator.click(spectator.query(byText('test value'))!);
+    spectator.click(spectator.query(byText('test_value'))!);
     spectator.click(spectator.queryAll('.select-option', { root: true })[1]);
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({
         specification: expect.objectContaining({
-          name: 'foo bar',
+          name: 'foo_bar',
           aggregation: MetricAggregationType.Min
         })
       })
@@ -257,11 +257,11 @@ describe('Explore Query Series Editor component', () => {
   test('disables aggregation selection when only one available', fakeAsync(() => {
     attributeMetadata.mockReturnValue([
       {
-        name: 'test value',
+        name: 'test_value',
         allowedAggregations: [MetricAggregationType.Sum]
       },
       {
-        name: 'foo bar'
+        name: 'foo_bar'
       }
     ]);
 
@@ -271,7 +271,7 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value', MetricAggregationType.Sum)
+          series: buildSeries('test_value', MetricAggregationType.Sum)
         }
       }
     );
@@ -290,7 +290,7 @@ describe('Explore Query Series Editor component', () => {
     </ht-explore-query-series-editor>`,
       {
         hostProps: {
-          series: buildSeries('test value', MetricAggregationType.Average),
+          series: buildSeries('test_value', MetricAggregationType.Average),
           onChange: onChange
         }
       }

--- a/projects/observability/src/shared/components/explore-query-editor/series/explore-query-series-group-editor.component.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/series/explore-query-series-group-editor.component.test.ts
@@ -127,6 +127,6 @@ describe('Explore Query Series Group Editor component', () => {
     spectator.queryAll(ExploreQuerySeriesEditorComponent)[0].seriesChange.emit(buildSeries('modified first'));
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith([matchSeriesWithName('modified first'), matchSeriesWithName('second')]);
+    expect(onChange).toHaveBeenCalledWith([matchSeriesWithName('modified_first'), matchSeriesWithName('second')]);
   });
 });

--- a/projects/observability/src/shared/graphql/request/builders/specification/explore/explore-specification-builder.ts
+++ b/projects/observability/src/shared/graphql/request/builders/specification/explore/explore-specification-builder.ts
@@ -40,7 +40,7 @@ export class ExploreSpecificationBuilder {
     expression: AttributeExpression,
     aggregation?: MetricAggregationType
   ): ExploreSpecification {
-    const expressionString = this.attributeExpressionAsString(expression).replaceAll('.', '_');
+    const expressionString = this.attributeExpressionAsString(expression).replace(/[^\w]/gi, '_');
     const queryAlias = aggregation === undefined ? expressionString : `${aggregation}_${expressionString}`;
 
     return {


### PR DESCRIPTION
Replace text to support alias (ignoring special chars or spaces)

### Testing
Tested Locally

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.