### PR TITLE
style(panel): update hover style

### DIFF
--- a/projects/components/src/panel/header/title/panel-title.component.scss
+++ b/projects/components/src/panel/header/title/panel-title.component.scss
@@ -4,10 +4,13 @@
   @include subtitle-2;
   display: inline-flex;
   align-items: center;
-  border-radius: 2px;
+  border-radius: 8px;
+  width: 100%;
+  padding: 8px 12px;
 
   .label {
     margin-left: 10px;
+    flex: 1;
   }
 
   &:hover {

--- a/projects/components/src/panel/panel.component.scss
+++ b/projects/components/src/panel/panel.component.scss
@@ -2,7 +2,6 @@
 @import 'color-palette';
 
 .ht-panel {
-  padding: 12px 10px;
   display: flex;
   flex-direction: column;
 
@@ -22,6 +21,7 @@
     flex: 1;
     overflow: auto;
     height: 100%;
+    padding: 0 12px 12px;
   }
 
   &.bordered {


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/29002760/187888324-6e3f5288-3442-4b13-a49b-bce204837443.png)

Updated the hover styles to select the complete header instead of just the title section.
- Added `flex:1` to the label container which is the container after the collapse button.