### PR TITLE
feat(table): add options to allow customization of cell renderers

### DIFF
--- a/projects/components/src/table/cells/table-cell-injection.ts
+++ b/projects/components/src/table/cells/table-cell-injection.ts
@@ -9,6 +9,7 @@ export const TABLE_DATA_PARSER: InjectionToken<TableCellParserBase<unknown, unkn
 );
 export const TABLE_CELL_DATA: InjectionToken<unknown> = new InjectionToken('TABLE_CELL_DATA');
 export const TABLE_ROW_DATA: InjectionToken<unknown> = new InjectionToken('TABLE_ROW_DATA');
+export const TABLE_CELL_OPTIONS: InjectionToken<unknown> = new InjectionToken('TABLE_CELL_OPTIONS');
 
 export const createTableCellInjector = (
   columnConfig: TableColumnConfig,
@@ -35,6 +36,10 @@ export const createTableCellInjector = (
       {
         provide: TABLE_CELL_DATA,
         useValue: cellData
+      },
+      {
+        provide: TABLE_CELL_OPTIONS,
+        useValue: columnConfig?.options
       },
       {
         provide: TABLE_ROW_DATA,

--- a/projects/components/src/table/cells/table-cell-injection.ts
+++ b/projects/components/src/table/cells/table-cell-injection.ts
@@ -9,7 +9,6 @@ export const TABLE_DATA_PARSER: InjectionToken<TableCellParserBase<unknown, unkn
 );
 export const TABLE_CELL_DATA: InjectionToken<unknown> = new InjectionToken('TABLE_CELL_DATA');
 export const TABLE_ROW_DATA: InjectionToken<unknown> = new InjectionToken('TABLE_ROW_DATA');
-export const TABLE_CELL_OPTIONS: InjectionToken<unknown> = new InjectionToken('TABLE_CELL_OPTIONS');
 
 export const createTableCellInjector = (
   columnConfig: TableColumnConfig,
@@ -36,10 +35,6 @@ export const createTableCellInjector = (
       {
         provide: TABLE_CELL_DATA,
         useValue: cellData
-      },
-      {
-        provide: TABLE_CELL_OPTIONS,
-        useValue: columnConfig?.options
       },
       {
         provide: TABLE_ROW_DATA,

--- a/projects/components/src/table/cells/table-cell-renderer-base.ts
+++ b/projects/components/src/table/cells/table-cell-renderer-base.ts
@@ -1,7 +1,8 @@
-import { Directive, Inject, OnInit } from '@angular/core';
+import { Directive, inject, Inject, OnInit } from '@angular/core';
 import { TableColumnConfig, TableRow } from '../table-api';
 import {
   TABLE_CELL_DATA,
+  TABLE_CELL_OPTIONS,
   TABLE_COLUMN_CONFIG,
   TABLE_COLUMN_INDEX,
   TABLE_DATA_PARSER,
@@ -13,7 +14,8 @@ import { CoreTableCellRendererType } from './types/core-table-cell-renderer-type
 import { TableCellAlignmentType } from './types/table-cell-alignment-type';
 
 @Directive() // Angular 9 Requires superclasses to be annotated as well in order to resolve injectables for constructor
-export abstract class TableCellRendererBase<TCellData, TValue = TCellData> implements OnInit {
+export abstract class TableCellRendererBase<TCellData, TValue = TCellData, TColumnConfigOptions = unknown>
+  implements OnInit {
   public static readonly type: CoreTableCellRendererType;
   public static readonly alignment: TableCellAlignmentType;
   public static readonly parser: CoreTableCellParserType;
@@ -23,6 +25,9 @@ export abstract class TableCellRendererBase<TCellData, TValue = TCellData> imple
   private _tooltip!: string;
   public readonly clickable: boolean = false;
   public readonly isFirstColumn: boolean = false;
+  protected readonly columnConfigOptions: TColumnConfigOptions | undefined = inject<TColumnConfigOptions | undefined>(
+    TABLE_CELL_OPTIONS
+  );
 
   public constructor(
     @Inject(TABLE_COLUMN_CONFIG) private readonly columnConfig: TableColumnConfig,

--- a/projects/components/src/table/cells/table-cell-renderer-base.ts
+++ b/projects/components/src/table/cells/table-cell-renderer-base.ts
@@ -1,8 +1,7 @@
-import { Directive, inject, Inject, OnInit } from '@angular/core';
+import { Directive, Inject, OnInit } from '@angular/core';
 import { TableColumnConfig, TableRow } from '../table-api';
 import {
   TABLE_CELL_DATA,
-  TABLE_CELL_OPTIONS,
   TABLE_COLUMN_CONFIG,
   TABLE_COLUMN_INDEX,
   TABLE_DATA_PARSER,
@@ -25,12 +24,9 @@ export abstract class TableCellRendererBase<TCellData, TValue = TCellData, TColu
   private _tooltip!: string;
   public readonly clickable: boolean = false;
   public readonly isFirstColumn: boolean = false;
-  protected readonly columnConfigOptions: TColumnConfigOptions | undefined = inject<TColumnConfigOptions | undefined>(
-    TABLE_CELL_OPTIONS
-  );
-
+  protected readonly columnConfigOptions: TColumnConfigOptions | undefined;
   public constructor(
-    @Inject(TABLE_COLUMN_CONFIG) private readonly columnConfig: TableColumnConfig,
+    @Inject(TABLE_COLUMN_CONFIG) private readonly columnConfig: TableColumnConfig<TColumnConfigOptions>,
     @Inject(TABLE_COLUMN_INDEX) private readonly index: number,
     @Inject(TABLE_DATA_PARSER) private readonly parser: TableCellParserBase<TCellData, TValue, unknown>,
     @Inject(TABLE_CELL_DATA) private readonly cellData: TCellData,
@@ -38,6 +34,7 @@ export abstract class TableCellRendererBase<TCellData, TValue = TCellData, TColu
   ) {
     this.clickable = this.columnConfig.onClick !== undefined;
     this.isFirstColumn = this.index === 0;
+    this.columnConfigOptions = this.columnConfig?.options;
   }
 
   public ngOnInit(): void {

--- a/projects/components/src/table/table-api.ts
+++ b/projects/components/src/table/table-api.ts
@@ -4,20 +4,35 @@ import { FieldFilter, FilterValue } from '../filtering/filter/filter';
 import { FilterOperator } from '../filtering/filter/filter-operators';
 import { TableCellAlignmentType } from './cells/types/table-cell-alignment-type';
 
-export interface TableColumnConfig {
-  id: string; // This is the unique ID for the column (often same as 'name' except for composite fields)
-  name?: string; // Attribute name (for composite columns use the attribute that should be filtered/sorted)
+export interface TableColumnConfig<TableColumnOptions = unknown> {
+  /**
+   * This is the unique ID for the column (often same as 'name' except for composite fields)
+   */
+  id: string;
+  /**
+   * Attribute name (for composite columns use the attribute that should be filtered/sorted)
+   */
+  name?: string;
+  /**
+   * This is used to correlate with a cell renderer that should be used for the column
+   */
   display?: string;
   title?: string;
   titleTooltip?: string;
   sort?: TableSortDirection;
-  visible?: boolean; // Is the column shown
-  editable?: boolean; // Can the column be added/removed
-  sortable?: boolean; // Can the column be sorted
-  filterable?: boolean; // Can the column be filtered
+  visible?: boolean;
+  editable?: boolean;
+  sortable?: boolean;
+  filterable?: boolean;
   alignment?: TableCellAlignmentType;
   width?: number | string;
   minWidth?: number | string;
+  /**
+   * Use the `options` to pass additional data to the renderer for
+   * customizations.
+   */
+  options?: TableColumnOptions;
+
   onClick?(row: TableRow, column: TableColumnConfig): void;
 }
 


### PR DESCRIPTION
## Description

- Add extra `options` prop to the `TableColumnConfig`
- Use it to pass extra data to the renderers which can then be used for customizing the renderers.