### PR TITLE
feat(time-picker): add size customization

### DIFF
--- a/projects/components/src/time-picker/time-picker.component.scss
+++ b/projects/components/src/time-picker/time-picker.component.scss
@@ -9,18 +9,6 @@
     border-radius: 4px;
     height: 36px;
 
-    &.extra-small {
-      height: 24px;
-    }
-
-    &.small {
-      height: 32px;
-    }
-
-    &.large {
-      height: 44px;
-    }
-
     &.with-background {
       border: 1px solid $gray-1;
       background: $gray-1;
@@ -29,6 +17,18 @@
     &.with-border {
       border: 1px solid $color-border;
       border-radius: 6px;
+    }
+  }
+
+  &.small {
+    .time-selector {
+      height: 32px;
+    }
+  }
+
+  &.large {
+    .time-selector {
+      height: 44px;
     }
   }
 }
@@ -41,6 +41,14 @@
   padding: 0 8px;
   cursor: pointer;
   min-width: 108px;
+
+  &.small {
+    height: 32px;
+  }
+
+  &.large {
+    height: 44px;
+  }
 
   .trigger-icon {
     padding: 0 8px;

--- a/projects/components/src/time-picker/time-picker.component.scss
+++ b/projects/components/src/time-picker/time-picker.component.scss
@@ -6,8 +6,20 @@
 
   .time-selector {
     @include body-1-medium($gray-7);
-    height: 32px;
     border-radius: 4px;
+    height: 36px;
+
+    &.extra-small {
+      height: 24px;
+    }
+
+    &.small {
+      height: 32px;
+    }
+
+    &.large {
+      height: 44px;
+    }
 
     &.with-background {
       border: 1px solid $gray-1;

--- a/projects/components/src/time-picker/time-picker.component.ts
+++ b/projects/components/src/time-picker/time-picker.component.ts
@@ -9,7 +9,7 @@ import { PredefinedTimeService } from '../time-range/predefined-time.service';
   styleUrls: ['./time-picker.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="time-picker" [ngClass]="{ disabled: this.disabled }">
+    <div class="time-picker" [ngClass]="[this.size, this.disabled ? 'disabled' : '']">
       <ht-popover class="time-selector" [disabled]="this.disabled" [ngClass]="this.displayMode" [closeOnClick]="true">
         <ht-popover-trigger>
           <div class="popover-trigger" #popoverTrigger>
@@ -55,6 +55,9 @@ export class TimePickerComponent {
   public iconSize?: TimePickerIconSize = TimePickerIconSize.Regular;
 
   @Input()
+  public size: TimePickerSize = TimePickerSize.Small;
+
+  @Input()
   public showTimeTriggerIcon?: boolean = false;
 
   @Input()
@@ -93,4 +96,11 @@ export const enum TimePickerDisplayMode {
 export const enum TimePickerIconSize {
   Small = 'small',
   Regular = 'regular'
+}
+
+export const enum TimePickerSize {
+  ExtraSmall = 'extra-small',
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large'
 }

--- a/projects/components/src/time-picker/time-picker.component.ts
+++ b/projects/components/src/time-picker/time-picker.component.ts
@@ -12,7 +12,7 @@ import { PredefinedTimeService } from '../time-range/predefined-time.service';
     <div class="time-picker" [ngClass]="[this.size, this.disabled ? 'disabled' : '']">
       <ht-popover class="time-selector" [disabled]="this.disabled" [ngClass]="this.displayMode" [closeOnClick]="true">
         <ht-popover-trigger>
-          <div class="popover-trigger" #popoverTrigger>
+          <div class="popover-trigger" [class]="this.size" #popoverTrigger>
             <ht-icon
               class="trigger-icon"
               icon="${IconType.Time}"
@@ -99,7 +99,6 @@ export const enum TimePickerIconSize {
 }
 
 export const enum TimePickerSize {
-  ExtraSmall = 'extra-small',
   Small = 'small',
   Medium = 'medium',
   Large = 'large'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29002760/214259235-77bb8296-aa12-4674-81bf-3d08808dc449.png)

Add ability to customize the size of **Time Picker** component.

Changes made so that current usages won't be affected:
Current size -> `32px` 
Default Size -> `TimePickerSize.Small` -> `32px`

