### PR TITLE
fix: fixing accessibility color in button

### DIFF
--- a/projects/components/src/button/button.component.scss
+++ b/projects/components/src/button/button.component.scss
@@ -73,7 +73,7 @@
   }
 
   &.additive {
-    @include button-style($green-5, $green-6, white, white);
+    @include button-style($green-7, $green-6, white, white);
   }
 }
 
@@ -125,7 +125,7 @@
   }
 
   &.additive {
-    @include button-style(inherit, $green-1, $green-5, $green-5);
+    @include button-style(inherit, $green-1, $green-7, $green-5);
   }
 }
 
@@ -152,7 +152,7 @@
   }
 
   &.additive {
-    @include button-style(inherit, inherit, $green-5, $green-6);
+    @include button-style(inherit, inherit, $green-7, $green-6);
   }
 }
 


### PR DESCRIPTION
## Description
Fixing Accessibility color in buttons

### Testing
![image](https://user-images.githubusercontent.com/79482271/236533204-8b55ad8e-a28d-477f-962e-ac222434cb04.png)


### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.