### PR TITLE
feat: Removing rate sec/min from aggregations

### DIFF
--- a/projects/observability/src/shared/components/explore-query-editor/order-by/explore-query-order-by-editor.component.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/order-by/explore-query-order-by-editor.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 import { TypedSimpleChanges } from '@hypertrace/common';
 import { SelectOption, SelectSearchMode } from '@hypertrace/components';
+import { difference } from 'lodash-es';
 import { combineLatest, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 import { AttributeMetadata } from '../../../graphql/model/metadata/attribute-metadata';
@@ -9,6 +10,7 @@ import { GraphQlSortDirection } from '../../../graphql/model/schema/sort/graphql
 import { TraceType } from '../../../graphql/model/schema/trace';
 import { MetadataService } from '../../../services/metadata/metadata.service';
 import { ExploreOrderBy } from '../explore-visualization-builder';
+
 @Component({
   selector: 'ht-explore-query-order-by-editor',
   styleUrls: ['./explore-query-order-by-editor.component.scss'],
@@ -98,6 +100,10 @@ export class ExploreQueryOrderByEditorComponent implements OnChanges {
   private readonly defaultDirection: GraphQlSortDirection = SortDirection.Asc;
   private readonly incomingOrderByExpressionSubject: Subject<ExploreOrderBy> = new ReplaySubject(1);
   private readonly contextSubject: Subject<TraceType> = new ReplaySubject(1);
+  private readonly notSupportedAggregations: MetricAggregationType[] = [
+    MetricAggregationType.AvgrateSecond,
+    MetricAggregationType.AvgrateMinute
+  ];
 
   public constructor(private readonly metadataService: MetadataService) {
     this.selectedAggregation$ = combineLatest([this.contextSubject, this.incomingOrderByExpressionSubject]).pipe(
@@ -206,6 +212,8 @@ export class ExploreQueryOrderByEditorComponent implements OnChanges {
     }
 
     return this.metadataService.getSelectionAttributes(context).pipe(
+      map(attributes => this.removeNotAllowedAggregations(attributes, this.notSupportedAggregations)),
+      map(attributes => attributes.filter(attribute => attribute.allowedAggregations.length > 0)), // Removes attributes without aggregations
       map(attributes =>
         attributes.map(attribute => ({
           value: attribute,
@@ -213,6 +221,16 @@ export class ExploreQueryOrderByEditorComponent implements OnChanges {
         }))
       )
     );
+  }
+
+  private removeNotAllowedAggregations(
+    attributes: AttributeMetadata[],
+    notSupportedAggregations: MetricAggregationType[]
+  ): AttributeMetadata[] {
+    return attributes.map(attribute => ({
+      ...attribute,
+      allowedAggregations: difference(attribute.allowedAggregations, notSupportedAggregations)
+    }));
   }
 
   private buildOrderExpression(

--- a/projects/observability/src/shared/components/explore-query-editor/order-by/explore-query-order-by-editor.component.ts
+++ b/projects/observability/src/shared/components/explore-query-editor/order-by/explore-query-order-by-editor.component.ts
@@ -100,7 +100,7 @@ export class ExploreQueryOrderByEditorComponent implements OnChanges {
   private readonly defaultDirection: GraphQlSortDirection = SortDirection.Asc;
   private readonly incomingOrderByExpressionSubject: Subject<ExploreOrderBy> = new ReplaySubject(1);
   private readonly contextSubject: Subject<TraceType> = new ReplaySubject(1);
-  private readonly notSupportedAggregations: MetricAggregationType[] = [
+  private readonly redundantOrderingAggregations: MetricAggregationType[] = [
     MetricAggregationType.AvgrateSecond,
     MetricAggregationType.AvgrateMinute
   ];
@@ -212,7 +212,7 @@ export class ExploreQueryOrderByEditorComponent implements OnChanges {
     }
 
     return this.metadataService.getSelectionAttributes(context).pipe(
-      map(attributes => this.removeNotAllowedAggregations(attributes, this.notSupportedAggregations)),
+      map(attributes => this.removeRedundantOrderingAggregations(attributes, this.redundantOrderingAggregations)),
       map(attributes => attributes.filter(attribute => attribute.allowedAggregations.length > 0)), // Removes attributes without aggregations
       map(attributes =>
         attributes.map(attribute => ({
@@ -223,13 +223,13 @@ export class ExploreQueryOrderByEditorComponent implements OnChanges {
     );
   }
 
-  private removeNotAllowedAggregations(
+  private removeRedundantOrderingAggregations(
     attributes: AttributeMetadata[],
-    notSupportedAggregations: MetricAggregationType[]
+    redundantOrderingAggregations: MetricAggregationType[]
   ): AttributeMetadata[] {
     return attributes.map(attribute => ({
       ...attribute,
-      allowedAggregations: difference(attribute.allowedAggregations, notSupportedAggregations)
+      allowedAggregations: difference(attribute.allowedAggregations, redundantOrderingAggregations)
     }));
   }
 


### PR DESCRIPTION
## Description
Removing rate sec/min from Aggregations in Traces.

### Testing
Locally tested

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
