### PR TITLE
fix(span-detai): error handling if tabs array is empty

### DIFF
--- a/projects/common/src/public-api.ts
+++ b/projects/common/src/public-api.ts
@@ -4,6 +4,7 @@
 
 // Angular
 export * from './utilities/angular/angular-utils';
+export * from './utilities/angular/pipes';
 export { DynamicComponentService } from './utilities/angular/dynamic-component.service';
 
 // Browser

--- a/projects/common/src/utilities/angular/pipes/index.ts
+++ b/projects/common/src/utilities/angular/pipes/index.ts
@@ -1,0 +1,2 @@
+export * from './is-nil/is-nil.pipe';
+export * from './is-nil/is-nil-pipe.module';

--- a/projects/common/src/utilities/angular/pipes/is-nil/is-nil-pipe.module.ts
+++ b/projects/common/src/utilities/angular/pipes/is-nil/is-nil-pipe.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { IsNilPipe } from './is-nil.pipe';
+
+@NgModule({
+  declarations: [IsNilPipe],
+  exports: [IsNilPipe]
+})
+export class IsNilPipeModule {}

--- a/projects/common/src/utilities/angular/pipes/is-nil/is-nil.pipe.ts
+++ b/projects/common/src/utilities/angular/pipes/is-nil/is-nil.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isNil } from 'lodash-es';
+
+@Pipe({
+  name: 'htIsNil'
+})
+export class IsNilPipe implements PipeTransform {
+  public transform(value: unknown): boolean {
+    return isNil(value);
+  }
+}

--- a/projects/components/src/summary-value/summary-value.component.ts
+++ b/projects/components/src/summary-value/summary-value.component.ts
@@ -7,7 +7,7 @@ import { IconSize } from '../icon/icon-size';
   styleUrls: ['./summary-value.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="ht-summary-value" *ngIf="this.value" [htTooltip]="this.tooltipText">
+    <div class="ht-summary-value" *ngIf="!(this.value | htIsNil)" [htTooltip]="this.tooltipText">
       <ht-icon *ngIf="this.icon" [icon]="this.icon" size="${IconSize.Small}" class="icon"></ht-icon>
       <div class="dot" *ngIf="!this.icon"></div>
       <div class="label" *ngIf="this.label">{{ this.label }}:</div>

--- a/projects/components/src/summary-value/summary-value.module.ts
+++ b/projects/components/src/summary-value/summary-value.module.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { IsNilPipeModule } from '@hypertrace/common';
 import { IconModule } from '../icon/icon.module';
 import { TooltipModule } from '../tooltip/tooltip.module';
 import { SummaryValueComponent } from './summary-value.component';
 
 @NgModule({
-  imports: [CommonModule, IconModule, TooltipModule],
+  imports: [CommonModule, IconModule, TooltipModule, IsNilPipeModule],
   declarations: [SummaryValueComponent],
   exports: [SummaryValueComponent]
 })

--- a/projects/observability/src/shared/components/span-detail/span-detail.component.ts
+++ b/projects/observability/src/shared/components/span-detail/span-detail.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { IconType } from '@hypertrace/assets-library';
 import { TypedSimpleChanges } from '@hypertrace/common';
 import { ToggleItem } from '@hypertrace/components';
 import { isEmpty } from 'lodash-es';
@@ -13,59 +14,66 @@ import { SpanDetailTab } from './span-detail-tab';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="span-detail" *ngIf="this.spanData">
-      <ht-span-detail-title-header
-        class="title-header"
-        *ngIf="this.showTitleHeader"
-        [serviceName]="this.spanData.serviceName"
-        [protocolName]="this.spanData.protocolName"
-        [apiName]="this.spanData.apiName"
-        (closed)="this.closed.emit()"
-      ></ht-span-detail-title-header>
+      <ng-container *ngIf="this.tabs.length > 0; else notAvailableTpl">
+        <ht-span-detail-title-header
+          class="title-header"
+          *ngIf="this.showTitleHeader"
+          [serviceName]="this.spanData.serviceName"
+          [protocolName]="this.spanData.protocolName"
+          [apiName]="this.spanData.apiName"
+          (closed)="this.closed.emit()"
+        ></ht-span-detail-title-header>
 
-      <div class="summary-container">
-        <ng-content></ng-content>
-      </div>
+        <div class="summary-container">
+          <ng-content></ng-content>
+        </div>
+        <ht-toggle-group
+          class="toggle-group"
+          [activeItem]="this.activeTab$ | async"
+          [items]="this.tabs"
+          (activeItemChange)="this.changeTab($event)"
+        >
+        </ht-toggle-group>
 
-      <ht-toggle-group
-        class="toggle-group"
-        [activeItem]="this.activeTab$ | async"
-        [items]="this.tabs"
-        (activeItemChange)="this.changeTab($event)"
-      >
-      </ht-toggle-group>
-
-      <div class="tab-container" *ngIf="this.activeTab$ | async as activeTab">
-        <ng-container [ngSwitch]="activeTab?.value">
-          <ng-container *ngSwitchCase="'${SpanDetailTab.Request}'">
-            <ht-span-request-detail
-              class="request"
-              [layout]="this.layout"
-              [requestHeaders]="this.spanData?.requestHeaders"
-              [requestCookies]="this.spanData?.requestCookies"
-              [requestBody]="this.spanData?.requestBody"
-            ></ht-span-request-detail>
+        <div class="tab-container" *ngIf="this.activeTab$ | async as activeTab">
+          <ng-container [ngSwitch]="activeTab?.value">
+            <ng-container *ngSwitchCase="'${SpanDetailTab.Request}'">
+              <ht-span-request-detail
+                class="request"
+                [layout]="this.layout"
+                [requestHeaders]="this.spanData?.requestHeaders"
+                [requestCookies]="this.spanData?.requestCookies"
+                [requestBody]="this.spanData?.requestBody"
+              ></ht-span-request-detail>
+            </ng-container>
+            <ng-container *ngSwitchCase="'${SpanDetailTab.Response}'">
+              <ht-span-response-detail
+                class="response"
+                [layout]="this.layout"
+                [responseHeaders]="this.spanData?.responseHeaders"
+                [responseCookies]="this.spanData?.responseCookies"
+                [responseBody]="this.spanData?.responseBody"
+              ></ht-span-response-detail>
+            </ng-container>
+            <ng-container *ngSwitchCase="'${SpanDetailTab.Attributes}'">
+              <ht-span-tags-detail [tags]="this.spanData?.tags"></ht-span-tags-detail>
+            </ng-container>
+            <ng-container *ngSwitchCase="'${SpanDetailTab.ExitCalls}'">
+              <ht-span-exit-calls [exitCalls]="this.spanData?.exitCallsBreakup"></ht-span-exit-calls>
+            </ng-container>
+            <ng-container *ngSwitchCase="'${SpanDetailTab.Logs}'">
+              <ht-log-events-table [logEvents]="this.spanData?.logEvents"></ht-log-events-table>
+            </ng-container>
           </ng-container>
-          <ng-container *ngSwitchCase="'${SpanDetailTab.Response}'">
-            <ht-span-response-detail
-              class="response"
-              [layout]="this.layout"
-              [responseHeaders]="this.spanData?.responseHeaders"
-              [responseCookies]="this.spanData?.responseCookies"
-              [responseBody]="this.spanData?.responseBody"
-            ></ht-span-response-detail>
-          </ng-container>
-          <ng-container *ngSwitchCase="'${SpanDetailTab.Attributes}'">
-            <ht-span-tags-detail [tags]="this.spanData?.tags"></ht-span-tags-detail>
-          </ng-container>
-          <ng-container *ngSwitchCase="'${SpanDetailTab.ExitCalls}'">
-            <ht-span-exit-calls [exitCalls]="this.spanData?.exitCallsBreakup"></ht-span-exit-calls>
-          </ng-container>
-          <ng-container *ngSwitchCase="'${SpanDetailTab.Logs}'">
-            <ht-log-events-table [logEvents]="this.spanData?.logEvents"></ht-log-events-table>
-          </ng-container>
-        </ng-container>
-      </div>
+        </div>
+      </ng-container>
     </div>
+
+    <ng-template #notAvailableTpl>
+      <div class="no-data-message">
+        <ht-message-display icon="${IconType.NoData}" description="Span Details Not Available"></ht-message-display>
+      </div>
+    </ng-template>
   `
 })
 export class SpanDetailComponent implements OnChanges {

--- a/projects/observability/src/shared/components/span-detail/span-detail.component.ts
+++ b/projects/observability/src/shared/components/span-detail/span-detail.component.ts
@@ -119,7 +119,9 @@ export class SpanDetailComponent implements OnChanges {
         this.changeTab(tab);
       }
     } else {
-      this.changeTab(this.tabs[0]);
+      if (this.tabs.length > 0) {
+        this.changeTab(this.tabs[0]);
+      }
     }
   }
 

--- a/projects/observability/src/shared/components/span-detail/span-detail.module.ts
+++ b/projects/observability/src/shared/components/span-detail/span-detail.module.ts
@@ -7,6 +7,7 @@ import {
   LabelModule,
   ListViewModule,
   LoadAsyncModule,
+  MessageDisplayModule,
   TabModule,
   ToggleButtonModule,
   ToggleGroupModule,
@@ -38,7 +39,8 @@ import { SpanTagsDetailModule } from './tags/span-tags-detail.module';
     SpanDetailTitleHeaderModule,
     SpanExitCallsModule,
     LogEventsTableModule,
-    ToggleGroupModule
+    ToggleGroupModule,
+    MessageDisplayModule
   ],
   declarations: [SpanDetailComponent],
   exports: [SpanDetailComponent]


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/29002760/209106110-f7c4a21e-b114-4c5e-84f7-c002fa875ac1.png)

- Component errors out when the `tabs` array is empty. Added extra check to prevent change of tabs if the tabs array is empty.
- Added no data message for span detail if there is no tabs.
- Summary value doesn't render if the value provided is `0` 