### PR TITLE
fix: allow writing query params while nav in flight

### DIFF
--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -30,6 +30,7 @@ export class NavigationService {
 
   private isFirstNavigation: boolean = true;
   private readonly globalQueryParams: Set<string> = new Set();
+  private pendingQueryParams: QueryParamObject = {};
 
   public constructor(
     private readonly router: Router,
@@ -44,19 +45,25 @@ export class NavigationService {
 
     this.navigation$
       .pipe(
-        switchMap(() => this.getCurrentActivatedRoute().data),
-        tap(routeData =>
-          this.titleService.setTitle(routeData.title ? `${this.appTitle} | ${routeData.title}` : this.appTitle)
-        )
+        switchMap(route => route.data),
+        tap(routeData => {
+          this.pendingQueryParams = {};
+          this.titleService.setTitle(routeData.title ? `${this.appTitle} | ${routeData.title}` : this.appTitle);
+        })
       )
       .subscribe();
   }
 
   public addQueryParametersToUrl(newParams: QueryParamObject): Observable<boolean> {
+    this.pendingQueryParams = {
+      ...this.pendingQueryParams,
+      ...newParams
+    };
+
     return this.navigate({
       navType: NavigationParamsType.InApp,
       path: [],
-      queryParams: newParams,
+      queryParams: this.pendingQueryParams,
       queryParamsHandling: 'merge',
       replaceCurrentHistory: true
     });

--- a/projects/common/src/time/time-range.service.ts
+++ b/projects/common/src/time/time-range.service.ts
@@ -61,8 +61,10 @@ export class TimeRangeService {
   }
 
   public refresh(): void {
-    const currentStringTimeRange = this.getCurrentTimeRange().toUrlString();
-    this.applyTimeRangeChange(this.timeRangeFromUrlString(currentStringTimeRange));
+    if (this.isInitialized()) {
+      const currentStringTimeRange = this.getCurrentTimeRange().toUrlString();
+      this.applyTimeRangeChange(this.timeRangeFromUrlString(currentStringTimeRange));
+    }
   }
 
   private isValidTimeRange(timeRange: TimeRange): boolean {


### PR DESCRIPTION
## Description
2 Changes
1. We've had a long standing issue where two different calls to add query params will cause the first to be ignored (because it cancels the nav in flight and starts a new one, so the query params don't get merged. Now, we hold query params until a nav finishes, and if another request arrives, we merge the prior in.
2. If time range refresh is called very early in app bootstrap, it leads to an error as the time range hasn't been initialized yet. Instead, treat it as a no-op.