### PR TITLE
fix: disallow console logging - eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -101,6 +101,9 @@
         ],
         "@typescript-eslint/require-await": "error",
         "@typescript-eslint/restrict-plus-operands": "error",
+        "no-console": ["error", {
+          "allow": ["warn","error"]
+        }],
         "arrow-body-style": ["error", "as-needed"],
         "complexity": ["error", 20],
         "default-case": "error",


### PR DESCRIPTION
## Description
Eslint no-console rule to disallow console logging
Allow only warnings and errors.