### PR TITLE
feat: choose the first value for the breadcrumb when an entity contains a list of values

### DIFF
--- a/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.ts
+++ b/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.ts
@@ -99,10 +99,14 @@ export class ApiDetailBreadcrumbResolver<T extends EntityBreadcrumb> extends Ent
     if (!parentTypeMetadata) {
       return {};
     }
+    const parentName: string | string[] = entity[this.getParentNameAttribute(parentTypeMetadata)] as string;
 
     return {
       parentId: entity[this.getParentIdAttribute(parentTypeMetadata)] as string,
-      parentName: entity[this.getParentNameAttribute(parentTypeMetadata)] as string
+      // TODO: (ENG-30212) How do we know which domain name to display when
+      //  there is an array? There is no guarantee that the first domain chosen
+      //  will match the domainId for the domain.
+      parentName: Array.isArray(parentName) ? parentName[0] : parentName
     };
   }
 

--- a/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.ts
+++ b/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.ts
@@ -99,7 +99,7 @@ export class ApiDetailBreadcrumbResolver<T extends EntityBreadcrumb> extends Ent
     if (!parentTypeMetadata) {
       return {};
     }
-    const parentName: string | string[] = entity[this.getParentNameAttribute(parentTypeMetadata)] as string;
+    const parentName = entity[this.getParentNameAttribute(parentTypeMetadata)] as string | string[];
 
     return {
       parentId: entity[this.getParentIdAttribute(parentTypeMetadata)] as string,

--- a/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.ts
+++ b/projects/observability/src/pages/apis/api-detail/api-detail-breadcrumb.resolver.ts
@@ -101,6 +101,10 @@ export class ApiDetailBreadcrumbResolver<T extends EntityBreadcrumb> extends Ent
     }
     const parentName = entity[this.getParentNameAttribute(parentTypeMetadata)] as string | string[];
 
+    if (Array.isArray(parentName) && parentName.length === 0) {
+      return {};
+    }
+
     return {
       parentId: entity[this.getParentIdAttribute(parentTypeMetadata)] as string,
       // TODO: (ENG-30212) How do we know which domain name to display when


### PR DESCRIPTION
## Description
When provided multiple values for the breadcrumb, show the first one (for now).

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
