### PR TITLE
fix: added check for event value on radio option change

### DIFF
--- a/projects/components/src/radio/radio-group.component.ts
+++ b/projects/components/src/radio/radio-group.component.ts
@@ -11,6 +11,7 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MatRadioChange } from '@angular/material/radio';
 import { LoggerService } from '@hypertrace/common';
+import { isNil } from 'lodash-es';
 import { RadioOption } from './radio-option';
 
 @Component({
@@ -113,7 +114,9 @@ export class RadioGroupComponent implements ControlValueAccessor, OnInit {
   }
 
   public onRadioChange(event: MatRadioChange): void {
-    this.setSelection(event.value);
+    if (!isNil(event.value)) {
+      this.setSelection(event.value);
+    }
   }
 
   public isLabelAString(label: string | TemplateRef<unknown>): boolean {


### PR DESCRIPTION
### Bug
`ht-radio-group` loses context when a change event triggers inside any complex `radio-option` template. For eg. lets say we have a `ht-input` as part of the radio option template, in that case on any update inside `ht-input` causes radio group to lose context.

### Issue
`mat-radio-group` emits event on any change that happens inside `radio-option`. Hence update inside `label-template` is considered as a `change` event, but option is not really changed. 
<img width="552" alt="Screenshot 2023-01-17 at 5 16 04 PM" src="https://user-images.githubusercontent.com/45289002/212890986-babf4845-5ec2-4585-97e9-b83f38daac1c.png">

On this event, `event.value` is not present that is being applied inside `onRadioChange`, hence context is lost.


### Fix
Added a nil check before applying `event.value`.