### PR TITLE
Add optional fields to explorer table

### DIFF
--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.test.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.test.ts
@@ -135,9 +135,13 @@ describe('Explorer dashboard builder', () => {
               expect.objectContaining({ title: 'API Discovery State' }),
               expect.objectContaining({ title: 'API ID' }),
               expect.objectContaining({ title: 'Entry Span ID' }),
+              expect.objectContaining({ title: 'IP Address' }),
               expect.objectContaining({ title: 'Service ID' }),
               expect.objectContaining({ title: 'Trace ID' }),
               expect.objectContaining({ title: 'Request URL' }),
+              expect.objectContaining({ title: 'User Agent' }),
+              expect.objectContaining({ title: 'User City' }),
+              expect.objectContaining({ title: 'User Country' }),
               expect.objectContaining({ title: 'Foo' })
             ]
           },

--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -357,6 +357,19 @@ export class ExplorerDashboardBuilder {
           },
           {
             type: 'table-widget-column',
+            title: 'IP Address',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userAgent'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
             title: 'Service ID',
             width: '1',
             visible: false,
@@ -400,19 +413,6 @@ export class ExplorerDashboardBuilder {
           {
             type: 'table-widget-column',
             title: 'User Agent',
-            visible: false,
-            filterable: true,
-            value: {
-              type: 'attribute-specification',
-              attribute: 'userAgent'
-            },
-            'click-handler': {
-              type: 'api-trace-navigation-handler'
-            }
-          },
-          {
-            type: 'table-widget-column',
-            title: 'IP Address',
             visible: false,
             filterable: true,
             value: {
@@ -561,6 +561,19 @@ export class ExplorerDashboardBuilder {
           },
           {
             type: 'table-widget-column',
+            title: 'IP Address',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userAgent'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
             visible: false,
             filterable: true,
             value: {
@@ -574,19 +587,6 @@ export class ExplorerDashboardBuilder {
           {
             type: 'table-widget-column',
             title: 'User Agent',
-            visible: false,
-            filterable: true,
-            value: {
-              type: 'attribute-specification',
-              attribute: 'userAgent'
-            },
-            'click-handler': {
-              type: 'api-trace-navigation-handler'
-            }
-          },
-          {
-            type: 'table-widget-column',
-            title: 'IP Address',
             visible: false,
             filterable: true,
             value: {

--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -396,6 +396,58 @@ export class ExplorerDashboardBuilder {
             'click-handler': {
               type: 'api-trace-navigation-handler'
             }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'User Agent',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userAgent'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'IP Address',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userAgent'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'User City',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userCity'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'User Country',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userCountry'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
           }
         ];
       case SPAN_SCOPE:
@@ -517,6 +569,58 @@ export class ExplorerDashboardBuilder {
             },
             'click-handler': {
               type: 'span-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'User Agent',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userAgent'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'IP Address',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userAgent'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'User City',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userCity'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
+            }
+          },
+          {
+            type: 'table-widget-column',
+            title: 'User Country',
+            visible: false,
+            filterable: true,
+            value: {
+              type: 'attribute-specification',
+              attribute: 'userCountry'
+            },
+            'click-handler': {
+              type: 'api-trace-navigation-handler'
             }
           }
         ];


### PR DESCRIPTION
## Description
Adding  add user agent, IP address, user city, country in the optional columns in traces

### Testing
Locally tested

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
