### PR TITLE
feat: adding multiple ways to highlight a code line

### DIFF
--- a/projects/components/src/viewer/code-viewer/code-viewer.component.scss
+++ b/projects/components/src/viewer/code-viewer/code-viewer.component.scss
@@ -63,7 +63,7 @@
       width: 100%;
       display: flex;
       flex-direction: column;
-      overflow-x: auto;
+      overflow: auto hidden;
 
       .code-line {
         @include line-base;

--- a/projects/components/src/viewer/code-viewer/code-viewer.component.test.ts
+++ b/projects/components/src/viewer/code-viewer/code-viewer.component.test.ts
@@ -51,9 +51,25 @@ describe('Code Viewer Component', () => {
     expect(spectator.queryAll('.line-number.line-highlight').length).toBe(0);
     expect(spectator.queryAll('.code-line.line-highlight').length).toBe(0);
 
-    // Highlight text
+    // Highlight text (with string input)
     spectator.setInput({
       highlightText: 'key'
+    });
+
+    expect(spectator.queryAll('.code-line.line-highlight').length).toBe(1);
+    expect(spectator.queryAll('.code-line.line-highlight').length).toBe(1);
+
+    // Highlight text (with string[] input)
+    spectator.setInput({
+      highlightText: ['key']
+    });
+
+    expect(spectator.queryAll('.code-line.line-highlight').length).toBe(1);
+    expect(spectator.queryAll('.code-line.line-highlight').length).toBe(1);
+
+    // Highlight text (with RegExp input)
+    spectator.setInput({
+      highlightText: new RegExp('key')
     });
 
     expect(spectator.queryAll('.code-line.line-highlight').length).toBe(1);

--- a/projects/components/src/viewer/code-viewer/code-viewer.component.ts
+++ b/projects/components/src/viewer/code-viewer/code-viewer.component.ts
@@ -157,9 +157,15 @@ export class CodeViewerComponent implements AfterViewInit, OnChanges, OnDestroy 
     }
 
     if (changes.code || changes.highlightText) {
+      /**
+       * `isEmpty(new RexExp('anything'))` returns true, so here we need to make another check for RegExp
+       */
+      const emptyValue =
+        this.highlightText instanceof RegExp ? isEmpty(this.highlightText.source) : isEmpty(this.highlightText);
+
       this.lineHighlights = new Array(this.codeLines.length)
         .fill(false)
-        .map((_, index) => this.isLineHighlighted(index));
+        .map((_, index) => (emptyValue ? false : this.isLineHighlighted(index)));
     }
   }
 
@@ -206,15 +212,6 @@ export class CodeViewerComponent implements AfterViewInit, OnChanges, OnDestroy 
   }
 
   private isLineHighlighted(lineNum: number): boolean {
-    /**
-     * `isEmpty(new RexExp('anything'))` returns true, so here we need to make another check for RegExp
-     */
-    const emptyValue =
-      this.highlightText instanceof RegExp ? isEmpty(this.highlightText.source) : isEmpty(this.highlightText);
-    if (emptyValue) {
-      return false;
-    }
-
     if (typeof this.highlightText === 'string') {
       return this.codeTexts[lineNum].toLowerCase().includes(this.highlightText.toLowerCase());
     }

--- a/projects/components/src/viewer/code-viewer/code-viewer.component.ts
+++ b/projects/components/src/viewer/code-viewer/code-viewer.component.ts
@@ -224,7 +224,7 @@ export class CodeViewerComponent implements AfterViewInit, OnChanges, OnDestroy 
       return (codeText.match(this.highlightText) ?? []).length > 0;
     }
 
-    throw new Error('Invalid type for highlight text, only string, string[] and RegExp is allowed');
+    return false;
   }
 
   // Background elements for search

--- a/projects/components/src/viewer/code-viewer/code-viewer.component.ts
+++ b/projects/components/src/viewer/code-viewer/code-viewer.component.ts
@@ -165,7 +165,7 @@ export class CodeViewerComponent implements AfterViewInit, OnChanges, OnDestroy 
 
       this.lineHighlights = new Array(this.codeLines.length)
         .fill(false)
-        .map((_, index) => (emptyValue ? false : this.isLineHighlighted(index)));
+        .map((_, index) => (emptyValue ? false : this.isLineHighlighted(this.codeTexts[index].toLowerCase())));
     }
   }
 
@@ -211,17 +211,17 @@ export class CodeViewerComponent implements AfterViewInit, OnChanges, OnDestroy 
     });
   }
 
-  private isLineHighlighted(lineNum: number): boolean {
+  private isLineHighlighted(codeText: string): boolean {
     if (typeof this.highlightText === 'string') {
-      return this.codeTexts[lineNum].toLowerCase().includes(this.highlightText.toLowerCase());
+      return codeText.includes(this.highlightText.toLowerCase());
     }
 
     if (Array.isArray(this.highlightText)) {
-      return this.highlightText.some(text => this.codeTexts[lineNum].toLowerCase().includes(text.toLowerCase()));
+      return this.highlightText.some(text => codeText.includes(text.toLowerCase()));
     }
 
     if (this.highlightText instanceof RegExp) {
-      return (this.codeTexts[lineNum].match(this.highlightText) ?? []).length > 0;
+      return (codeText.match(this.highlightText) ?? []).length > 0;
     }
 
     throw new Error('Invalid type for highlight text, only string, string[] and RegExp is allowed');


### PR DESCRIPTION
## Description
Adding multiple ways to highlight a code line
- String (Already Present)
- String Array (New)
- RegExp (New)

### Testing
Local testing is done and added tests for newer support

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
