### PR TITLE
feat: added info icon support in radio option

### DIFF
--- a/projects/components/src/radio/radio-group.component.scss
+++ b/projects/components/src/radio/radio-group.component.scss
@@ -1,3 +1,4 @@
+@use 'layout' as l;
 @import 'color-palette';
 @import 'font';
 
@@ -65,8 +66,18 @@
       }
     }
 
-    .radio-button-label {
-      @include body-2-regular($gray-7);
+    .radio-button-item {
+      @include l.flex-layout(row);
+      gap: 8px;
+
+      .radio-button-label {
+        @include body-2-regular($gray-7);
+      }
+
+      .info-icon {
+        display: flex;
+        align-items: center;
+      }
     }
 
     .radio-button-description {

--- a/projects/components/src/radio/radio-group.component.ts
+++ b/projects/components/src/radio/radio-group.component.ts
@@ -41,12 +41,15 @@ import { RadioOption } from './radio-option';
         [disabled]="option.disabled"
         (change)="$event.stopPropagation()"
       >
-        <ng-container
-          *ngTemplateOutlet="
-            this.isLabelAString(option.label) ? defaultLabel : option.label;
-            context: { $implicit: option.label }
-          "
-        ></ng-container>
+        <div class="radio-button-item">
+          <ng-container
+            *ngTemplateOutlet="
+              this.isLabelAString(option.label) ? defaultLabel : option.label;
+              context: { $implicit: option.label }
+            "
+          ></ng-container>
+          <ht-info-icon *ngIf="option.infoText" [info]="option.infoText" class="info-icon"></ht-info-icon>
+        </div>
         <span *ngIf="option.description" class="radio-button-description">{{ option.description }}</span>
       </mat-radio-button>
     </mat-radio-group>

--- a/projects/components/src/radio/radio-option.ts
+++ b/projects/components/src/radio/radio-option.ts
@@ -5,4 +5,5 @@ export interface RadioOption {
   label: string | TemplateRef<unknown>;
   description?: string;
   disabled?: boolean;
+  infoText?: string;
 }

--- a/projects/components/src/radio/radio.module.ts
+++ b/projects/components/src/radio/radio.module.ts
@@ -2,11 +2,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatRadioModule } from '@angular/material/radio';
+import { InfoIconModule } from '../info-icon/info-icon.module';
 import { LabelModule } from '../label/label.module';
 import { RadioGroupComponent } from './radio-group.component';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, MatRadioModule, LabelModule],
+  imports: [CommonModule, InfoIconModule, FormsModule, MatRadioModule, LabelModule],
   declarations: [RadioGroupComponent],
   exports: [RadioGroupComponent]
 })


### PR DESCRIPTION
## Description
Added info icon support within a radio option in `ht-radio-group`.

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
