### PR TITLE
fix: added enhancements in TimeDuration class

### DIFF
--- a/projects/common/src/time/time-duration.ts
+++ b/projects/common/src/time/time-duration.ts
@@ -17,10 +17,6 @@ export class TimeDuration {
     return this.millis;
   }
 
-  public toDate(): Date {
-    return this.militaryTime;
-  }
-
   public static parse(durationString: string): TimeDuration {
     return new TimeDuration(toSeconds(parse(durationString)), TimeUnit.Second);
   }
@@ -63,16 +59,38 @@ export class TimeDuration {
   }
 
   private toTimeObject(): TimeObject {
-    const unixDate = new Date(0);
-
     return {
-      years: this.militaryTime.getUTCFullYear() - unixDate.getUTCFullYear(),
-      months: this.militaryTime.getUTCMonth() - unixDate.getUTCMonth(),
-      days: this.militaryTime.getUTCDate() - unixDate.getUTCDate(),
-      hours: this.militaryTime.getUTCHours(),
-      minutes: this.militaryTime.getUTCMinutes(),
-      seconds: this.militaryTime.getUTCSeconds()
+      years: this.years,
+      months: this.months,
+      days: this.days,
+      hours: this.hours,
+      minutes: this.minutes,
+      seconds: this.seconds
     };
+  }
+
+  public get years(): number {
+    return this.militaryTime.getUTCFullYear() - new Date(0).getUTCFullYear();
+  }
+
+  public get months(): number {
+    return this.militaryTime.getUTCMonth() - new Date(0).getUTCMonth();
+  }
+
+  public get days(): number {
+    return this.militaryTime.getUTCDate() - new Date(0).getUTCDate();
+  }
+
+  public get hours(): number {
+    return this.militaryTime.getUTCHours();
+  }
+
+  public get minutes(): number {
+    return this.militaryTime.getUTCMinutes();
+  }
+
+  public get seconds(): number {
+    return this.militaryTime.getUTCSeconds();
   }
 
   public toMultiUnitString(


### PR DESCRIPTION
## Description
Added a few enhancements to the `TimeDuration` class.
- Enabled support to query for `hours`, `minutes`, `seconds`, `days`, `months`, `years`.
- Exposed new logic for `Iso8601DurationString` conversion. The original one converted duration to seconds by default before computing. Exposed new one as `toIso8601DurationStringMilitaryTime()` that persists the units as per military time. For eg, 2 hours 20minutes translates to `PT2H20M`.

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

