### PR TITLE
fix: support async rendered menu items

### DIFF
--- a/projects/components/src/menu-dropdown/menu-dropdown.component.ts
+++ b/projects/components/src/menu-dropdown/menu-dropdown.component.ts
@@ -1,7 +1,10 @@
-import { ChangeDetectionStrategy, Component, ContentChildren, Input, QueryList } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component, ContentChildren, Input, QueryList } from '@angular/core';
 import { IconType } from '@hypertrace/assets-library';
+import { queryListAndChanges$ } from '@hypertrace/common';
+import { Observable, of } from 'rxjs';
 import { IconSize } from '../icon/icon-size';
 import { MenuItemComponent } from './menu-item/menu-item.component';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'ht-menu-dropdown',
@@ -9,10 +12,10 @@ import { MenuItemComponent } from './menu-item/menu-item.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ht-event-blocker event="click" [enabled]="true">
-      <ht-popover [closeOnClick]="true" [disabled]="this.disabled" *ngIf="this.items?.length > 0">
+      <ht-popover [closeOnClick]="true" [disabled]="this.disabled" *ngIf="this.hasItems$ | async">
         <ht-popover-trigger>
           <div class="trigger-content" [ngClass]="{ disabled: this.disabled, labeled: !!this.label }">
-            <ht-label *ngIf="this.label" class="trigger-label" [label]="this.label"> </ht-label>
+            <ht-label *ngIf="this.label" class="trigger-label" [label]="this.label"></ht-label>
             <ht-icon *ngIf="this.icon" class="trigger-icon" [icon]="this.icon" size="${IconSize.Small}"></ht-icon>
           </div>
         </ht-popover-trigger>
@@ -25,7 +28,7 @@ import { MenuItemComponent } from './menu-item/menu-item.component';
     </ht-event-blocker>
   `
 })
-export class MenuDropdownComponent {
+export class MenuDropdownComponent implements AfterContentInit {
   @Input()
   public icon?: IconType;
 
@@ -37,4 +40,12 @@ export class MenuDropdownComponent {
 
   @ContentChildren(MenuItemComponent)
   public items?: QueryList<MenuItemComponent>;
+
+  public hasItems$: Observable<boolean> = of(false);
+
+  public ngAfterContentInit(): void {
+    if (this.items) {
+      this.hasItems$ = queryListAndChanges$(this.items).pipe(map(items => items.length > 0));
+    }
+  }
 }

--- a/projects/components/src/menu-dropdown/menu-dropdown.component.ts
+++ b/projects/components/src/menu-dropdown/menu-dropdown.component.ts
@@ -41,7 +41,7 @@ export class MenuDropdownComponent implements AfterContentInit {
   @ContentChildren(MenuItemComponent)
   public items?: QueryList<MenuItemComponent>;
 
-  public hasItems$: Observable<boolean> = of(false);
+  protected hasItems$: Observable<boolean> = of(false);
 
   public ngAfterContentInit(): void {
     if (this.items) {


### PR DESCRIPTION
## Description
Previously, we were using the length of the query list to determine whether the menu is active. This means if it changes (either from or to zero items, for example when using an ngIf with an async pipe), it won't be updated with on push change detection. Switched to a more robust approach here. 