### PR TITLE
refactor: only render active stepper content

### DIFF
--- a/projects/components/src/select/select.component.ts
+++ b/projects/components/src/select/select.component.ts
@@ -15,7 +15,7 @@ import { IconType } from '@hypertrace/assets-library';
 import { LoggerService, queryListAndChanges$, SubscriptionLifecycle, TypedSimpleChanges } from '@hypertrace/common';
 import { isEmpty, isEqual } from 'lodash-es';
 import { EMPTY, merge, Observable, of } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { ButtonRole, ButtonSize, ButtonStyle } from '../button/button';
 import { IconSize } from '../icon/icon-size';
 import { SearchBoxDisplayMode } from '../search-box/search-box.component';
@@ -261,6 +261,7 @@ export class SelectComponent<V> implements ControlValueAccessor, AfterContentIni
 
   public topControlItems$?: Observable<SelectControlOptionComponent<V>[]>;
   public isSearchTextPresent$: Observable<boolean> = this.searchValueChange.pipe(
+    shareReplay(1),
     map(searchText => !isEmpty(searchText))
   );
 

--- a/projects/components/src/stepper/stepper.component.ts
+++ b/projects/components/src/stepper/stepper.component.ts
@@ -41,7 +41,9 @@ import { StepperTabComponent } from './tab/stepper-tab.component';
             <ng-template matStepLabel>
               <ht-label class="header-label" [label]="step.label"></ht-label>
             </ng-template>
-            <ng-container *ngTemplateOutlet="step.content"></ng-container>
+            <ng-template matStepContent>
+              <ng-container *ngTemplateOutlet="step.content"></ng-container>
+            </ng-template>
             <ng-template matStepperIcon="edit">
               <ht-icon [icon]="step.icon" size="${IconSize.ExtraSmall}"></ht-icon>
             </ng-template>


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
