### PR TITLE
fix: topology chart rendering

### DIFF
--- a/projects/observability/src/shared/components/topology/renderers/edge/topology-edge-renderer.service.ts
+++ b/projects/observability/src/shared/components/topology/renderers/edge/topology-edge-renderer.service.ts
@@ -135,7 +135,13 @@ export interface TopologyEdgeRenderDelegate<T extends TopologyEdge = TopologyEdg
     position: TopologyEdgePositionInformation,
     domRenderer: Renderer2
   ): void;
-  updateState(parentElement: SVGGElement, edge: T, state: TopologyEdgeState, domRenderer: Renderer2): void;
+  updateState(
+    parentElement: SVGGElement,
+    edge: T,
+    state: TopologyEdgeState,
+    domRenderer: Renderer2,
+    position?: TopologyEdgePositionInformation
+  ): void;
 }
 
 interface RenderedEdgeInfo {

--- a/projects/observability/src/shared/dashboard/widgets/topology/edge/curved/entity-edge-curve-renderer.scss
+++ b/projects/observability/src/shared/dashboard/widgets/topology/edge/curved/entity-edge-curve-renderer.scss
@@ -29,6 +29,12 @@
 
       .entity-edge-metric-value {
         @include hide;
+        @include code;
+        font-size: 0.8em;
+        font-weight: 600;
+        text-anchor: middle;
+        fill: white;
+        stroke: none;
       }
 
       .edge-path {
@@ -53,11 +59,6 @@
 
         .entity-edge-metric-value {
           @include show;
-          fill: white;
-          stroke: none;
-          font-size: 0.8em;
-          font-weight: 600;
-          text-anchor: middle;
         }
 
         .edge-path {

--- a/projects/observability/src/shared/dashboard/widgets/topology/node/box/entity-node-box-renderer.scss
+++ b/projects/observability/src/shared/dashboard/widgets/topology/node/box/entity-node-box-renderer.scss
@@ -62,7 +62,6 @@
       .entity-label {
         @include link-hover(true);
         @include body-2-medium($gray-7);
-        text-anchor: middle;
         fill: $gray-7;
       }
 


### PR DESCRIPTION
## 🐛 BUG

For large data, the topology chart is taking a lot of time to render.

## 🔍  ISSUE

We are computing the text widths for node and edge from DOM and updating the properties in the same flow which takes a lot of time to be done.

## 🔨  FIX

`For Edge` -> We used the monospace font so that we know each character would have the same width. Used that to define the `getCharWidth` function.

`For Node` -> Similar pattern as edge. But didn't use monospace just defined an average char width, which works well.