### PR TITLE
fix: update destroy button color to support accessibility

### DIFF
--- a/projects/assets-library/assets/styles/_color-palette.scss
+++ b/projects/assets-library/assets/styles/_color-palette.scss
@@ -7,7 +7,7 @@ $red-2: #fecac2;
 $red-3: #fea395;
 $red-4: #fd7c68;
 $red-5: #fd5138;
-$red-6: #f72202;
+$red-6: #e81f01;
 $red-7: #bb1902;
 $red-8: #6a0e01;
 $red-9: #140300;

--- a/projects/components/src/button/button.component.scss
+++ b/projects/components/src/button/button.component.scss
@@ -69,7 +69,7 @@
   }
 
   &.destructive {
-    @include button-style($red-5, $red-7, white, white);
+    @include button-style($red-6, $red-7, white, white);
   }
 
   &.additive {
@@ -95,7 +95,7 @@
   }
 
   &.destructive {
-    @include button-style(inherit, $red-1, $gray-7, $gray-7, $red-5);
+    @include button-style(inherit, $red-1, $gray-7, $gray-7, $red-6);
   }
 
   &.additive {
@@ -121,7 +121,7 @@
   }
 
   &.destructive {
-    @include button-style(inherit, $red-1, $red-5, $red-5);
+    @include button-style(inherit, $red-1, $red-6, $red-6);
   }
 
   &.additive {
@@ -148,7 +148,7 @@
   }
 
   &.destructive {
-    @include button-style(inherit, inherit, $red-5, $red-7);
+    @include button-style(inherit, inherit, $red-6, $red-7);
   }
 
   &.additive {


### PR DESCRIPTION
## Description
Update destroy button color to support accessibility

### Testing
Locally tested

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
