### PR TITLE
feat: update ignore global filters handling

### DIFF
--- a/projects/observability/src/shared/graphql/request/handlers/entities/query/entities-graphql-query-builder.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/entities/query/entities-graphql-query-builder.service.ts
@@ -42,11 +42,9 @@ export class EntitiesGraphqlQueryBuilderService {
     ];
   }
 
-  protected buildFilters(request: GraphQlEntitiesRequest): GraphQlArgument[] {
+  protected buildFilters(request: GraphQlEntitiesRequest, globalFiltersToExclude: symbol[] = []): GraphQlArgument[] {
     return this.argBuilder.forFilters(
-      request.ignoreGlobalFilters ?? false
-        ? request.filters ?? []
-        : this.globalGraphQlFilterService.mergeGlobalFilters(request.entityType, request.filters)
+      this.globalGraphQlFilterService.mergeGlobalFilters(request.entityType, request.filters, globalFiltersToExclude)
     );
   }
 
@@ -95,6 +93,9 @@ export class EntitiesGraphqlQueryBuilderService {
   }
 }
 
+/**
+ * @param
+ */
 export interface GraphQlEntitiesRequest {
   timeRange: GraphQlTimeRange;
   entityType: EntityType;
@@ -105,7 +106,8 @@ export interface GraphQlEntitiesRequest {
   filters?: GraphQlFilter[];
   includeTotal?: boolean;
   includeInactive?: boolean;
-  ignoreGlobalFilters?: boolean;
+  ignoreApiDiscoveryStateFilter?: boolean;
+  ignoreGlobalEnvironmentFilter?: boolean;
 }
 
 export interface EntitiesResponse {

--- a/projects/observability/src/shared/graphql/request/handlers/entities/query/entity/entity-graphql-query-handler.service.ts
+++ b/projects/observability/src/shared/graphql/request/handlers/entities/query/entity/entity-graphql-query-handler.service.ts
@@ -61,7 +61,7 @@ export class EntityGraphQlQueryHandlerService implements GraphQlQueryHandler<Gra
       // If querying for a single API by ID, then usually want to includeInactive
       includeInactive: request.includeInactive !== false,
       // If querying for a single API by ID, ignore all global filters on entities query
-      ignoreGlobalFilters: true
+      ignoreApiDiscoveryStateFilter: true
     };
   }
 }


### PR DESCRIPTION
## Description
The idea of `ignoreGlobalFilters` was to only ignore the Api discovery state. So avoid any confusion around it, the key is now called `ignoreApiDiscoveryStateFilter`.

- Added new `ignoreGlobalEnvironmentFilter` in `GraphQlEntitiesRequest`.
- Add ability to exclude global filters