### PR TITLE
Use query alias on server data extraction

### DIFF
--- a/projects/observability/src/shared/graphql/request/builders/specification/specification-builder.test.ts
+++ b/projects/observability/src/shared/graphql/request/builders/specification/specification-builder.test.ts
@@ -9,4 +9,16 @@ describe('Specification Builder', () => {
       })
     ).toBeUndefined();
   });
+
+  test('Should extract server data with hyphenated attribute key ', () => {
+    expect(
+      specBuilder.attributeSpecificationForKey('test-non-word-character-attributes').extractFromServerData({
+        test_non_word_character_attributes: {
+          prop1: 'prop1'
+        }
+      })
+    ).toEqual({
+      prop1: 'prop1'
+    });
+  });
 });

--- a/projects/observability/src/shared/graphql/request/builders/specification/specification-builder.ts
+++ b/projects/observability/src/shared/graphql/request/builders/specification/specification-builder.ts
@@ -41,7 +41,7 @@ export class SpecificationBuilder {
         arguments: [this.argBuilder.forAttributeKey(attributeKey)]
       }),
       extractFromServerData: serverData => {
-        const serverValue = serverData[attributeKey];
+        const serverValue = serverData[queryAlias];
 
         return serverValue === 'null' ? undefined : serverValue;
       },


### PR DESCRIPTION
## Description
Use the query alias for `extractFromServerData()` property of specifications

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
