### PR TITLE
refactor: no deselect mode for color picker

### DIFF
--- a/projects/components/src/color-picker/color-picker.component.ts
+++ b/projects/components/src/color-picker/color-picker.component.ts
@@ -49,8 +49,9 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
   @Input()
   public disabled?: boolean = false;
 
+  // Disables de-selecting current option, meaning only allow selection to another option
   @Input()
-  public noDeselectMode?: boolean = false;
+  public disableDeselection?: boolean = false;
 
   @Output()
   private readonly selectedChange: EventEmitter<string> = new EventEmitter<string>();
@@ -81,7 +82,7 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
   }
 
   public selectColor(color: string): void {
-    if (this.disabled || (this.noDeselectMode && color === this.selected)) {
+    if (this.disabled || (this.disableDeselection && color === this.selected)) {
       return;
     }
 

--- a/projects/components/src/color-picker/color-picker.component.ts
+++ b/projects/components/src/color-picker/color-picker.component.ts
@@ -51,7 +51,7 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
 
   // Disables de-selecting current option, meaning only allow selection to another option
   @Input()
-  public disableDeselection?: boolean = false;
+  public disableDeselection: boolean = false;
 
   @Output()
   private readonly selectedChange: EventEmitter<string> = new EventEmitter<string>();

--- a/projects/components/src/color-picker/color-picker.component.ts
+++ b/projects/components/src/color-picker/color-picker.component.ts
@@ -49,6 +49,9 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
   @Input()
   public disabled?: boolean = false;
 
+  @Input()
+  public noDeselectMode?: boolean = false;
+
   @Output()
   private readonly selectedChange: EventEmitter<string> = new EventEmitter<string>();
 
@@ -78,7 +81,7 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
   }
 
   public selectColor(color: string): void {
-    if (this.disabled) {
+    if (this.disabled || (this.noDeselectMode && color === this.selected)) {
       return;
     }
 

--- a/projects/components/src/color-picker/color-picker.component.ts
+++ b/projects/components/src/color-picker/color-picker.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Out
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { IconType } from '@hypertrace/assets-library';
 import { Color, TypedSimpleChanges } from '@hypertrace/common';
-import { isNil } from 'lodash-es';
 import { IconSize } from '../icon/icon-size';
 
 @Component({
@@ -87,10 +86,11 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
       return;
     }
 
-    const clickedColor = this.selected === color ? undefined : color;
-    if (this.required && isNil(clickedColor)) {
+    const isDeselect = this.selected === color;
+    if (this.required && isDeselect) {
       return;
     }
+    const clickedColor = isDeselect ? undefined : color;
     this.selected = clickedColor;
     this.selectedChange.emit(clickedColor);
     this.propagateValueChangeToFormControl(clickedColor);

--- a/projects/components/src/color-picker/color-picker.component.ts
+++ b/projects/components/src/color-picker/color-picker.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Out
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { IconType } from '@hypertrace/assets-library';
 import { Color, TypedSimpleChanges } from '@hypertrace/common';
+import { isNil } from 'lodash-es';
 import { IconSize } from '../icon/icon-size';
 
 @Component({
@@ -51,7 +52,7 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
 
   // Disables de-selecting current option, meaning only allow selection to another option
   @Input()
-  public disableDeselection: boolean = false;
+  public required?: boolean = false;
 
   @Output()
   private readonly selectedChange: EventEmitter<string> = new EventEmitter<string>();
@@ -82,11 +83,14 @@ export class ColorPickerComponent implements ControlValueAccessor, OnChanges {
   }
 
   public selectColor(color: string): void {
-    if (this.disabled || (this.disableDeselection && color === this.selected)) {
+    if (this.disabled) {
       return;
     }
 
     const clickedColor = this.selected === color ? undefined : color;
+    if (this.required && isNil(clickedColor)) {
+      return;
+    }
     this.selected = clickedColor;
     this.selectedChange.emit(clickedColor);
     this.propagateValueChangeToFormControl(clickedColor);


### PR DESCRIPTION
## Description
Adds input config option to color picker to disallow de-selecting current element, and only allow change selection to another option

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
