### PR TITLE
style(table): table not respecting min-height

### DIFF
--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -7,6 +7,7 @@ $header-height: 32px;
   display: flex;
   flex-direction: column;
   flex: 1 1;
+  min-height: inherit;
   height: 100%;
   width: 100%;
   overflow: auto;


### PR DESCRIPTION
Table was not respecting `min-height` added to parent.