### PR TITLE
refactor: remove second interval granularity

### DIFF
--- a/projects/common/src/time/interval-duration.service.test.ts
+++ b/projects/common/src/time/interval-duration.service.test.ts
@@ -35,12 +35,7 @@ describe('Interval duration service', () => {
       });
 
       expectObservable(spectator.service.availableIntervals$).toBe(marblePattern, {
-        x: [
-          new TimeDuration(15, TimeUnit.Second),
-          new TimeDuration(30, TimeUnit.Second),
-          new TimeDuration(1, TimeUnit.Minute),
-          new TimeDuration(5, TimeUnit.Minute)
-        ],
+        x: [new TimeDuration(1, TimeUnit.Minute), new TimeDuration(5, TimeUnit.Minute)],
         y: [
           new TimeDuration(1, TimeUnit.Minute),
           new TimeDuration(5, TimeUnit.Minute),
@@ -74,12 +69,7 @@ describe('Interval duration service', () => {
       });
 
       expectObservable(spectator.service.availableIntervals$).toBe('x--', {
-        x: [
-          new TimeDuration(15, TimeUnit.Second),
-          new TimeDuration(30, TimeUnit.Second),
-          new TimeDuration(1, TimeUnit.Minute),
-          new TimeDuration(5, TimeUnit.Minute)
-        ]
+        x: [new TimeDuration(1, TimeUnit.Minute), new TimeDuration(5, TimeUnit.Minute)]
       });
     });
   });

--- a/projects/common/src/time/interval-duration.service.ts
+++ b/projects/common/src/time/interval-duration.service.ts
@@ -11,9 +11,6 @@ import { TimeUnit } from './time-unit.type';
 @Injectable({ providedIn: 'root' })
 export class IntervalDurationService {
   private static readonly PREDEFINED_INTERVALS: TimeDuration[] = [
-    new TimeDuration(1, TimeUnit.Second),
-    new TimeDuration(15, TimeUnit.Second),
-    new TimeDuration(30, TimeUnit.Second),
     new TimeDuration(1, TimeUnit.Minute),
     new TimeDuration(5, TimeUnit.Minute),
     new TimeDuration(15, TimeUnit.Minute),

--- a/projects/observability/src/pages/explorer/explorer.component.test.ts
+++ b/projects/observability/src/pages/explorer/explorer.component.test.ts
@@ -162,7 +162,7 @@ describe('Explorer component', () => {
         requestType: EXPLORE_GQL_REQUEST,
         context: ObservabilityTraceType.Api,
         limit: 1000,
-        interval: new TimeDuration(15, TimeUnit.Second)
+        interval: new TimeDuration(1, TimeUnit.Minute)
       }),
       undefined
     );
@@ -207,7 +207,7 @@ describe('Explorer component', () => {
         context: ObservabilityTraceType.Api,
         filters: [new GraphQlFieldFilter({ key: 'first' }, GraphQlOperatorType.Equals, 'foo')],
         limit: 1000,
-        interval: new TimeDuration(15, TimeUnit.Second)
+        interval: new TimeDuration(1, TimeUnit.Minute)
       }),
       undefined
     );
@@ -241,7 +241,7 @@ describe('Explorer component', () => {
         requestType: EXPLORE_GQL_REQUEST,
         context: SPAN_SCOPE,
         limit: 1000,
-        interval: new TimeDuration(15, TimeUnit.Second)
+        interval: new TimeDuration(1, TimeUnit.Minute)
       }),
       undefined
     );
@@ -291,7 +291,7 @@ describe('Explorer component', () => {
         requestType: EXPLORE_GQL_REQUEST,
         context: SPAN_SCOPE,
         limit: 1000,
-        interval: new TimeDuration(15, TimeUnit.Second),
+        interval: new TimeDuration(1, TimeUnit.Minute),
         filters: [new GraphQlFieldFilter({ key: 'first' }, GraphQlOperatorType.Equals, 'foo')]
       }),
       undefined
@@ -359,7 +359,7 @@ describe('Explorer component', () => {
     const queryParamChangeSpy = spyOn(spectator.inject(NavigationService), 'addQueryParametersToUrl');
     spectator.click(spectator.queryAll('ht-toggle-item')[1]);
     spectator.query(ExploreQueryEditorComponent)!.setSeries([buildSeries('second', MetricAggregationType.Average)]);
-    spectator.query(ExploreQueryEditorComponent)!.setInterval(new TimeDuration(30, TimeUnit.Second));
+    spectator.query(ExploreQueryEditorComponent)!.setInterval(new TimeDuration(5, TimeUnit.Minute));
     spectator.query(ExploreQueryEditorComponent)!.updateGroupByExpression(
       {
         keyExpressions: [{ key: 'apiName' }],
@@ -375,7 +375,7 @@ describe('Explorer component', () => {
       group: ['apiName'],
       limit: 6,
       other: true,
-      interval: '30s'
+      interval: '5m'
     });
   }));
 
@@ -390,7 +390,7 @@ describe('Explorer component', () => {
             group: 'apiName',
             limit: '6',
             other: 'true',
-            interval: '30s'
+            interval: '5m'
           })
         )
       }
@@ -407,7 +407,7 @@ describe('Explorer component', () => {
       visualizationOptions: { type: CartesianSeriesVisualizationType.Line }
     });
     expect(spectator.query(ExploreQueryIntervalEditorComponent)?.interval).toEqual(
-      new TimeDuration(30, TimeUnit.Second)
+      new TimeDuration(5, TimeUnit.Minute)
     );
   }));
 });

--- a/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/explore-query-editor.component.test.ts
@@ -90,8 +90,8 @@ describe('Explore query editor', () => {
       }),
       mockProvider(IntervalDurationService, {
         availableIntervals$: of('AUTO'),
-        getAutoDurationFromTimeDurations: () => new TimeDuration(15, TimeUnit.Second),
-        getAutoDuration: () => new TimeDuration(15, TimeUnit.Second)
+        getAutoDurationFromTimeDurations: () => new TimeDuration(1, TimeUnit.Minute),
+        getAutoDuration: () => new TimeDuration(1, TimeUnit.Minute)
       }),
       mockProvider(FeatureStateResolver, {
         getCombinedFeatureState: () => of(FeatureState.Disabled)

--- a/projects/observability/src/shared/components/explore-query-editor/interval/explore-query-interval-editor.component.test.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/interval/explore-query-interval-editor.component.test.ts
@@ -71,13 +71,13 @@ describe('Explore Query Interval Editor component', () => {
 
     spectator.click(spectator.query(byText('None'))!);
     const options = spectator.queryAll('.select-option', { root: true });
-    expect(options.length).toBe(7);
+    expect(options.length).toBe(5);
 
     spectator.click(options.find(option => option.textContent!.includes('Auto')));
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith('AUTO');
 
-    expect(spectator.element).toHaveText('Auto (15s)');
+    expect(spectator.element).toHaveText('Auto (1m)');
     flush();
   }));
 
@@ -101,16 +101,16 @@ describe('Explore Query Interval Editor component', () => {
 
     spectator.click(spectator.query(byText('None'))!);
     const options = spectator.queryAll('.select-option', { root: true });
-    expect(options.length).toBe(7);
-    expect(options[1]).toHaveText('Auto (15s)');
+    expect(options.length).toBe(5);
+    expect(options[1]).toHaveText('Auto (1m)');
 
-    // To simulate setRelativeRange(3, TimeUnit.Hour)
-    timeRangeSubject.next(new RelativeTimeRange(new TimeDuration(3, TimeUnit.Hour)));
+    // To simulate setRelativeRange(12, TimeUnit.Hour)
+    timeRangeSubject.next(new RelativeTimeRange(new TimeDuration(12, TimeUnit.Hour)));
 
     spectator.detectChanges();
     const newOptions = spectator.queryAll('.select-option', { root: true });
-    expect(newOptions.length).toBe(8);
-    expect(newOptions[1]).toHaveText('Auto (30s)');
+    expect(newOptions.length).toBe(6);
+    expect(newOptions[1]).toHaveText('Auto (5m)');
     flush();
   }));
 
@@ -122,17 +122,17 @@ describe('Explore Query Interval Editor component', () => {
     </ht-explore-query-interval-editor>`,
       {
         hostProps: {
-          interval: new TimeDuration(15, TimeUnit.Second),
+          interval: new TimeDuration(1, TimeUnit.Minute),
           onChange: onChange
         }
       }
     );
     spectator.tick();
 
-    expect(spectator.element).toHaveText('15s');
+    expect(spectator.element).toHaveText('1m');
 
-    // To simulate setRelativeRange(3, TimeUnit.Hour)
-    mockTimeRangeSubject.next(new RelativeTimeRange(new TimeDuration(3, TimeUnit.Hour)));
+    // To simulate setRelativeRange(3, TimeUnit.Day)
+    mockTimeRangeSubject.next(new RelativeTimeRange(new TimeDuration(3, TimeUnit.Day)));
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith('AUTO');
   }));


### PR DESCRIPTION
## Description

Sub-minute granularity isn't used and adds confusion for end user (as axes are always printed without seconds). 