### PR TITLE
fix: Update blue color and add textarea aria-label

### DIFF
--- a/projects/assets-library/assets/styles/_color-palette.scss
+++ b/projects/assets-library/assets/styles/_color-palette.scss
@@ -45,7 +45,7 @@ $green-9: #03110a;
 $blue-1: #f0f6ff;
 $blue-2: #b8d3ff;
 $blue-3: #70a7ff;
-$blue-4: #2478ff;
+$blue-4: #0666ff;
 $blue-5: #0053d7;
 $blue-6: #0043ad;
 $blue-7: #003385;

--- a/projects/components/src/textarea/textarea.component.ts
+++ b/projects/components/src/textarea/textarea.component.ts
@@ -29,6 +29,7 @@ import { LoggerService } from '@hypertrace/common';
         [rows]="this.rows"
         [disabled]="this.disabled"
         [placeholder]="this.placeholder"
+        [attr.aria-label]="this.ariaLabel || 'textarea'"
         [ngModel]="this.value"
         (ngModelChange)="this.onValueChange($event)"
       >
@@ -48,6 +49,9 @@ export class TextareaComponent implements ControlValueAccessor, OnInit {
 
   @Input()
   public rows: number = 2;
+
+  @Input()
+  public ariaLabel?: string;
 
   @Output()
   public readonly valueChange: EventEmitter<string> = new EventEmitter();


### PR DESCRIPTION
## Description
Updating blue color to support accessibility and adding ariaLabel into textArea

### Testing
Tested Locally

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.