### PR TITLE
fix: update close subject in the sheet when popover gets closed

### DIFF
--- a/projects/components/src/overlay/sheet/default-sheet-ref.ts
+++ b/projects/components/src/overlay/sheet/default-sheet-ref.ts
@@ -7,6 +7,7 @@ export class DefaultSheetRef extends SheetRef {
 
   private readonly closedObserver: Observer<unknown>;
   private popoverRef?: PopoverRef;
+  private closedWithResult: boolean = false;
 
   public constructor() {
     super();
@@ -18,7 +19,12 @@ export class DefaultSheetRef extends SheetRef {
   public initialize(popoverRef: PopoverRef): void {
     this.popoverRef = popoverRef;
     this.popoverRef.closed$.subscribe({
-      next: () => this.closedObserver.next(undefined),
+      next: () => {
+        if (!this.closedWithResult) {
+          this.closedObserver.next(undefined);
+        }
+        this.closedWithResult = false;
+      },
       complete: () => this.closedObserver.complete(),
       error: err => this.closedObserver.error(err)
     });
@@ -27,6 +33,7 @@ export class DefaultSheetRef extends SheetRef {
   public close(result?: unknown): void {
     if (result !== undefined) {
       this.closedObserver.next(result);
+      this.closedWithResult = true;
     }
     this.popoverRef?.close();
   }

--- a/projects/components/src/overlay/sheet/default-sheet-ref.ts
+++ b/projects/components/src/overlay/sheet/default-sheet-ref.ts
@@ -18,6 +18,7 @@ export class DefaultSheetRef extends SheetRef {
   public initialize(popoverRef: PopoverRef): void {
     this.popoverRef = popoverRef;
     this.popoverRef.closed$.subscribe({
+      next: () => this.closedObserver.next(undefined),
       complete: () => this.closedObserver.complete(),
       error: err => this.closedObserver.error(err)
     });


### PR DESCRIPTION
## Description
Currently, Sheet's `closed$` doesn't get updated when `popoverRef.close()` happens from the `SheetOverlayComponent`.
This change will allow that to happen

### Testing
Local testing is done

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules