### PR TITLE
Add support for isCustom field to metadata api

### DIFF
--- a/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.test.ts
@@ -36,7 +36,8 @@ describe('Explore query editor', () => {
       onlySupportsAggregation: false,
       onlySupportsGrouping: false,
       allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Sum],
-      groupable: false
+      groupable: false,
+      isCustom: false
     },
     {
       name: 'second',
@@ -47,7 +48,8 @@ describe('Explore query editor', () => {
       onlySupportsAggregation: false,
       onlySupportsGrouping: false,
       allowedAggregations: [MetricAggregationType.Average, MetricAggregationType.Sum],
-      groupable: false
+      groupable: false,
+      isCustom: false
     },
     {
       name: 'first groupable',
@@ -58,7 +60,8 @@ describe('Explore query editor', () => {
       onlySupportsAggregation: false,
       onlySupportsGrouping: false,
       allowedAggregations: [],
-      groupable: true
+      groupable: true,
+      isCustom: false
     },
     {
       name: 'second groupable',
@@ -69,7 +72,8 @@ describe('Explore query editor', () => {
       onlySupportsAggregation: false,
       onlySupportsGrouping: false,
       allowedAggregations: [],
-      groupable: true
+      groupable: true,
+      isCustom: false
     }
   ];
 

--- a/projects/observability/src/shared/graphql/model/metadata/attribute-metadata.ts
+++ b/projects/observability/src/shared/graphql/model/metadata/attribute-metadata.ts
@@ -11,6 +11,7 @@ export interface AttributeMetadata {
   onlySupportsGrouping: boolean;
   allowedAggregations: MetricAggregationType[];
   groupable: boolean;
+  isCustom: boolean;
 }
 
 export const enum AttributeMetadataType {

--- a/projects/observability/src/shared/services/metadata/handler/metadata-graphql-query-handler.service.test.ts
+++ b/projects/observability/src/shared/services/metadata/handler/metadata-graphql-query-handler.service.test.ts
@@ -55,6 +55,9 @@ describe('Metadata graphql query handler service', () => {
         },
         {
           path: 'groupable'
+        },
+        {
+          path: 'isCustom'
         }
       ]
     });
@@ -80,7 +83,8 @@ describe('Metadata graphql query handler service', () => {
           GraphQlMetricAggregationType.Count,
           GraphQlMetricAggregationType.Percentile
         ],
-        groupable: false
+        groupable: false,
+        isCustom: false
       },
       {
         name: 'second',
@@ -91,7 +95,8 @@ describe('Metadata graphql query handler service', () => {
         onlySupportsAggregation: false,
         onlySupportsGrouping: false,
         supportedAggregations: [],
-        groupable: true
+        groupable: false,
+        isCustom: false
       },
       {
         name: 'Third',
@@ -102,7 +107,8 @@ describe('Metadata graphql query handler service', () => {
         onlySupportsAggregation: false,
         onlySupportsGrouping: false,
         supportedAggregations: [],
-        groupable: false
+        groupable: false,
+        isCustom: false
       }
     ];
 
@@ -128,7 +134,8 @@ describe('Metadata graphql query handler service', () => {
           MetricAggregationType.P90,
           MetricAggregationType.P50
         ],
-        groupable: false
+        groupable: false,
+        isCustom: false
       },
       {
         name: 'second',
@@ -139,7 +146,8 @@ describe('Metadata graphql query handler service', () => {
         onlySupportsAggregation: false,
         onlySupportsGrouping: false,
         allowedAggregations: [],
-        groupable: true
+        groupable: false,
+        isCustom: false
       },
       {
         name: 'Third',
@@ -150,7 +158,8 @@ describe('Metadata graphql query handler service', () => {
         onlySupportsAggregation: false,
         onlySupportsGrouping: false,
         allowedAggregations: [],
-        groupable: false
+        groupable: false,
+        isCustom: false
       }
     ]);
   });

--- a/projects/observability/src/shared/services/metadata/handler/metadata-graphql-query-handler.service.ts
+++ b/projects/observability/src/shared/services/metadata/handler/metadata-graphql-query-handler.service.ts
@@ -31,7 +31,8 @@ export class MetadataGraphQlQueryHandlerService
         { path: 'onlySupportsAggregation' },
         { path: 'onlySupportsGrouping' },
         { path: 'supportedAggregations' },
-        { path: 'groupable' }
+        { path: 'groupable' },
+        { path: 'isCustom' }
       ]
     };
   }
@@ -46,7 +47,8 @@ export class MetadataGraphQlQueryHandlerService
       onlySupportsAggregation: result.onlySupportsAggregation,
       onlySupportsGrouping: result.onlySupportsGrouping,
       allowedAggregations: result.supportedAggregations.flatMap(convertFromGraphQlMetricAggregationType),
-      groupable: result.groupable
+      groupable: result.groupable,
+      isCustom: result.isCustom
     }));
   }
 }
@@ -67,4 +69,5 @@ interface AttributeMetadataServerResult {
   onlySupportsGrouping: boolean;
   supportedAggregations: GraphQlMetricAggregationType[];
   groupable: boolean;
+  isCustom: boolean;
 }


### PR DESCRIPTION
## Description
Adds isCustom field to metadata api.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
