### PR TITLE
fix(select): removed assertion

### DIFF
--- a/projects/components/src/select/select.component.ts
+++ b/projects/components/src/select/select.component.ts
@@ -254,7 +254,7 @@ export class SelectComponent<V> implements ControlValueAccessor, AfterContentIni
 
   @ContentChildren(SelectOptionComponent)
   private readonly allOptionsList?: QueryList<SelectOptionComponent<V>>;
-  public allOptions$!: Observable<QueryList<SelectOptionComponent<V>>>;
+  public allOptions$: Observable<QueryList<SelectOptionComponent<V>>> = EMPTY;
   public filteredOptions$!: Observable<SelectOptionComponent<V>[]>;
 
   @ContentChildren(SelectControlOptionComponent)


### PR DESCRIPTION
## Description
We use `!` on `allOptions$` but it is assigned a value only in the `ngAfterContentInit` lifecycle.

When the component gets initialized, if `writeValue` is called, then there is this piece of code which runs:
```ts
  private buildObservableOfSelected(): Observable<SelectOption<V> | undefined> {
    return this.allOptions$.pipe(
      switchMap(items => merge(of(undefined), ...items.map(option => option.optionChange$))),
      map(() => this.findItem(this.selected))
    );
  }
```

Here `this.allOptions$` will be `undefined` in the start and hence throws error. Having a default `EMPTY` value for `allOptions$` doesn't break the code. 