### PR TITLE
refactor: update styles

### DIFF
--- a/projects/components/src/table/table.component.scss
+++ b/projects/components/src/table/table.component.scss
@@ -11,6 +11,11 @@ $header-height: 32px;
   width: 100%;
   overflow: auto;
   background-color: white;
+
+  &.detail {
+    display: grid;
+    align-content: start;
+  }
 }
 
 .title-row {
@@ -44,6 +49,7 @@ $header-height: 32px;
 .data-row {
   display: flex;
   flex-direction: row;
+  min-width: 0;
 
   &.selectable {
     cursor: pointer;
@@ -69,6 +75,14 @@ $header-height: 32px;
     .data-cell {
       background: $gray-1;
     }
+  }
+}
+
+.expandable-row {
+  display: flex;
+
+  .expanded-cell {
+    flex: 1 1 auto;
   }
 }
 

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -60,13 +60,13 @@ import { TableColumnConfigExtended, TableService } from './table.service';
   styleUrls: ['./table.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="table">
+    <div class="table" [ngClass]="this.mode">
       <cdk-table
         *ngIf="this.dataSource"
         #cdkTable
         [multiTemplateDataRows]="this.isDetailType()"
         [dataSource]="this.dataSource"
-        [ngClass]="[this.display, this.pageable && this.isTableFullPage ? 'bottom-margin' : '']"
+        [ngClass]="[this.display, this.pageable && this.isTableFullPage ? 'bottom-margin' : '', this.mode]"
         class="table"
       >
         <!-- Columns -->


### PR DESCRIPTION
## Description
Adjusts the table display to remove the expandable detail horizontal scrollbar for each row, and allow the detail content to overflow, giving the main table the horizontal scrollbar.

V2 of this PR, first was reverted because it was causing blowout in certain scenarios. This PR adds `min-width: 0` to the data rows, so they don't get the default `min-width: auto` 

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
