### PR TITLE
fix: added limit to StringArrayCellRenderer tooltip

### DIFF
--- a/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.ts
+++ b/projects/components/src/table/cells/data-renderers/string-array/string-array-table-cell-renderer.component.ts
@@ -1,5 +1,14 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
 import { XMoreDisplay } from '../../../../x-more/x-more.component';
+import { TableColumnConfig, TableRow } from '../../../table-api';
+import {
+  TABLE_CELL_DATA,
+  TABLE_COLUMN_CONFIG,
+  TABLE_COLUMN_INDEX,
+  TABLE_DATA_PARSER,
+  TABLE_ROW_DATA
+} from '../../table-cell-injection';
+import { TableCellParserBase } from '../../table-cell-parser-base';
 import { TableCellRenderer } from '../../table-cell-renderer';
 import { TableCellRendererBase } from '../../table-cell-renderer-base';
 import { CoreTableCellParserType } from '../../types/core-table-cell-parser-type';
@@ -18,7 +27,11 @@ import { TableCellAlignmentType } from '../../types/table-cell-alignment-type';
       </ng-container>
 
       <ng-template #summaryTooltip>
-        <div *ngFor="let value of this.value">{{ value }}</div>
+        <div *ngFor="let value of this.value | slice: 0:this.maxItemsInTooltip">{{ value }}</div>
+        <ht-label
+          *ngIf="this.value.length > this.maxItemsInTooltip"
+          [label]="this.getOffsetLabel | htMemoize: this.value.length - this.maxItemsInTooltip"
+        ></ht-label>
       </ng-template>
 
       <ng-template #emptyValueTemplate>-</ng-template>
@@ -30,4 +43,20 @@ import { TableCellAlignmentType } from '../../types/table-cell-alignment-type';
   alignment: TableCellAlignmentType.Left,
   parser: CoreTableCellParserType.NoOp
 })
-export class StringArrayTableCellRendererComponent extends TableCellRendererBase<string[]> implements OnInit {}
+export class StringArrayTableCellRendererComponent extends TableCellRendererBase<string[]> implements OnInit {
+  public maxItemsInTooltip: number = 50;
+
+  public constructor(
+    @Inject(TABLE_COLUMN_CONFIG) columnConfig: TableColumnConfig,
+    @Inject(TABLE_COLUMN_INDEX) index: number,
+    @Inject(TABLE_DATA_PARSER) parser: TableCellParserBase<string[], string[], boolean>,
+    @Inject(TABLE_CELL_DATA) cellData: string[],
+    @Inject(TABLE_ROW_DATA) rowData: TableRow
+  ) {
+    super(columnConfig, index, parser, cellData, rowData);
+  }
+
+  public getOffsetLabel(count: number): string {
+    return count === 1 ? '+1 other' : `+${count} others`;
+  }
+}

--- a/projects/components/src/table/cells/table-cells.module.ts
+++ b/projects/components/src/table/cells/table-cells.module.ts
@@ -1,13 +1,14 @@
 import { CdkTableModule } from '@angular/cdk/table';
 import { CommonModule } from '@angular/common';
 import { Inject, InjectionToken, NgModule } from '@angular/core';
-import { FormattingModule } from '@hypertrace/common';
+import { FormattingModule, MemoizeModule } from '@hypertrace/common';
 import { CheckboxModule } from '../../checkbox/checkbox.module';
 import { CopyToClipboardModule } from '../../copy-to-clipboard/copy-to-clipboard.module';
 import { ExpanderToggleModule } from '../../expander/expander-toggle.module';
 import { FilterButtonModule } from '../../filtering/filter-button/filter-button.module';
 import { FilterModalModule } from '../../filtering/filter-modal/filter-modal.module';
 import { IconModule } from '../../icon/icon.module';
+import { LabelModule } from '../../label/label.module';
 import { PopoverModule } from '../../popover/popover.module';
 import { TooltipModule } from '../../tooltip/tooltip.module';
 import { XMoreModule } from '../../x-more/x-more.module';
@@ -38,8 +39,6 @@ import { TableCellParserConstructor } from './table-cell-parser';
 import { TableCellParserLookupService } from './table-cell-parser-lookup.service';
 import { TableCellRendererConstructor } from './table-cell-renderer';
 import { TableCellRendererLookupService } from './table-cell-renderer-lookup.service';
-import { LabelModule } from './../../label/label.module';
-import { MemoizeModule } from '@hypertrace/common';
 
 export const TABLE_CELL_RENDERERS = new InjectionToken<unknown[][]>('TABLE_CELL_RENDERERS');
 export const TABLE_CELL_PARSERS = new InjectionToken<unknown[][]>('TABLE_CELL_PARSERS');

--- a/projects/components/src/table/cells/table-cells.module.ts
+++ b/projects/components/src/table/cells/table-cells.module.ts
@@ -38,6 +38,8 @@ import { TableCellParserConstructor } from './table-cell-parser';
 import { TableCellParserLookupService } from './table-cell-parser-lookup.service';
 import { TableCellRendererConstructor } from './table-cell-renderer';
 import { TableCellRendererLookupService } from './table-cell-renderer-lookup.service';
+import { LabelModule } from './../../label/label.module';
+import { MemoizeModule } from '@hypertrace/common';
 
 export const TABLE_CELL_RENDERERS = new InjectionToken<unknown[][]>('TABLE_CELL_RENDERERS');
 export const TABLE_CELL_PARSERS = new InjectionToken<unknown[][]>('TABLE_CELL_PARSERS');
@@ -55,7 +57,9 @@ export const TABLE_CELL_PARSERS = new InjectionToken<unknown[][]>('TABLE_CELL_PA
     FilterModalModule,
     PopoverModule,
     CopyToClipboardModule,
-    XMoreModule
+    LabelModule,
+    XMoreModule,
+    MemoizeModule
   ],
   exports: [
     TableHeaderCellRendererComponent,


### PR DESCRIPTION
This PR adds a limit to StringArrayCellRenderer tooltip items. Currently, if a large size array is supplied to the renderer it hangs up the screen in order to render all the items in tooltip on hover.