### PR TITLE
fix: two reverts to undo the recent changes to column configs emission in table

### DIFF
--- a/projects/components/src/table/table.component.test.ts
+++ b/projects/components/src/table/table.component.test.ts
@@ -445,34 +445,6 @@ describe('Table component', () => {
     flush();
   }));
 
-  test('should emit correctly on column changes', fakeAsync(() => {
-    const mockColumnConfigsChange = jest.fn();
-    const columns = buildColumns();
-    const spectator = createHost(
-      `<ht-table [columnConfigs]="columnConfigs" [data]="data" [selectionMode]="selectionMode"
-         [mode]="mode" (columnConfigsChange)="mockColumnConfigsChange($event)"></ht-table>`,
-      {
-        hostProps: {
-          columnConfigs: columns,
-          data: buildData(),
-          selectionMode: TableSelectionMode.Multiple,
-          mode: TableMode.Flat,
-          mockColumnConfigsChange: mockColumnConfigsChange
-        }
-      }
-    );
-
-    // Hiding a column
-    spectator.component.onHideColumn(columns[0]);
-    expect(mockColumnConfigsChange).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ ...columns[0], visible: false }),
-        expect.objectContaining({ ...columns[1] })
-      ])
-    );
-    flush();
-  }));
-
   test('should select only selected rows', fakeAsync(() => {
     const columns = buildColumns();
     const rows = buildData();

--- a/projects/components/src/table/table.component.test.ts
+++ b/projects/components/src/table/table.component.test.ts
@@ -464,10 +464,12 @@ describe('Table component', () => {
 
     // Hiding a column
     spectator.component.onHideColumn(columns[0]);
-    expect(mockColumnConfigsChange).toHaveBeenLastCalledWith([
-      expect.objectContaining({ ...columns[0], visible: false }),
-      expect.objectContaining({ ...columns[1] })
-    ]);
+    expect(mockColumnConfigsChange).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ ...columns[0], visible: false }),
+        expect.objectContaining({ ...columns[1] })
+      ])
+    );
     flush();
   }));
 

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -2,8 +2,8 @@
 /* eslint-disable @angular-eslint/component-max-inline-declarations */
 import { ModalService } from '../modal/modal.service';
 import {
-  TableEditColumnsModalComponent,
-  TableEditColumnsModalConfig
+  TableEditColumnsModalConfig,
+  TableEditColumnsModalComponent
 } from './columns/table-edit-columns-modal.component';
 import { CdkHeaderRow } from '@angular/cdk/table';
 import {
@@ -35,7 +35,7 @@ import {
 } from '@hypertrace/common';
 import { isNil, without } from 'lodash-es';
 import { BehaviorSubject, combineLatest, merge, Observable, Subject } from 'rxjs';
-import { filter, map, switchMap, take } from 'rxjs/operators';
+import { switchMap, take, filter, map } from 'rxjs/operators';
 import { FilterAttribute } from '../filtering/filter/filter-attribute';
 import { LoadAsyncConfig } from '../load-async/load-async.service';
 import { PageEvent } from '../paginator/page.event';
@@ -722,7 +722,7 @@ export class TableComponent
     this.initialColumnConfigIdWidthMap = new Map(visibleColumns.map(column => [column.id, column.width ?? -1]));
     this.updateVisibleColumns(visibleColumns);
 
-    this.propagateUpdatedColumns(columnConfigurations);
+    this.columnConfigsSubject.next(columnConfigurations);
   }
 
   private checkColumnWidthCompatibilityOrThrow(width?: TableColumnWidth): void {
@@ -827,7 +827,7 @@ export class TableComponent
     const updatedColumns = this.columnConfigsSubject.value;
     this.updateVisibleColumns(updatedColumns.filter(c => c.visible));
     this.distributeWidthToColumns(TableColumnWidthUtil.getColWidthInPx(column.width));
-    this.propagateUpdatedColumns(updatedColumns);
+    this.columnConfigsSubject.next(updatedColumns);
   }
 
   public showEditColumnsModal(): void {
@@ -911,11 +911,6 @@ export class TableComponent
     }
 
     return this.hasExpandableRows() ? index - 1 : index;
-  }
-
-  private propagateUpdatedColumns(updatedColumns: TableColumnConfigExtended[]): void {
-    this.columnConfigsSubject.next(updatedColumns);
-    this.columnConfigsChange.next(updatedColumns);
   }
 
   private buildColumnConfigExtendeds(columnConfigs: TableColumnConfig[]): TableColumnConfigExtended[] {

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -915,7 +915,7 @@ export class TableComponent
 
   private propagateUpdatedColumns(updatedColumns: TableColumnConfigExtended[]): void {
     this.columnConfigsSubject.next(updatedColumns);
-    this.columnConfigsChange.next(updatedColumns.filter(column => !this.isStateColumn(column)));
+    this.columnConfigsChange.next(updatedColumns);
   }
 
   private buildColumnConfigExtendeds(columnConfigs: TableColumnConfig[]): TableColumnConfigExtended[] {


### PR DESCRIPTION
This reverts commit 1e8d426.
[Please include a summary of the change, motivation and context.](fix: two reverts to undo the recent changes to column configs emission in table)