### PR TITLE
fix: table detail content rendering

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -494,7 +494,11 @@ export class TableComponent
       this.initializeData();
     }
 
-    if (changes.selections) {
+    // Current and previous selections both should not be empty.
+    if (
+      changes.selections &&
+      !((changes.selections.previousValue?.length ?? 0) === 0 && (changes.selections.currentValue?.length ?? 0) === 0)
+    ) {
       this.toggleRowSelections(this.selections);
     }
   }
@@ -807,7 +811,13 @@ export class TableComponent
 
   public toggleRowExpanded(row: StatefulTableRow): void {
     row.$$state.expanded = !row.$$state.expanded;
-    this.rowStateSubject.next(row);
+    /**
+     * Only needed for the `tree` type table.
+     * For detail type, it is not needed since we're triggering change detection.
+     */
+    if (this.isTreeType()) {
+      this.rowStateSubject.next(row);
+    }
     this.toggleRowChange.emit(row);
     this.changeDetector.markForCheck();
   }


### PR DESCRIPTION
## Description
This fixes the re-rendering for the detailed content if any other row is expanded.

`Current Behaviour`
Currently, if we have a table of type `detail` and we expand a row, the first one works fine but if we expand another row then it renders both the rows. That means it will always render all the previously expanded rows if we expand any other rows.

`FIx`
There are checks needed to fix this.
1. Selections change should not be triggered if current and previous both selections are empty.
2. The rowChange emission should only happen when the table of `tree` type, since it causes the whole table to re-render

### Testing
Manual testing is done.

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
