### PR TITLE
fix: add empty value template for string array table cell renderer

### DIFF
--- a/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.test.ts
+++ b/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.test.ts
@@ -36,8 +36,9 @@ describe('String array table cell renderer component', () => {
       providers: [tableCellDataProvider([])]
     });
 
-    expect(spectator.query('.first-item')).toHaveText('-');
-    expect(spectator.query(XMoreComponent)?.count).toBe(0);
+    expect(spectator.query('.string-array-cell')).toHaveText('-');
+    expect(spectator.query('.first-item')).not.toExist();
+    expect(spectator.query(XMoreComponent)).not.toExist();
   });
 
   test('should render array with multiple items as expected', () => {

--- a/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.ts
+++ b/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.ts
@@ -11,14 +11,17 @@ import { TableCellAlignmentType } from '../../types/table-cell-alignment-type';
   styleUrls: ['./string-array-table-cell-renderer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="string-array-cell" [htTooltip]="summaryTooltip">
-      <span class="first-item">{{ this.value[0] | htDisplayString }}</span>
-      <ht-x-more [count]="(this.value | slice: 1).length" displayStyle="${XMoreDisplay.Gray}"></ht-x-more>
+    <ng-container *ngIf="this.value?.length > 0; else emptyValueTemplate">
+      <div class="string-array-cell" [htTooltip]="summaryTooltip">
+        <span class="first-item">{{ this.value[0] | htDisplayString }}</span>
+        <ht-x-more [count]="(this.value | slice: 1).length" displayStyle="${XMoreDisplay.Gray}"></ht-x-more>
 
-      <ng-template #summaryTooltip>
-        <div *ngFor="let value of this.value">{{ value }}</div>
-      </ng-template>
-    </div>
+        <ng-template #summaryTooltip>
+          <div *ngFor="let value of this.value">{{ value }}</div>
+        </ng-template>
+      </div>
+    </ng-container>
+    <ng-template #emptyValueTemplate>-</ng-template>
   `
 })
 @TableCellRenderer({

--- a/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.ts
+++ b/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.ts
@@ -11,17 +11,18 @@ import { TableCellAlignmentType } from '../../types/table-cell-alignment-type';
   styleUrls: ['./string-array-table-cell-renderer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ng-container *ngIf="this.value?.length > 0; else emptyValueTemplate">
-      <div class="string-array-cell" [htTooltip]="summaryTooltip">
+    <div class="string-array-cell" [htTooltip]="this.value?.length > 0 ? summaryTooltip : undefined">
+      <ng-container *ngIf="this.value?.length > 0; else emptyValueTemplate">
         <span class="first-item">{{ this.value[0] | htDisplayString }}</span>
         <ht-x-more [count]="(this.value | slice: 1).length" displayStyle="${XMoreDisplay.Gray}"></ht-x-more>
+      </ng-container>
 
-        <ng-template #summaryTooltip>
-          <div *ngFor="let value of this.value">{{ value }}</div>
-        </ng-template>
-      </div>
-    </ng-container>
-    <ng-template #emptyValueTemplate>-</ng-template>
+      <ng-template #summaryTooltip>
+        <div *ngFor="let value of this.value">{{ value }}</div>
+      </ng-template>
+
+      <ng-template #emptyValueTemplate>-</ng-template>
+    </div>
   `
 })
 @TableCellRenderer({


### PR DESCRIPTION
## Description
Add empty value template for string array table cell renderer
- This takes care of cell value as `undefined`, `null`, and `[]` and save the code with possible null pointer exceptions.
- It shows `-` when a value is empty

### Testing
Local testing is done

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules