### PR TITLE
fix: center align modal header text

### DIFF
--- a/projects/components/src/modal/modal-container.component.scss
+++ b/projects/components/src/modal/modal-container.component.scss
@@ -22,6 +22,7 @@
 
     .header-title {
       @include header-4($gray-7);
+      text-align: center;
     }
   }
 


### PR DESCRIPTION
## Description
Center align modal header text.

### Testing
N/A

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
