### PR TITLE
fix(stepper): action label not updated

### DIFF
--- a/projects/components/src/stepper/tab/stepper-tab.component.ts
+++ b/projects/components/src/stepper/tab/stepper-tab.component.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component, ContentChild, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, Input, OnChanges } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
 import { IconType } from '@hypertrace/assets-library';
+import { BehaviorSubject, Observable } from 'rxjs';
 
-import { ContentHolder, CONTENT_HOLDER_TEMPLATE } from '../../content/content-holder';
+import { CONTENT_HOLDER_TEMPLATE, ContentHolder } from '../../content/content-holder';
 import { StepperTabControlsComponent } from '../tab-controls/stepper-tab-controls.component';
 
 @Component({
@@ -10,7 +11,7 @@ import { StepperTabControlsComponent } from '../tab-controls/stepper-tab-control
   template: CONTENT_HOLDER_TEMPLATE,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class StepperTabComponent extends ContentHolder {
+export class StepperTabComponent extends ContentHolder implements OnChanges {
   @ContentChild(StepperTabControlsComponent)
   public tabControls?: StepperTabControlsComponent;
 
@@ -34,4 +35,11 @@ export class StepperTabComponent extends ContentHolder {
 
   @Input()
   public actionButtonLabel?: string;
+
+  private readonly refreshSubject: BehaviorSubject<void> = new BehaviorSubject<void>(undefined);
+  public readonly refresh$: Observable<void> = this.refreshSubject.asObservable();
+
+  public ngOnChanges(): void {
+    this.refreshSubject.next();
+  }
 }


### PR DESCRIPTION
## 😞 Issue
Stepper tab can have custom label for the main action button:
```html
<ht-stepper>
      <ht-stepper-tab label="My Tab" actionButtonLabel="Cool Button">
     	<div> CONTENT </div>
      </ht-stepper-tab>
</ht-stepper>
```

But if we try to update the `actionButtonLabel` at a later point based on some condition:
```html
<ht-stepper>
      <ht-stepper-tab label="My Tab" [actionButtonLabel]="condition ? 'Cool Button' : 'Cancel'">
     	<div> CONTENT </div>
      </ht-stepper-tab>
</ht-stepper>
```

The change is not getting reflected in the stepper because of the current implementation of the logic which gets the label for the button:
```ts
<ht-button [label]="this.getActionButtonLabel | htMemoize : stepper.selectedIndex : steps"></ht-button>
```

Since we use `htMemoize` the `steps` value doesn't change.

## ⚒️ Fix

Stepper Tab component exposes a `refresh$` observable which emits when any input changes. The new logic for getting label for action button is:
```ts
// Know when input changed
const stepsInputChange$ = this.steps$.pipe(
  switchMap(steps => merge(...steps.map(tab => tab.refresh$))),
  startWith(undefined)
);

// Stepper index change
const stepperSelectionChange$ = this.selectionChange.asObservable().pipe(
  map(event => event.selectedIndex),
  startWith(0)
);

this.actionButtonLabel$ = combineLatest([stepperSelectionChange$, this.steps$, stepsInputChange$]).pipe(
  map(([selectedIndex, steps]) => this.getActionButtonLabel(selectedIndex, steps))
);
```