### PR TITLE
feat: value extractor pipe

### DIFF
--- a/projects/common/src/utilities/angular/pipes/extract-value/extract-values-pipe.module.ts
+++ b/projects/common/src/utilities/angular/pipes/extract-value/extract-values-pipe.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+import { ExtractValuesPipe } from './extract-values.pipe';
+
+@NgModule({
+  declarations: [ExtractValuesPipe],
+  exports: [ExtractValuesPipe]
+})
+export class ExtractValuesPipeModule {}

--- a/projects/common/src/utilities/angular/pipes/extract-value/extract-values.pipe.test.ts
+++ b/projects/common/src/utilities/angular/pipes/extract-value/extract-values.pipe.test.ts
@@ -25,6 +25,6 @@ describe('ExtractValuesPipe', () => {
         false
       )
     ).toEqual([1, 3, 3]);
-    expect(pipe.transform(['unsupported-input'], 'a')).toEqual([]);
+    expect(pipe.transform(['unsupported-input'], 'a')).toEqual([undefined]);
   });
 });

--- a/projects/common/src/utilities/angular/pipes/extract-value/extract-values.pipe.test.ts
+++ b/projects/common/src/utilities/angular/pipes/extract-value/extract-values.pipe.test.ts
@@ -1,0 +1,30 @@
+import { ExtractValuesPipe } from '@hypertrace/common';
+
+describe('ExtractValuesPipe', () => {
+  const pipe = new ExtractValuesPipe();
+
+  test('should extract values correctly from an array of objects', () => {
+    expect(
+      pipe.transform(
+        [
+          { a: 1, b: 2 },
+          { a: 3, b: 4 },
+          { a: 3, b: 6 }
+        ],
+        'a'
+      )
+    ).toEqual([1, 3]);
+    expect(
+      pipe.transform(
+        [
+          { a: 1, b: 2 },
+          { a: 3, b: 4 },
+          { a: 3, b: 6 }
+        ],
+        'a',
+        false
+      )
+    ).toEqual([1, 3, 3]);
+    expect(pipe.transform(['unsupported-input'], 'a')).toEqual([]);
+  });
+});

--- a/projects/common/src/utilities/angular/pipes/extract-value/extract-values.pipe.ts
+++ b/projects/common/src/utilities/angular/pipes/extract-value/extract-values.pipe.ts
@@ -1,0 +1,22 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isArray, isObject, uniq } from 'lodash-es';
+import { Dictionary } from '../../../types/types';
+
+/**
+ * Extracts the value of a key from an array of objects.
+ * Can be extended for more use cases in the future.
+ */
+@Pipe({
+  name: 'htExtractValues'
+})
+export class ExtractValuesPipe implements PipeTransform {
+  public transform(value: unknown[] | undefined, key: string, returnUniqueValuesOnly: boolean = true): unknown[] {
+    const values: unknown[] = !isArray(value)
+      ? []
+      : (value ?? []).map(item =>
+          isObject(item) && item.hasOwnProperty(key) ? (item as Dictionary<unknown>)?.[key] : undefined
+        );
+
+    return returnUniqueValuesOnly ? uniq(values) : values;
+  }
+}

--- a/projects/common/src/utilities/angular/pipes/index.ts
+++ b/projects/common/src/utilities/angular/pipes/index.ts
@@ -1,2 +1,5 @@
 export * from './is-nil/is-nil.pipe';
 export * from './is-nil/is-nil-pipe.module';
+
+export * from './extract-value/extract-values.pipe';
+export * from './extract-value/extract-values-pipe.module';


### PR DESCRIPTION
## Description
A utility pipe that facilitates easy extraction of individual values for a property field from an array of objects.

Sample usage
```
...
public arrayOfObjects = [{x: 1, y:2}];
...
```

```
...
<some-component [values]="this.arrayOfObjects | htExtractValues: 'x'"></some-component>
...
```

### Testing
UT added.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules