### PR TITLE
fix: old class introduced unintentionally

### DIFF
--- a/projects/components/src/load-async/wrapper/load-async-wrapper.scss
+++ b/projects/components/src/load-async/wrapper/load-async-wrapper.scss
@@ -1,9 +1,3 @@
-@import 'layout';
-
-:host {
-  @include fill-container();
-}
-
 .custom-templated-message {
   display: flex;
   height: 100%;


### PR DESCRIPTION
## Description

Fixing regression from https://github.com/hypertrace/hypertrace-ui/pull/2075 - this stylesheet was previously unreferenced, but the new usage introduced a class that breaks styling.