### PR TITLE
style(stepper): add z-index for stepper actions

### DIFF
--- a/projects/components/src/stepper/stepper.component.scss
+++ b/projects/components/src/stepper/stepper.component.scss
@@ -56,6 +56,7 @@
     padding-top: 8px;
     display: flex;
     justify-content: space-between;
+    z-index: 20;
 
     .back-next {
       display: flex;


### PR DESCRIPTION
## Description
Add a z-index of the actions button.

When placing tables inside stepper, the action buttons get hidden because the table header have a `z-index` of `10`