### PR TITLE
fix: changed style of selected card

### DIFF
--- a/projects/observability/src/shared/components/card-list/card-list.component.scss
+++ b/projects/observability/src/shared/components/card-list/card-list.component.scss
@@ -32,7 +32,7 @@
     }
 
     &.selected-card {
-      background: $gray-1;
+      background: $blue-1;
       border: 1px solid $blue-2;
 
       &.grouped-style {


### PR DESCRIPTION
Currently, both the blocked and selected card have same background color, which should not be the case. Applied the background color suggested by the UX