### PR TITLE
feat: disable tooltip on hover for topology

### DIFF
--- a/projects/observability/src/shared/components/topology/d3/d3-topology.ts
+++ b/projects/observability/src/shared/components/topology/d3/d3-topology.ts
@@ -337,7 +337,10 @@ export class D3Topology implements Topology {
         this.neighborhoodFinder.neighborhoodForNode(hoverEvent.source.userNode),
         this.neighborhoodFinder.singleNodeNeighborhood(hoverEvent.source.userNode)
       );
-      this.showNodeTooltip(hoverEvent.source, false);
+
+      if (!(this.config.nodeInteractionHandler?.disableTooltipOnHover ?? false)) {
+        this.showNodeTooltip(hoverEvent.source, false);
+      }
     }
   }
 
@@ -347,7 +350,10 @@ export class D3Topology implements Topology {
       this.tooltip && this.tooltip.hide();
     } else {
       this.emphasizeTopologyNeighborhood(this.neighborhoodFinder.neighborhoodForEdge(hoverEvent.source.userEdge));
-      this.showEdgeTooltip(hoverEvent.source, false);
+
+      if (!(this.config.edgeInteractionHandler?.disableTooltipOnHover ?? false)) {
+        this.showEdgeTooltip(hoverEvent.source, false);
+      }
     }
   }
 

--- a/projects/observability/src/shared/components/topology/topology.ts
+++ b/projects/observability/src/shared/components/topology/topology.ts
@@ -221,6 +221,7 @@ export interface TopologyTooltipOptions {
 
 export interface TopologyInteractionHandler<T = unknown> {
   click?(data: T): Observable<true>; // Observable is used to reset visibility (Eg. closed$ for popover)
+  disableTooltipOnHover?: boolean; // Default to `false`
 }
 
 export type TopologyNodeInteractionHandler = TopologyInteractionHandler<TopologyNode>;


### PR DESCRIPTION
## Description
Added a configuration to disable the tooltip on hover for topology nodes and edges.

### Testing
Local testing is done

### Checklist:
- [x] My changes generate no new warnings