### PR TITLE
feat: add external urls allow list handling

### DIFF
--- a/projects/common/src/constants/external-url-constants.ts
+++ b/projects/common/src/constants/external-url-constants.ts
@@ -1,0 +1,13 @@
+import { InjectionToken } from '@angular/core';
+
+export const externalUrlConstants: ExternalUrlConstants = {
+  urlAllowList: [],
+  domainAllowList: ['hypertrace.org']
+};
+
+export interface ExternalUrlConstants {
+  urlAllowList: string[];
+  domainAllowList: string[];
+}
+
+export const EXTERNAL_URL_CONSTANTS = new InjectionToken<ExternalUrlConstants>('EXTERNAL_URL_CONSTANTS');

--- a/projects/common/src/constants/external-url-constants.ts
+++ b/projects/common/src/constants/external-url-constants.ts
@@ -6,8 +6,8 @@ export const externalUrlConstants: ExternalUrlConstants = {
 };
 
 export interface ExternalUrlConstants {
-  urlAllowList: string[];
-  domainAllowList: string[];
+  urlAllowList: string[]; // Use for static urls
+  domainAllowList: string[]; // Use for dynamic urls
 }
 
 export const EXTERNAL_URL_CONSTANTS = new InjectionToken<ExternalUrlConstants>('EXTERNAL_URL_CONSTANTS');

--- a/projects/common/src/external/external-url-navigator.test.ts
+++ b/projects/common/src/external/external-url-navigator.test.ts
@@ -6,12 +6,22 @@ import {
   NavigationService
 } from '../navigation/navigation.service';
 import { ExternalUrlNavigator } from './external-url-navigator';
+import { EXTERNAL_URL_CONSTANTS } from '../constants/external-url-constants';
 
 describe('External URL navigator', () => {
   let spectator: SpectatorService<ExternalUrlNavigator>;
   const buildNavigator = createServiceFactory({
     service: ExternalUrlNavigator,
-    providers: [mockProvider(NavigationService)]
+    providers: [
+      mockProvider(NavigationService),
+      {
+        provide: EXTERNAL_URL_CONSTANTS,
+        useValue: {
+          urlAllowList: ['https://www.test.com'],
+          domainAllowList: ['test123.in']
+        }
+      }
+    ]
   });
 
   beforeEach(() => {
@@ -19,12 +29,12 @@ describe('External URL navigator', () => {
     window.open = jest.fn();
   });
 
-  test('goes back when unable to detect a url on navigation', () => {
+  test('goes to error page when unable to detect a url on navigation', () => {
     spectator.service.canActivate({
       paramMap: convertToParamMap({})
     } as ActivatedRouteSnapshot);
 
-    expect(spectator.inject(NavigationService).navigateBack).toHaveBeenCalledTimes(1);
+    expect(spectator.inject(NavigationService).navigateToErrorPage).toHaveBeenCalledTimes(1);
 
     spectator.service.canActivate({
       paramMap: convertToParamMap({
@@ -32,25 +42,51 @@ describe('External URL navigator', () => {
       })
     } as ActivatedRouteSnapshot);
 
-    expect(spectator.inject(NavigationService).navigateBack).toHaveBeenCalledTimes(2);
+    expect(spectator.inject(NavigationService).navigateToErrorPage).toHaveBeenCalledTimes(2);
     expect(window.open).not.toHaveBeenCalled();
   });
 
-  test('navigates when a url is provided', () => {
+  test('navigates when an allowed url is provided', () => {
     spectator.service.canActivate({
-      paramMap: convertToParamMap({ [ExternalNavigationPathParams.Url]: 'https://www.google.com' })
+      paramMap: convertToParamMap({ [ExternalNavigationPathParams.Url]: 'https://www.test.com' })
     } as ActivatedRouteSnapshot);
 
-    expect(window.open).toHaveBeenNthCalledWith(1, 'https://www.google.com', '_self');
+    expect(window.open).toHaveBeenNthCalledWith(1, 'https://www.test.com', '_self');
 
     spectator.service.canActivate({
       paramMap: convertToParamMap({
-        [ExternalNavigationPathParams.Url]: 'https://www.bing.com',
+        [ExternalNavigationPathParams.Url]: 'https://www.test456.com',
         [ExternalNavigationPathParams.WindowHandling]: ExternalNavigationWindowHandling.NewWindow
       })
     } as ActivatedRouteSnapshot);
 
-    expect(window.open).toHaveBeenNthCalledWith(2, 'https://www.bing.com', undefined);
-    expect(spectator.inject(NavigationService).navigateBack).not.toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalledTimes(2);
+    expect(spectator.inject(NavigationService).navigateToErrorPage).toHaveBeenCalled();
+  });
+
+  test('navigates when an allowed domain url is provided', () => {
+    spectator.service.canActivate({
+      paramMap: convertToParamMap({ [ExternalNavigationPathParams.Url]: 'https://www.test123.in/test' })
+    } as ActivatedRouteSnapshot);
+
+    expect(window.open).toHaveBeenNthCalledWith(1, 'https://www.test123.in/test', '_self');
+
+    spectator.service.canActivate({
+      paramMap: convertToParamMap({
+        [ExternalNavigationPathParams.Url]: 'https://www.test456.com',
+        [ExternalNavigationPathParams.WindowHandling]: ExternalNavigationWindowHandling.NewWindow
+      })
+    } as ActivatedRouteSnapshot);
+
+    expect(window.open).not.toHaveBeenCalledTimes(2);
+    expect(spectator.inject(NavigationService).navigateToErrorPage).toHaveBeenCalled();
+  });
+
+  test('navigates when an partial url is provided', () => {
+    spectator.service.canActivate({
+      paramMap: convertToParamMap({ [ExternalNavigationPathParams.Url]: '/test' })
+    } as ActivatedRouteSnapshot);
+
+    expect(window.open).toHaveBeenCalled();
   });
 });

--- a/projects/common/src/external/external-url-navigator.ts
+++ b/projects/common/src/external/external-url-navigator.ts
@@ -37,10 +37,20 @@ export class ExternalUrlNavigator implements CanActivate {
    *  Or If it is related to the current app-domain
    */
   private isExternalUrlNavigable(url: string): boolean {
+    let correctUrl: string = '';
+
+    // Check whether given url is a correct url or not.
+    try {
+      new URL(url);
+      correctUrl = url;
+    } catch {
+      correctUrl = `${window.location.origin}${url.startsWith('/') ? '' : '/'}${url}`;
+    }
+
     return (
-      this.externalUrlConstants.urlAllowList.includes(url) ||
-      this.isExternalDomainAllowed(url) ||
-      this.isCurrentAppDomain(url)
+      this.externalUrlConstants.urlAllowList.includes(correctUrl) ||
+      this.isExternalDomainAllowed(correctUrl) ||
+      this.isCurrentAppDomain(correctUrl)
     );
   }
 

--- a/projects/common/src/external/external-url-navigator.ts
+++ b/projects/common/src/external/external-url-navigator.ts
@@ -8,6 +8,7 @@ import {
 } from '../navigation/navigation.service';
 import { assertUnreachable } from '../utilities/lang/lang-utils';
 import { EXTERNAL_URL_CONSTANTS, ExternalUrlConstants } from '../constants/external-url-constants';
+import { isEmpty } from 'lodash-es';
 
 @Injectable({ providedIn: 'root' })
 export class ExternalUrlNavigator implements CanActivate {
@@ -21,7 +22,7 @@ export class ExternalUrlNavigator implements CanActivate {
     const windowHandling = route.paramMap.has(ExternalNavigationPathParams.WindowHandling)
       ? (route.paramMap.get(ExternalNavigationPathParams.WindowHandling) as ExternalNavigationWindowHandling)
       : undefined;
-    if (this.isExternalUrlNavigable(encodedUrl)) {
+    if (!isEmpty(encodedUrl) && this.isExternalUrlNavigable(encodedUrl)) {
       this.navigateToUrl(encodedUrl, windowHandling);
     } else {
       this.navService.navigateToErrorPage();

--- a/projects/common/src/public-api.ts
+++ b/projects/common/src/public-api.ts
@@ -26,6 +26,7 @@ export * from './color/color';
 
 // Constants
 export * from './constants/application-constants';
+export * from './constants/external-url-constants';
 
 // Custom Error
 export * from './custom-error/custom-error';

--- a/src/app/config.module.ts
+++ b/src/app/config.module.ts
@@ -1,6 +1,12 @@
 import { NgModule } from '@angular/core';
 import { MATERIAL_SANITY_CHECKS } from '@angular/material/core';
-import { ALTERNATE_COLOR_PALETTES, APP_TITLE, DEFAULT_COLOR_PALETTE } from '@hypertrace/common';
+import {
+  ALTERNATE_COLOR_PALETTES,
+  APP_TITLE,
+  DEFAULT_COLOR_PALETTE,
+  EXTERNAL_URL_CONSTANTS,
+  externalUrlConstants
+} from '@hypertrace/common';
 import { GRAPHQL_OPTIONS } from '@hypertrace/graphql-client';
 import { ENTITY_METADATA, RED_COLOR_PALETTE } from '@hypertrace/observability';
 import { environment } from '../environments/environment';
@@ -47,6 +53,10 @@ import { FeatureResolverModule } from './shared/feature-resolver/feature-resolve
         theme: false,
         version: true
       }
+    },
+    {
+      provide: EXTERNAL_URL_CONSTANTS,
+      useValue: externalUrlConstants
     }
   ]
 })


### PR DESCRIPTION
We're introducing `urlAllowList` and `domainAllowList` in the case of external URL redirection.
An external will only be redirected if
1. It is a full URL and inside the urlAllowList
2. It is a full URL and the domain is inside domainAllowList
3. It is a partial URL (for in-app navigation with external nav params)