### PR TITLE
fix: Updating color and adding aria label into modal icon to support accessibility

### DIFF
--- a/projects/assets-library/assets/styles/_interaction.scss
+++ b/projects/assets-library/assets/styles/_interaction.scss
@@ -95,7 +95,7 @@
 
 @mixin disableable {
   &.disabled {
-    opacity: 0.4;
+    opacity: 0.58; // Minimal opacity to provide contrast for accessibility
     cursor: not-allowed;
   }
 }

--- a/projects/common/src/color/color.ts
+++ b/projects/common/src/color/color.ts
@@ -51,7 +51,7 @@ export const enum Color {
   Red3 = '#FEA395',
   Red4 = '#fd7c68',
   Red5 = '#FD5138',
-  Red6 = '#F72202',
+  Red6 = '#e51f01',
   Red7 = '#bb1902',
   Red8 = '#6a0e01',
   Red9 = '#140300',

--- a/projects/components/src/modal/modal-container.component.ts
+++ b/projects/components/src/modal/modal-container.component.ts
@@ -21,6 +21,7 @@ import { getModalDimensions, ModalConfig, ModalDimension, MODAL_DATA } from './m
           display="${ButtonStyle.Outlined}"
           size="${ButtonSize.Tiny}"
           htTooltip="Close modal"
+          ariaLabel="Close"
           (click)="this.close()"
         >
         </ht-button>


### PR DESCRIPTION
## Description
Adding aria-label and updating color and opacity value

### Testing
Tested locally

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
