### PR TITLE
feat(gql): query operation name in network tab

### DIFF
--- a/projects/graphql-client/src/graphql-config.ts
+++ b/projects/graphql-client/src/graphql-config.ts
@@ -9,12 +9,14 @@ export interface GraphQlHandler<TRequest, TResponse> {
   readonly type: GraphQlHandlerType;
 
   matchesRequest(request: unknown): request is TRequest;
+
   /**
    * Converts the provided request into a single selection, or a map of selections with arbitrary keys.
    * If a map is provided, the response provided to the converter will use the same keys to disambiguate
    * the response for each selection.
    */
   convertRequest(request: TRequest): GraphQlSelection | Map<unknown, GraphQlSelection>;
+
   /**
    * Converts the provided response, or map of responses (if a map of selections were provided in the request
    * conversion), to a response object.
@@ -32,9 +34,15 @@ export interface GraphQlMutationHandler<TRequest, TResponse> extends GraphQlHand
   readonly type: GraphQlHandlerType.Mutation;
 }
 
+/**
+ * @param cacheability - Cache config
+ * @param isolated - If true, the request will be sent to the backend without any other requests in the same batch.
+ * @param name - The name of the query or mutation which will be shown in the network tab
+ */
 export interface GraphQlRequestOptions {
   cacheability?: GraphQlRequestCacheability;
   isolated?: boolean;
+  name?: string;
 }
 
 export const enum GraphQlRequestCacheability {

--- a/projects/graphql-client/src/model/graphql-selection.ts
+++ b/projects/graphql-client/src/model/graphql-selection.ts
@@ -2,6 +2,7 @@ import { GraphQlArgument } from './graphql-argument';
 
 export interface GraphQlSelection {
   path: string;
+  name?: string;
   arguments?: GraphQlArgument[];
   children?: GraphQlSelection[];
   alias?: string;

--- a/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
+++ b/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
@@ -31,7 +31,10 @@ export class GraphQlRequestBuilder {
     return new Map(
       this.originalSelections.map(selection => {
         const key = this.getKeyForSelection(selection);
-        const requestString = `{ ${this.translateRequestFragmentToGql(key, this.mergedRequest[key])} }`;
+        const requestString = `${selection.name ?? selection.path} { ${this.translateRequestFragmentToGql(
+          key,
+          this.mergedRequest[key]
+        )} }`;
 
         return [selection, requestString];
       })
@@ -199,5 +202,6 @@ interface MergedRequestArgumentMap {
 
 interface GeneratedRequestKey {
   toString(): string;
+
   next(): GeneratedRequestKey;
 }

--- a/projects/graphql-client/src/utils/resolver/graphql-request-option-resolver.ts
+++ b/projects/graphql-client/src/utils/resolver/graphql-request-option-resolver.ts
@@ -5,7 +5,7 @@ export class GraphQlRequestOptionResolver {
 
   public groupQueriesByResolvedOptions(
     ...requests: GraphQlRequestWithOptions[]
-  ): Map<GraphQlRequestOptions, GraphQlRequest[]> {
+  ): Map<GraphQlRequestOptions, GraphQlRequestWithMetadata[]> {
     return requests
       .map(request => this.resolveOptions(request))
       .reduce((resolvedMap, request) => {
@@ -13,11 +13,11 @@ export class GraphQlRequestOptionResolver {
           this.areOptionsCompatible(options, request.options)
         ) || [request.options, []];
 
-        entryToUpdate[1].push(request.request);
+        entryToUpdate[1].push({ request: request.request, name: request.options.name });
         resolvedMap.set(...entryToUpdate);
 
         return resolvedMap;
-      }, new Map<GraphQlRequestOptions, GraphQlRequest[]>());
+      }, new Map<GraphQlRequestOptions, GraphQlRequestWithMetadata[]>());
   }
 
   private areOptionsCompatible(first: GraphQlRequestOptions, second: GraphQlRequestOptions): boolean {
@@ -37,6 +37,7 @@ export class GraphQlRequestOptionResolver {
 }
 
 type GraphQlRequest = unknown;
+
 interface GraphQlRequestWithMergedOptions {
   request: GraphQlRequest;
   options: GraphQlRequestOptions;
@@ -46,4 +47,9 @@ export interface GraphQlRequestWithOptions {
   request: GraphQlRequest;
   handlerOptions?: GraphQlRequestOptions;
   requestOptions?: GraphQlRequestOptions;
+}
+
+export interface GraphQlRequestWithMetadata {
+  request: GraphQlRequest;
+  name?: string;
 }


### PR DESCRIPTION
## Description
Add support for query naming. This will make identifying queries in Network panel much easier.

## Usage
```ts
  private querySomething() {
    return this.gql.query(
      {
        requestType: ''
      },
      {
        cacheability: GraphQlRequestCacheability.Cacheable,
        name: 'FetchEntities' // <-- provide name
      }
    );
  }
```

![image](https://user-images.githubusercontent.com/29002760/197332806-be1b12c3-c0d2-486b-824c-0ec57ead5a14.png)
