### PR TITLE
fix: row expansion when a row is already selected

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -666,9 +666,15 @@ export class TableComponent
   }
 
   public toggleRowExpanded(row: StatefulTableRow): void {
-    row.$$state.expanded = !row.$$state.expanded;
-    this.rowStateSubject.next(row);
-    this.toggleRowChange.emit(row);
+    const updatedRow = {
+      ...row,
+      $$state: {
+        ...row.$$state,
+        expanded: !row.$$state.expanded
+      }
+    };
+    this.rowStateSubject.next(updatedRow);
+    this.toggleRowChange.emit(updatedRow);
     this.changeDetector.markForCheck();
   }
 


### PR DESCRIPTION
## Description
Bug: Unable to expand table row when a row has already been selected

1. In table component, `toggleRowExpanded()` , we do a mutation on the toggled row: `row.$$state.expanded = !row.$$state.expanded;`
2. When we do this before a table row selection has occurred, `row` in `toggledRowExpanded()` does not share the same memory address as any of the `this.dataSource.cachedData.rows` (in the dataSource, cdk-table-data-source)
3. However when we do this after a selection has occurred, the nth row does share the same memory address as `this.dataSource.cachedData.rows[n]` which means when the mutation in point 1. happens, we are modifying the cached row.
4. The reason that point 3. matters, is because `toggleRowExpanded()` triggers `buildDataObservable() -> fetchAndAppendNewChildren()` to run, which is responsible for getting all the rows + new child rows we want expanded. However it fails to append new children because `isNewlyExpandedParentRow` fails the check, this check fails because `this.cachedData.rows[n].expanded` has been modified, because of point 1/3.
5. The reason row selection causes the table component stateful table rows to reference the same objects as `this.cachedData.rows`: 
  - row selection triggers this.selectionsChange in toggleRowSelected() which eventually ends up calling toggleRowSelections() (from CD)
  - which in turn calls  the data source methods unselectAllRows() and selectAllRows() <- these methods are the culprit for everything. They read this.cachedData.rows and without creating new objects, they modify, and emit these rows to rowsChange$
   - this triggers the whole this.changeSubscription cycle to emit in connect() and the rows(same ones referencing the cache) are passed on to be used in the component


### Changes in this PR:
Removes the row mutation made in `toggleRowExpanded`
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
