### PR TITLE
feat: add panel collapsed body component

### DIFF
--- a/projects/components/src/panel/collapsed-body/panel-collapsed-body.component.ts
+++ b/projects/components/src/panel/collapsed-body/panel-collapsed-body.component.ts
@@ -1,0 +1,9 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ContentHolder, CONTENT_HOLDER_TEMPLATE } from '../../content/content-holder';
+
+@Component({
+  selector: 'ht-panel-collapsed-body',
+  template: CONTENT_HOLDER_TEMPLATE,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PanelCollapsedBodyComponent extends ContentHolder {}

--- a/projects/components/src/panel/panel.component.scss
+++ b/projects/components/src/panel/panel.component.scss
@@ -24,6 +24,13 @@
     padding: 0 12px 12px;
   }
 
+  .collapsed-body {
+    flex: 1;
+    overflow: auto;
+    height: 100%;
+    padding: 0 12px 12px;
+  }
+
   &.bordered {
     border: 1px solid $gray-2;
     border-radius: 10px;

--- a/projects/components/src/panel/panel.component.test.ts
+++ b/projects/components/src/panel/panel.component.test.ts
@@ -41,6 +41,9 @@ describe('Panel component', () => {
           <div class="title">{{title}}</div>
           <div class="summary">{{summary}}</div>
         </ht-panel-header>
+        <ht-panel-collapsed-body>
+          <div>Collapsed Body Content</div>
+        </ht-panel-collapsed-body>
         <ht-panel-body>
           <div>Body Content</div>
         </ht-panel-body>
@@ -56,9 +59,11 @@ describe('Panel component', () => {
     expect(spectator.query('.title')).toHaveText('Results');
     expect(spectator.query('.summary')).toHaveText('(508 Records)');
     expect(spectator.query('.body')).not.toExist();
+    expect(spectator.query('.collapsed-body')).toHaveText('Collapsed Body Content');
 
     spectator.click('.title');
     expect(spectator.query('.body')).toHaveText('Body Content');
+    expect(spectator.query('.collapsed-body')).not.toExist();
   });
 
   test('renders body content with no header', () => {

--- a/projects/components/src/panel/panel.component.test.ts
+++ b/projects/components/src/panel/panel.component.test.ts
@@ -32,6 +32,7 @@ describe('Panel component', () => {
     );
     expect(spectator.query('.title')).toHaveText('Results');
     expect(spectator.query('.summary')).toHaveText('(508 Records)');
+    expect(spectator.query('.collapsed-body')).not.toExist();
   });
 
   test('renders body content', () => {

--- a/projects/components/src/panel/panel.component.ts
+++ b/projects/components/src/panel/panel.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { Color } from '@hypertrace/common';
 import { PanelBodyComponent } from './body/panel-body.component';
+import { PanelCollapsedBodyComponent } from './collapsed-body/panel-collapsed-body.component';
 import { PanelHeaderComponent } from './header/panel-header.component';
 
 @Component({
@@ -31,6 +32,9 @@ import { PanelHeaderComponent } from './header/panel-header.component';
       </div>
       <div class="body" *ngIf="this.expanded && this.body">
         <ng-container *ngTemplateOutlet="this.body!.content"></ng-container>
+      </div>
+      <div class="collapsed-body" *ngIf="!this.expanded && this.collapsedBody">
+        <ng-container *ngTemplateOutlet="this.collapsedBody.content"></ng-container>
       </div>
     </div>
   `
@@ -56,6 +60,9 @@ export class PanelComponent implements AfterViewInit {
 
   @ContentChild(PanelBodyComponent, { static: true })
   public readonly body?: PanelBodyComponent;
+
+  @ContentChild(PanelCollapsedBodyComponent, { static: true })
+  public readonly collapsedBody?: PanelCollapsedBodyComponent;
 
   @ViewChild('headerContainer', { read: ViewContainerRef, static: false })
   public readonly headerContainer?: ViewContainerRef;

--- a/projects/components/src/panel/panel.module.ts
+++ b/projects/components/src/panel/panel.module.ts
@@ -6,6 +6,7 @@ import { EventBlockerModule } from '../event-blocker/event-blocker.module';
 import { ExpanderToggleModule } from '../expander/expander-toggle.module';
 import { LayoutChangeModule } from '../layout/layout-change.module';
 import { PanelBodyComponent } from './body/panel-body.component';
+import { PanelCollapsedBodyComponent } from './collapsed-body/panel-collapsed-body.component';
 import { PanelHeaderComponent } from './header/panel-header.component';
 import { PanelTitleComponent } from './header/title/panel-title.component';
 import { PanelComponent } from './panel.component';
@@ -19,7 +20,13 @@ import { PanelComponent } from './panel.component';
     EventBlockerModule,
     ButtonModule
   ],
-  declarations: [PanelComponent, PanelHeaderComponent, PanelBodyComponent, PanelTitleComponent],
-  exports: [PanelComponent, PanelHeaderComponent, PanelBodyComponent, PanelTitleComponent]
+  declarations: [
+    PanelComponent,
+    PanelHeaderComponent,
+    PanelBodyComponent,
+    PanelTitleComponent,
+    PanelCollapsedBodyComponent
+  ],
+  exports: [PanelComponent, PanelHeaderComponent, PanelBodyComponent, PanelTitleComponent, PanelCollapsedBodyComponent]
 })
 export class PanelModule {}


### PR DESCRIPTION
`UseCase` -> We want to have some minimized content when the Panel is collapsed.
`Implementation` -> Added a new `ht-panel-collapsed-body` component