### PR TITLE
fix: adding hide column functionality back

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -133,6 +133,7 @@ import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
                       [sort]="columnDef.sort"
                       [indeterminateRowsSelected]="this.indeterminateRowsSelected"
                       (sortChange)="this.onSortChange($event, columnDef)"
+                      (hideCurrentColumnChange)="this.onHideColumn(columnDef)"
                       (showEditColumnsChange)="this.showEditColumnsModal()"
                     >
                     </ht-table-header-cell-renderer>


### PR DESCRIPTION
This got removed mistakenly with the last PR, so adding it back again