### PR TITLE
feat: converts trace ID visible in spam table

### DIFF
--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -510,6 +510,7 @@ export class ExplorerDashboardBuilder {
           },
           {
             type: 'table-widget-column',
+            visible: false,
             filterable: true,
             value: {
               type: 'attribute-specification',

--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -510,7 +510,6 @@ export class ExplorerDashboardBuilder {
           },
           {
             type: 'table-widget-column',
-            visible: false,
             filterable: true,
             value: {
               type: 'attribute-specification',

--- a/projects/observability/src/shared/components/cartesian/d3/legend/cartesian-legend.ts
+++ b/projects/observability/src/shared/components/cartesian/d3/legend/cartesian-legend.ts
@@ -129,7 +129,7 @@ export class CartesianLegend<TData> {
       .selectAll('.legend-entry')
       .data(seriesGroup)
       .enter()
-      .each((_, index, elements) => this.drawLegendEntry(elements[index]));
+      .each((_, index, elements) => this.drawLegendEntry(elements[index], true));
   }
 
   private drawLegendContainer(
@@ -151,7 +151,10 @@ export class CartesianLegend<TData> {
       .classed('grouped', this.isGrouped);
   }
 
-  private drawLegendEntry(element: EnterElement): Selection<HTMLDivElement, Series<TData>, null, undefined> {
+  private drawLegendEntry(
+    element: EnterElement,
+    showFilters?: boolean
+  ): Selection<HTMLDivElement, Series<TData>, null, undefined> {
     const legendEntry = select<EnterElement, Series<TData>>(element).append('div').classed('legend-entry', true);
 
     this.appendLegendSymbol(legendEntry);
@@ -166,9 +169,11 @@ export class CartesianLegend<TData> {
 
     this.updateLegendClassesAndStyle();
 
-    legendEntry
-      .on('mouseover', () => legendEntry.select('.filter').style('visibility', 'visible'))
-      .on('mouseout', () => legendEntry.select('.filter').style('visibility', 'hidden'));
+    if (showFilters) {
+      legendEntry
+        .on('mouseover', () => legendEntry.select('.filter').style('visibility', 'visible'))
+        .on('mouseout', () => legendEntry.select('.filter').style('visibility', 'hidden'));
+    }
 
     return legendEntry;
   }

--- a/projects/observability/src/shared/dashboard/data/graphql/table/spans/spans-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/spans/spans-table-data-source.model.ts
@@ -16,7 +16,7 @@ import { TableDataSourceModel } from '../table-data-source.model';
 })
 export class SpansTableDataSourceModel extends TableDataSourceModel {
   // Mandatory fields: added to the request even if they are not visible
-  private mandatoryColumns: string[] = ['traceId'];
+  private readonly mandatoryColumns: string[] = ['traceId'];
 
   public getScope(): string {
     return SPAN_SCOPE;

--- a/projects/observability/src/shared/dashboard/data/graphql/table/spans/spans-table-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/table/spans/spans-table-data-source.model.ts
@@ -15,6 +15,9 @@ import { TableDataSourceModel } from '../table-data-source.model';
   type: 'spans-table-data-source'
 })
 export class SpansTableDataSourceModel extends TableDataSourceModel {
+  // Mandatory fields: added to the request even if they are not visible
+  private mandatoryColumns: string[] = ['traceId'];
+
   public getScope(): string {
     return SPAN_SCOPE;
   }
@@ -25,7 +28,9 @@ export class SpansTableDataSourceModel extends TableDataSourceModel {
   ): GraphQlSpansRequest {
     return {
       requestType: SPANS_GQL_REQUEST,
-      properties: request.columns.filter(column => column.visible).map(column => column.specification),
+      properties: request.columns
+        .filter(column => column.visible || this.mandatoryColumns.includes(column.id))
+        .map(column => column.specification),
       limit: request.position.limit * 2, // Prefetch 2 pages
       offset: request.position.startIndex,
       sort: request.sort && {


### PR DESCRIPTION
## Description
Fix spams redirection (using traceID) and remove filters from legends that show no possible options

### Testing
Locally Tested

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
