### PR TITLE
fix: don't count a navigation until history change

### DIFF
--- a/projects/common/src/navigation/navigation.service.ts
+++ b/projects/common/src/navigation/navigation.service.ts
@@ -5,6 +5,7 @@ import {
   ActivatedRoute,
   ActivatedRouteSnapshot,
   Event,
+  Navigation,
   NavigationEnd,
   NavigationExtras,
   ParamMap,
@@ -40,7 +41,11 @@ export class NavigationService {
     @Optional() @Inject(APP_TITLE) private readonly appTitle: string
   ) {
     this.event$(RoutesRecognized)
-      .pipe(skip(1), take(1))
+      .pipe(
+        skip(1),
+        filter(() => !this.getActiveNavigation()?.extras.skipLocationChange),
+        take(1)
+      )
       .subscribe(() => (this.isFirstNavigation = false));
 
     this.navigation$
@@ -142,6 +147,10 @@ export class NavigationService {
         relativeTo: params?.relativeTo
       }
     };
+  }
+
+  public getActiveNavigation(): Navigation | undefined {
+    return this.router.getCurrentNavigation() ?? undefined;
   }
 
   public buildNavigationParams$(


### PR DESCRIPTION
## Description
Fixed the tracking of first navigation (used to handle in-app back behavior), to ignore if we update the URL without changing history. This was previously causing erroneous back navigation out of the app.

### Testing
Local E2E
