### PR TITLE
feat: Adding Accessibility to Input and Button

### DIFF
--- a/projects/components/src/button/button.component.ts
+++ b/projects/components/src/button/button.component.ts
@@ -18,6 +18,7 @@ import { ButtonSize, ButtonStyle, ButtonType, ButtonVariant } from './button';
         [htTrackLabel]="this.label"
         [type]="this.type"
         [attr.aria-label]="this.ariaLabel ?? this.label"
+        [disabled]="this.disabled"
       >
         <ht-icon
           *ngIf="this.icon"

--- a/projects/components/src/input/input.component.ts
+++ b/projects/components/src/input/input.component.ts
@@ -30,6 +30,7 @@ import { InputAppearance } from './input-appearance';
         [required]="this.required"
         [disabled]="this.disabled"
         [placeholder]="this.placeholderValue"
+        [attr.aria-label]="this.ariaLabel || 'input'"
         [ngModel]="this.value"
         (ngModelChange)="this.onValueChange($event)"
       />
@@ -54,6 +55,9 @@ export class InputComponent<T extends string | number> implements ControlValueAc
 
   @Input()
   public disabled: boolean = false;
+
+  @Input()
+  public ariaLabel?: string;
 
   @Output()
   public readonly valueChange: EventEmitter<T | undefined> = new EventEmitter();


### PR DESCRIPTION
## Description
Adding Accesibility to Input (ariaLabel) and disabling to button to prevent an issue with the correspondent opacity

### Testing
Tested locally

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
