### PR TITLE
fix: remove sort from hidden column

### DIFF
--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -295,7 +295,6 @@ export class ExplorerDashboardBuilder {
               type: 'attribute-specification',
               attribute: 'endTime'
             },
-            sort: TableSortDirection.Descending,
             'click-handler': {
               type: 'api-trace-navigation-handler'
             }
@@ -504,7 +503,6 @@ export class ExplorerDashboardBuilder {
               type: 'attribute-specification',
               attribute: 'endTime'
             },
-            sort: TableSortDirection.Descending,
             'click-handler': {
               type: 'span-trace-navigation-handler'
             }


### PR DESCRIPTION
## Description

Default sort is on startTime, extra sort on endTime is overriding the default sort even though endTime column not shown.