### PR TITLE
fix: separate mat-icon implementation for svg and ligature

### DIFF
--- a/projects/components/src/icon/icon.component.test.ts
+++ b/projects/components/src/icon/icon.component.test.ts
@@ -22,6 +22,8 @@ describe('Icon component', () => {
     );
 
     expect(spectator.query(MatIcon)!.svgIcon).toBe('hypertrace');
+    expect(spectator.query('.svg-icon')).toExist();
+    expect(spectator.query('.ligature-icon')).not.toExist();
     expect(spectator).toHaveExactText('');
     expect(spectator.query('.ht-icon')).toHaveAttribute('aria-label', 'hypertrace');
   });
@@ -41,7 +43,8 @@ describe('Icon component', () => {
        </ht-icon>`
     );
 
-    expect(spectator.query(MatIcon)!.svgIcon).toBe('');
+    expect(spectator.query('.svg-icon')).not.toExist();
+    expect(spectator.query('.ligature-icon')).toExist();
     expect(spectator.query('.ht-icon')).toHaveExactText(IconType.Add);
     expect(spectator.query('.ht-icon')).toHaveAttribute('aria-label', 'other label');
   });

--- a/projects/components/src/icon/icon.component.ts
+++ b/projects/components/src/icon/icon.component.ts
@@ -13,7 +13,7 @@ import { IconSize } from './icon-size';
     <ng-container>
       <mat-icon
         *ngIf="this.svgIcon; else matIconTemplate"
-        class="ht-icon"
+        class="ht-icon svg-icon"
         [ngClass]="this.styleClasses"
         [ngStyle]="this.customStyles"
         [attr.aria-label]="this.labelToUse"
@@ -23,7 +23,7 @@ import { IconSize } from './icon-size';
 
       <ng-template #matIconTemplate>
         <mat-icon
-          class="ht-icon"
+          class="ht-icon ligature-icon"
           [ngClass]="this.styleClasses"
           [ngStyle]="this.customStyles"
           [attr.aria-label]="this.labelToUse"

--- a/projects/components/src/icon/icon.component.ts
+++ b/projects/components/src/icon/icon.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { IconRegistryService, IconType } from '@hypertrace/assets-library';
 import { assertUnreachable } from '@hypertrace/common';
-import { isEmpty } from 'lodash-es';
+import { isEmpty, isNil } from 'lodash-es';
 import { IconBorder } from './icon-border';
 import { IconSize } from './icon-size';
 
@@ -97,15 +97,15 @@ export class IconComponent implements OnChanges {
   }
 
   public get styleClasses(): string[] {
-    return [this.size, this.borderType ? this.borderType : ''];
+    return [this.size, !isNil(this.borderType) ? this.borderType : ''];
   }
 
   public get customStyles(): Record<string, string> {
     return {
       color: this.color ? this.color : '',
-      borderColor: this.borderType !== IconBorder.InsetBorder && this.borderColor ? this.borderColor : '',
-      background: this.borderType === IconBorder.InsetBorder && this.borderColor ? this.borderColor : '',
-      borderRadius: this.borderRadius ? this.borderRadius : ''
+      borderColor: this.borderType !== IconBorder.InsetBorder && !isNil(this.borderColor) ? this.borderColor : '',
+      background: this.borderType === IconBorder.InsetBorder && !isNil(this.borderColor) ? this.borderColor : '',
+      borderRadius: !isNil(this.borderRadius) ? this.borderRadius : ''
     };
   }
 

--- a/projects/components/src/icon/icon.component.ts
+++ b/projects/components/src/icon/icon.component.ts
@@ -100,10 +100,10 @@ export class IconComponent implements OnChanges {
 
   public get customStyles(): Record<string, string> {
     return {
-      color: this.color ? this.color : '',
-      borderColor: this.borderType !== IconBorder.InsetBorder && !isNil(this.borderColor) ? this.borderColor : '',
-      background: this.borderType === IconBorder.InsetBorder && !isNil(this.borderColor) ? this.borderColor : '',
-      borderRadius: !isNil(this.borderRadius) ? this.borderRadius : ''
+      color: this.color ?? '',
+      borderColor: this.borderType !== IconBorder.InsetBorder ? this.borderColor ?? '' : '',
+      background: this.borderType === IconBorder.InsetBorder ? this.borderColor ?? '' : '',
+      borderRadius: this.borderRadius ?? ''
     };
   }
 

--- a/projects/components/src/icon/icon.component.ts
+++ b/projects/components/src/icon/icon.component.ts
@@ -10,29 +10,27 @@ import { IconSize } from './icon-size';
   styleUrls: ['./icon.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ng-container>
+    <mat-icon
+      *ngIf="this.svgIcon; else matIconTemplate"
+      class="ht-icon svg-icon"
+      [ngClass]="this.styleClasses"
+      [ngStyle]="this.customStyles"
+      [attr.aria-label]="this.labelToUse"
+      [htTooltip]="this.tooltip"
+      [svgIcon]="this.svgIcon"
+    ></mat-icon>
+
+    <ng-template #matIconTemplate>
       <mat-icon
-        *ngIf="this.svgIcon; else matIconTemplate"
-        class="ht-icon svg-icon"
+        class="ht-icon ligature-icon"
         [ngClass]="this.styleClasses"
         [ngStyle]="this.customStyles"
         [attr.aria-label]="this.labelToUse"
         [htTooltip]="this.tooltip"
-        [svgIcon]="this.svgIcon"
-      ></mat-icon>
-
-      <ng-template #matIconTemplate>
-        <mat-icon
-          class="ht-icon ligature-icon"
-          [ngClass]="this.styleClasses"
-          [ngStyle]="this.customStyles"
-          [attr.aria-label]="this.labelToUse"
-          [htTooltip]="this.tooltip"
-          [fontSet]="this.fontSet"
-          >{{ this.ligatureText }}</mat-icon
-        >
-      </ng-template>
-    </ng-container>
+        [fontSet]="this.fontSet"
+        >{{ this.ligatureText }}</mat-icon
+      >
+    </ng-template>
   `
 })
 export class IconComponent implements OnChanges {

--- a/projects/components/src/icon/icon.component.ts
+++ b/projects/components/src/icon/icon.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { IconRegistryService, IconType } from '@hypertrace/assets-library';
 import { assertUnreachable } from '@hypertrace/common';
+import { isEmpty } from 'lodash-es';
 import { IconBorder } from './icon-border';
 import { IconSize } from './icon-size';
 
@@ -9,21 +10,29 @@ import { IconSize } from './icon-size';
   styleUrls: ['./icon.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <mat-icon
-      class="ht-icon"
-      [ngClass]="[this.size, this.borderType ? this.borderType : '']"
-      [ngStyle]="{
-        color: this.color ? this.color : '',
-        borderColor: this.borderType !== '${IconBorder.InsetBorder}' && this.borderColor ? this.borderColor : '',
-        background: this.borderType === '${IconBorder.InsetBorder}' && this.borderColor ? this.borderColor : '',
-        borderRadius: this.borderRadius ? this.borderRadius : ''
-      }"
-      [attr.aria-label]="this.labelToUse"
-      [htTooltip]="this.showTooltip ? this.labelToUse : undefined"
-      [fontSet]="this.fontSet"
-      [svgIcon]="this.svgIcon"
-      >{{ this.ligatureText }}</mat-icon
-    >
+    <ng-container>
+      <mat-icon
+        *ngIf="this.svgIcon; else matIconTemplate"
+        class="ht-icon"
+        [ngClass]="this.styleClasses"
+        [ngStyle]="this.customStyles"
+        [attr.aria-label]="this.labelToUse"
+        [htTooltip]="this.tooltip"
+        [svgIcon]="this.svgIcon"
+      ></mat-icon>
+
+      <ng-template #matIconTemplate>
+        <mat-icon
+          class="ht-icon"
+          [ngClass]="this.styleClasses"
+          [ngStyle]="this.customStyles"
+          [attr.aria-label]="this.labelToUse"
+          [htTooltip]="this.tooltip"
+          [fontSet]="this.fontSet"
+          >{{ this.ligatureText }}</mat-icon
+        >
+      </ng-template>
+    </ng-container>
   `
 })
 export class IconComponent implements OnChanges {
@@ -81,5 +90,26 @@ export class IconComponent implements OnChanges {
           assertUnreachable(iconRenderInfo);
       }
     }
+  }
+
+  public get isSvgIcon(): boolean {
+    return !isEmpty(this.svgIcon);
+  }
+
+  public get styleClasses(): string[] {
+    return [this.size, this.borderType ? this.borderType : ''];
+  }
+
+  public get customStyles(): Record<string, string> {
+    return {
+      color: this.color ? this.color : '',
+      borderColor: this.borderType !== IconBorder.InsetBorder && this.borderColor ? this.borderColor : '',
+      background: this.borderType === IconBorder.InsetBorder && this.borderColor ? this.borderColor : '',
+      borderRadius: this.borderRadius ? this.borderRadius : ''
+    };
+  }
+
+  public get tooltip(): string | undefined {
+    return this.showTooltip ? this.labelToUse : undefined;
   }
 }


### PR DESCRIPTION
## Description
mat-icon component does not render correctly when we switch from svg icon to ligature icon in place.
We get a blank element instead of a ligature icon.

Using separate instances of mat-icon inside the ht-icon component to isolate this problem and supply only relevant values to each usage.

After
https://user-images.githubusercontent.com/63222211/220830360-068e39f7-6e22-45df-9ea6-2df07419c49b.mov

Before
https://user-images.githubusercontent.com/63222211/220830483-bbcb5f83-6950-4f4a-af59-ce01dc151252.mov


### Testing
Tested locally. Added UTs.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules