### PR TITLE
fix: Fixing Null argument in GraphqlRequestBuilder

### DIFF
--- a/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
+++ b/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isEqual, map, merge, mergeWith, toPairs } from 'lodash-es';
+import { isEmpty, isEqual, isNil, map, merge, mergeWith, toPairs } from 'lodash-es';
 import { GraphQlArgument, GraphQlArgumentValue, GraphQlEnumArgument } from '../../../model/graphql-argument';
 import { GraphQlSelection } from '../../../model/graphql-selection';
 
@@ -40,7 +40,9 @@ export class GraphQlRequestBuilder {
 
   private translateMergedRequestFragmentsToGql(mergedRequest: MergedRequestFragment): string {
     const contents = Object.keys(mergedRequest)
-      .map(key => this.translateRequestFragmentToGql(key, mergedRequest[key]))
+      .map(key => {
+        return this.translateRequestFragmentToGql(key, mergedRequest[key]);
+      })
       .join(' ');
 
     return `{ ${contents} }`;
@@ -132,9 +134,12 @@ export class GraphQlRequestBuilder {
       return `[${arrayContents}]`;
     }
 
-    if (typeof argumentValue === 'object' && !(argumentValue instanceof Date)) {
+    if (typeof argumentValue === 'object' && !isNil(argumentValue) && !(argumentValue instanceof Date)) {
       const objectContents = toPairs(argumentValue)
-        .map(nameValuePair => `${nameValuePair[0]}: ${this.stringifyArgumentValue(nameValuePair[1])}`)
+        .map(nameValuePair => {
+          console.log(nameValuePair[0], nameValuePair[1]);
+          return `${nameValuePair[0]}: ${this.stringifyArgumentValue(nameValuePair[1])}`;
+        })
         .join(', ');
 
       return `{${objectContents}}`;

--- a/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
+++ b/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
@@ -120,6 +120,10 @@ export class GraphQlRequestBuilder {
   }
 
   private stringifyArgumentValue(argumentValue: GraphQlArgumentValue): string {
+    if (isNil(argumentValue)) {
+      return 'null';
+    }
+
     if (argumentValue instanceof GraphQlEnumArgument) {
       return argumentValue.toString();
     }
@@ -132,7 +136,7 @@ export class GraphQlRequestBuilder {
       return `[${arrayContents}]`;
     }
 
-    if (typeof argumentValue === 'object' && !isNil(argumentValue) && !(argumentValue instanceof Date)) {
+    if (typeof argumentValue === 'object' && !(argumentValue instanceof Date)) {
       const objectContents = toPairs(argumentValue)
         .map(nameValuePair => `${nameValuePair[0]}: ${this.stringifyArgumentValue(nameValuePair[1])}`)
         .join(', ');

--- a/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
+++ b/projects/graphql-client/src/utils/builders/request/graphql-request-builder.ts
@@ -40,9 +40,7 @@ export class GraphQlRequestBuilder {
 
   private translateMergedRequestFragmentsToGql(mergedRequest: MergedRequestFragment): string {
     const contents = Object.keys(mergedRequest)
-      .map(key => {
-        return this.translateRequestFragmentToGql(key, mergedRequest[key]);
-      })
+      .map(key => this.translateRequestFragmentToGql(key, mergedRequest[key]))
       .join(' ');
 
     return `{ ${contents} }`;
@@ -136,10 +134,7 @@ export class GraphQlRequestBuilder {
 
     if (typeof argumentValue === 'object' && !isNil(argumentValue) && !(argumentValue instanceof Date)) {
       const objectContents = toPairs(argumentValue)
-        .map(nameValuePair => {
-          console.log(nameValuePair[0], nameValuePair[1]);
-          return `${nameValuePair[0]}: ${this.stringifyArgumentValue(nameValuePair[1])}`;
-        })
+        .map(nameValuePair => `${nameValuePair[0]}: ${this.stringifyArgumentValue(nameValuePair[1])}`)
         .join(', ');
 
       return `{${objectContents}}`;


### PR DESCRIPTION
## Description
Prevents generating and Argument with an empty object '{}' when the argument is null.

### Testing
Tested locally

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
