### PR TITLE
fix: update red risk color to support accessibility

### DIFF
--- a/projects/assets-library/assets/styles/_color-palette.scss
+++ b/projects/assets-library/assets/styles/_color-palette.scss
@@ -96,12 +96,12 @@ $off-white: #f6f6f64d;
 $color-health-green: $green-5;
 $color-health-yellow: $yellow-5;
 $color-health-orange: $orange-5;
-$color-health-red: $red-5;
+$color-health-red: $red-6;
 $color-health-unknown: $gray-7;
 
 // Risk
 $color-risk-critical: $purple-6;
-$color-risk-high: $red-5;
+$color-risk-high: $red-6;
 $color-risk-medium: $orange-4;
 $color-risk-low: $yellow-4;
 


### PR DESCRIPTION
## Description
update red risk color to support accessibility

### Testing
Locally tested

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
