### PR TITLE
feat: setting default TR from current url when ff is disabled

### DIFF
--- a/projects/common/src/time/page-time-range-preference.service.ts
+++ b/projects/common/src/time/page-time-range-preference.service.ts
@@ -37,7 +37,7 @@ export class PageTimeRangePreferenceService {
       this.featureStateResolver.getFeatureFlagValue<Dictionary<string>>(ApplicationFeature.FeatureDefaultTimeRangeMap)
     ]).pipe(
       map(([pageTimeRangeStringDictionary, featureState, featureDefaultTimeRangeMap]) => {
-        if (featureState === FeatureState.Enabled) {
+        if (featureState !== FeatureState.Enabled) {
           if (!isNil(pageTimeRangeStringDictionary[rootLevelPath])) {
             return () => this.timeRangeService.timeRangeFromUrlString(pageTimeRangeStringDictionary[rootLevelPath]);
           }
@@ -93,7 +93,11 @@ export class PageTimeRangePreferenceService {
   }
 
   public getGlobalDefaultTimeRange(): TimeRange {
-    return new RelativeTimeRange(new TimeDuration(1, TimeUnit.Day));
+    return this.maybeGetCurrentTimeRange() ?? new RelativeTimeRange(new TimeDuration(1, TimeUnit.Day));
+  }
+
+  private maybeGetCurrentTimeRange(): TimeRange | undefined {
+    return this.timeRangeService.maybeGetCurrentTimeRange();
   }
 }
 

--- a/projects/common/src/time/page-time-range-preference.service.ts
+++ b/projects/common/src/time/page-time-range-preference.service.ts
@@ -37,7 +37,7 @@ export class PageTimeRangePreferenceService {
       this.featureStateResolver.getFeatureFlagValue<Dictionary<string>>(ApplicationFeature.FeatureDefaultTimeRangeMap)
     ]).pipe(
       map(([pageTimeRangeStringDictionary, featureState, featureDefaultTimeRangeMap]) => {
-        if (featureState !== FeatureState.Enabled) {
+        if (featureState === FeatureState.Enabled) {
           if (!isNil(pageTimeRangeStringDictionary[rootLevelPath])) {
             return () => this.timeRangeService.timeRangeFromUrlString(pageTimeRangeStringDictionary[rootLevelPath]);
           }

--- a/projects/common/src/time/page-time-range-preference.service.ts
+++ b/projects/common/src/time/page-time-range-preference.service.ts
@@ -49,7 +49,7 @@ export class PageTimeRangePreferenceService {
         }
 
         // When FF is disabled
-        return () => this.getGlobalDefaultTimeRange();
+        return () => this.maybeGetCurrentTimeRange() ?? this.getGlobalDefaultTimeRange();
       })
     );
   }
@@ -93,7 +93,7 @@ export class PageTimeRangePreferenceService {
   }
 
   public getGlobalDefaultTimeRange(): TimeRange {
-    return this.maybeGetCurrentTimeRange() ?? new RelativeTimeRange(new TimeDuration(1, TimeUnit.Day));
+    return new RelativeTimeRange(new TimeDuration(1, TimeUnit.Day));
   }
 
   private maybeGetCurrentTimeRange(): TimeRange | undefined {

--- a/projects/common/src/time/time-range.service.ts
+++ b/projects/common/src/time/time-range.service.ts
@@ -52,6 +52,10 @@ export class TimeRangeService {
     return this.currentTimeRange;
   }
 
+  public maybeGetCurrentTimeRange(): TimeRange | undefined {
+    return this.currentTimeRange;
+  }
+
   public setRelativeRange(value: number, unit: TimeUnit): this {
     return this.setTimeRangeInUrl(TimeRangeService.toRelativeTimeRange(value, unit));
   }
@@ -99,7 +103,9 @@ export class TimeRangeService {
   }
 
   private initializeTimeRange(): void {
-    this.getInitialTimeRange().subscribe(timeRangeFromInitialUrl => this.applyTimeRangeChange(timeRangeFromInitialUrl));
+    this.getInitialTimeRange().subscribe(timeRangeFromInitialUrl => {
+      this.applyTimeRangeChange(timeRangeFromInitialUrl);
+    });
 
     this.getPageTimeRangeChanges().subscribe(timeRange => {
       if (!this.timeRangeMatchesCurrentUrl(timeRange)) {


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.
feat: setting default TR from current url when ff is disabled
<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
