### PR TITLE
fix(radio-group): write value bug fix

### DIFF
--- a/projects/components/src/radio/radio-group.component.ts
+++ b/projects/components/src/radio/radio-group.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  TemplateRef
+} from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatRadioChange } from '@angular/material/radio';
 import { LoggerService } from '@hypertrace/common';
@@ -68,7 +77,7 @@ export class RadioGroupComponent implements ControlValueAccessor, OnInit {
   private propagateControlValueChange?: (value: string | undefined) => void;
   private propagateControlValueChangeOnTouch?: (value: string | undefined) => void;
 
-  public constructor(private readonly loggerService: LoggerService) {}
+  public constructor(private readonly loggerService: LoggerService, private readonly cdr: ChangeDetectorRef) {}
 
   public ngOnInit(): void {
     // tslint:disable-next-line:strict-type-predicates
@@ -86,6 +95,7 @@ export class RadioGroupComponent implements ControlValueAccessor, OnInit {
 
   public writeValue(value?: string): void {
     this.selected = this.options.find(option => option.value === value);
+    this.cdr.detectChanges();
   }
 
   public setDisabledState(isDisabled?: boolean): void {

--- a/projects/components/src/radio/radio-group.component.ts
+++ b/projects/components/src/radio/radio-group.component.ts
@@ -41,7 +41,9 @@ import { RadioOption } from './radio-option';
         <span *ngIf="option.description" class="radio-button-description">{{ option.description }}</span>
       </mat-radio-button>
     </mat-radio-group>
-    <ng-template #defaultLabel let-label><ht-label class="radio-button-label" [label]="label"></ht-label></ng-template>
+    <ng-template #defaultLabel let-label>
+      <ht-label class="radio-button-label" [label]="label"></ht-label>
+    </ng-template>
   `
 })
 export class RadioGroupComponent implements ControlValueAccessor, OnInit {
@@ -83,7 +85,7 @@ export class RadioGroupComponent implements ControlValueAccessor, OnInit {
   }
 
   public writeValue(value?: string): void {
-    this.setSelection(value);
+    this.selected = this.options.find(option => option.value === value);
   }
 
   public setDisabledState(isDisabled?: boolean): void {


### PR DESCRIPTION
## Description
`writeValue` in radio button should just update the state of the component. But it's also emitting a change again. The change event should only be triggered when the change is done from within a component and not from outside (by the form API).