### PR TITLE
feat: Add backdrop property to create sheet service

### DIFF
--- a/projects/components/src/overlay/overlay.service.ts
+++ b/projects/components/src/overlay/overlay.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Injector } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { PopoverFixedPositionLocation, PopoverPositionType } from '../popover/popover';
+import { PopoverBackdrop, PopoverFixedPositionLocation, PopoverPositionType } from '../popover/popover';
 import { PopoverRef } from '../popover/popover-ref';
 import { PopoverService } from '../popover/popover.service';
 import { DefaultSheetRef } from './sheet/default-sheet-ref';
@@ -32,6 +32,7 @@ export class OverlayService {
         type: PopoverPositionType.Fixed,
         location: config.position ?? PopoverFixedPositionLocation.RightUnderHeader
       },
+      backdrop: config.backdrop ?? PopoverBackdrop.None,
       data: metadata
     });
 

--- a/projects/components/src/overlay/sheet/sheet.ts
+++ b/projects/components/src/overlay/sheet/sheet.ts
@@ -1,13 +1,14 @@
 import { InjectionToken, TemplateRef } from '@angular/core';
 import { ExternalNavigationParams } from '@hypertrace/common';
 import { Observable } from 'rxjs';
-import { PopoverFixedPositionLocation } from '../../popover/popover';
+import { PopoverBackdrop, PopoverFixedPositionLocation } from '../../popover/popover';
 import { OverlayConfig } from './../overlay';
 
 export interface SheetOverlayConfig<TData = unknown> extends OverlayConfig {
   size: SheetSize;
   data?: TData;
   position?: PopoverFixedPositionLocation.Right | PopoverFixedPositionLocation.RightUnderHeader;
+  backdrop?: PopoverBackdrop;
   closeOnEscapeKey?: boolean;
   closeOnNavigation?: boolean;
   attachedTriggerTemplate?: TemplateRef<unknown>;


### PR DESCRIPTION
## Description
Adding backdrop property to CreateSheet method in Overlay service

### Testing
Locally tested

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
