### PR TITLE
fix: Adapt the height of the multi-select component with other components

### DIFF
--- a/projects/components/src/multi-select/multi-select.component.scss
+++ b/projects/components/src/multi-select/multi-select.component.scss
@@ -7,11 +7,6 @@
   height: 100%;
   width: 100%;
 
-  &.border {
-    border: 1px solid $color-border;
-    border-radius: 6px;
-  }
-
   .multi-select-container {
     width: 100%;
   }
@@ -48,6 +43,11 @@
 
     &.open {
       background-color: $gray-2;
+    }
+
+    &.border {
+      border: 1px solid $color-border;
+      border-radius: 6px;
     }
 
     &.icon-mode {

--- a/projects/components/src/multi-select/multi-select.component.ts
+++ b/projects/components/src/multi-select/multi-select.component.ts
@@ -39,15 +39,7 @@ import { MultiSelectJustify } from './multi-select-justify';
     }
   ],
   template: `
-    <div
-      class="multi-select"
-      [ngClass]="[
-        this.size,
-        this.showBorder ? 'border' : '',
-        this.disabled ? 'disabled' : '',
-        this.popoverOpen ? 'open' : ''
-      ]"
-    >
+    <div class="multi-select" [ngClass]="[this.size, this.disabled ? 'disabled' : '', this.popoverOpen ? 'open' : '']">
       <ht-popover
         [disabled]="this.disabled"
         class="multi-select-container"
@@ -63,6 +55,7 @@ import { MultiSelectJustify } from './multi-select-justify';
               this.popoverOpen ? 'open' : '',
               this.size,
               this.disabled ? 'disabled' : '',
+              this.showBorder ? 'border' : '',
               this.triggerDisplayMode
             ]"
             #triggerContainer


### PR DESCRIPTION
## Description

The border was misplaced and created extra space that didn't fit properly with the other components in the library.

### Testing
Tested Locally

Old:
![image](https://user-images.githubusercontent.com/79482271/198357777-df871a5e-1bc0-4226-b8c7-cbec536c66b6.png)

New: 
![image](https://user-images.githubusercontent.com/79482271/198357632-2518c3be-21b1-4d1d-8cf4-82277cfda654.png)

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
