### PR TITLE
Fix/stepper validation

### DIFF
--- a/projects/components/src/stepper/stepper.component.test.ts
+++ b/projects/components/src/stepper/stepper.component.test.ts
@@ -99,7 +99,6 @@ describe('Stepper Component', () => {
           }
         }
       );
-      spectator.tick(200); // <-- There is a 100ms debounce delay
       const actionButtons = spectator.queryAll(ButtonComponent);
       expect(spectator.query('.next')).toExist();
       expect(actionButtons[1].disabled).toBeFalsy();
@@ -122,7 +121,6 @@ describe('Stepper Component', () => {
           }
         }
       );
-      spectator.tick(200); // <-- There is a 100ms debounce delay
       const actionButtons = spectator.queryAll(ButtonComponent);
       expect(spectator.query('.next')).toExist();
       expect(actionButtons[1].disabled).toBeTruthy();
@@ -142,7 +140,6 @@ describe('Stepper Component', () => {
           }
         }
       );
-      spectator.tick(200); // <-- There is a 100ms debounce delay
       const actionButtons = spectator.queryAll(ButtonComponent);
       expect(spectator.query('.next')).toExist();
       expect(actionButtons[1].disabled).toBeFalsy();
@@ -169,7 +166,6 @@ describe('Stepper Component', () => {
     // Goto last step
     spectator.click('.next');
     spectator.click('.next');
-    spectator.tick(200); // <-- There is a 100ms debounce delay
 
     const actionButtons = spectator.queryAll(ButtonComponent);
     const submitButton = actionButtons[2]; // <-- ["Cancel", "Back", "Submit"]

--- a/projects/components/src/stepper/stepper.component.test.ts
+++ b/projects/components/src/stepper/stepper.component.test.ts
@@ -67,7 +67,7 @@ describe('Stepper Component', () => {
   });
 
   describe('Next button disabled state with completed status', () => {
-    test('should disable next button when the stepper is linear and first tab is not completed', fakeAsync(() => {
+    test('should disable next button when the stepper is linear and first tab is not completed', () => {
       spectator = createHost(
         `<ht-stepper class="stepper" [isLinear]="isLinear">
             <ht-stepper-tab label="Hello" [completed]="tabOneStatus"> Hello World!</ht-stepper-tab>
@@ -80,13 +80,12 @@ describe('Stepper Component', () => {
           }
         }
       );
-      spectator.tick(200); // <-- There is a 100ms debounce delay
       const actionButtons = spectator.queryAll(ButtonComponent);
       expect(spectator.query('.next')).toExist();
       expect(actionButtons[1].disabled).toBeTruthy();
-    }));
+    });
 
-    test('should enable next button when the stepper is linear and first tab is completed', fakeAsync(() => {
+    test('should enable next button when the stepper is linear and first tab is completed', () => {
       spectator = createHost(
         `<ht-stepper class="stepper" [isLinear]="isLinear">
             <ht-stepper-tab label="Hello" [completed]="tabOneStatus"> Hello World!</ht-stepper-tab>
@@ -99,14 +98,15 @@ describe('Stepper Component', () => {
           }
         }
       );
+      spectator.detectComponentChanges();
       const actionButtons = spectator.queryAll(ButtonComponent);
       expect(spectator.query('.next')).toExist();
       expect(actionButtons[1].disabled).toBeFalsy();
-    }));
+    });
   });
 
   describe('Next button disabled state with form validation', () => {
-    test('should disable next button when the stepper is linear and first tab form is invalid', fakeAsync(() => {
+    test('should disable next button when the stepper is linear and first tab form is invalid', () => {
       const formControl = new FormControl(undefined, [Validators.required]);
 
       spectator = createHost(
@@ -124,7 +124,7 @@ describe('Stepper Component', () => {
       const actionButtons = spectator.queryAll(ButtonComponent);
       expect(spectator.query('.next')).toExist();
       expect(actionButtons[1].disabled).toBeTruthy();
-    }));
+    });
     test('should enabled next button when the stepper is linear and first tab form is valid', fakeAsync(() => {
       const formControl = new FormControl('Hello', [Validators.required]);
 
@@ -140,13 +140,14 @@ describe('Stepper Component', () => {
           }
         }
       );
+      spectator.detectComponentChanges();
       const actionButtons = spectator.queryAll(ButtonComponent);
       expect(spectator.query('.next')).toExist();
       expect(actionButtons[1].disabled).toBeFalsy();
     }));
   });
 
-  test('should disable submit button correctly on tab completed state in linear mode', fakeAsync(() => {
+  test('should disable submit button correctly on tab completed state in linear mode', () => {
     spectator = createHost(
       `<ht-stepper class="stepper" [isLinear]="isLinear">
             <ht-stepper-tab label="Hello" [completed]="tabOneStatus"> Hello World!</ht-stepper-tab>
@@ -171,5 +172,5 @@ describe('Stepper Component', () => {
     const submitButton = actionButtons[2]; // <-- ["Cancel", "Back", "Submit"]
     expect(submitButton.label).toBe('Click me!');
     expect(submitButton.disabled).toBeTruthy();
-  }));
+  });
 });

--- a/projects/components/src/stepper/stepper.component.ts
+++ b/projects/components/src/stepper/stepper.component.ts
@@ -130,12 +130,13 @@ export class StepperComponent implements AfterContentInit {
       return true;
     }
 
-    const isValid = currentTab.stepControl ? currentTab.stepControl?.status === 'VALID' : currentTab?.completed;
-    const isLastStep = this.stepper ? this.stepper?.selectedIndex === this.stepper?.steps.length - 1 : true;
-    const isNextDisabled = this.isLinear && !isValid;
-    const isSubmitDisabled = !this.areAllStepsValid();
+    const isValid = currentTab.stepControl ? currentTab.stepControl.status === 'VALID' : currentTab.completed;
+    const isLastStep = this.stepper ? this.isLastStep(this.stepper) : true;
+    if (isLastStep) {
+      return !this.areAllStepsValid();
+    }
 
-    return isLastStep ? isSubmitDisabled : isNextDisabled;
+    return this.isLinear && !isValid;
   }
 
   /**
@@ -151,8 +152,12 @@ export class StepperComponent implements AfterContentInit {
   }
 
   public nextOrSubmit(stepper: MatStepper): void {
-    const isLastStep = stepper.selectedIndex === stepper.steps.length - 1;
-    isLastStep ? this.submitted.emit() : stepper.next();
+    const isLastStep = this.isLastStep(stepper);
+    if (isLastStep) {
+      this.submitted.emit();
+    } else {
+      stepper.next();
+    }
   }
 
   public getActionButtonLabel(selectedIndex: number, steps: StepperTabComponent[]): string {
@@ -176,6 +181,10 @@ export class StepperComponent implements AfterContentInit {
    */
   private areAllStepsValid(): boolean {
     return this.steps.toArray().every((_, index) => this.isStepCompleted(index));
+  }
+
+  private isLastStep(stepper: MatStepper): boolean {
+    return stepper.selectedIndex === stepper.steps.length - 1;
   }
 }
 


### PR DESCRIPTION
## Description
When using step control with the stepper, the Next/Submit buttons were not getting disabled/enabled until user actually hovers over the component (Change detection issue). This PR adds a fix to the issue, by switching to an observable.

Continued from https://github.com/hypertrace/hypertrace-ui/pull/1835
Based on the discussion. Implemented methods with explicit change detection checks.