### PR TITLE
fix: stepper container should only overflow on y axis

### DIFF
--- a/projects/components/src/stepper/stepper.component.scss
+++ b/projects/components/src/stepper/stepper.component.scss
@@ -37,7 +37,7 @@
       height: 100%;
       display: flex;
       flex-direction: column;
-      overflow: auto;
+      overflow-y: auto;
       padding-bottom: 54px;
     }
   }


### PR DESCRIPTION
## Description
Stepper container should only overflow on y axis