### PR TITLE
fix: add gql request name support

### DIFF
--- a/projects/graphql-client/src/graphql-config.ts
+++ b/projects/graphql-client/src/graphql-config.ts
@@ -35,6 +35,7 @@ export interface GraphQlMutationHandler<TRequest, TResponse> extends GraphQlHand
 export interface GraphQlRequestOptions {
   cacheability?: GraphQlRequestCacheability;
   isolated?: boolean;
+  name?: string;
 }
 
 export const enum GraphQlRequestCacheability {

--- a/projects/graphql-client/src/graphql-request.service.ts
+++ b/projects/graphql-client/src/graphql-request.service.ts
@@ -145,7 +145,7 @@ export class GraphQlRequestService {
     options: GraphQlRequestOptions
   ): Observable<TResponse> {
     return type === GraphQlHandlerType.Mutation
-      ? this.executeMutation(requestString)
+      ? this.executeMutation(requestString, options)
       : this.executeQuery(requestString, options);
   }
 
@@ -155,7 +155,7 @@ export class GraphQlRequestService {
   ): Observable<TResponse> {
     return this.apollo
       .query<TResponse>({
-        query: gql(requestString),
+        query: gql(`query ${options?.name ?? ''} ${requestString}`),
         errorPolicy: 'all',
         fetchPolicy: options.cacheability
       })
@@ -169,10 +169,13 @@ export class GraphQlRequestService {
       );
   }
 
-  private executeMutation<TResponse extends Dictionary<unknown>>(requestString: string): Observable<TResponse> {
+  private executeMutation<TResponse extends Dictionary<unknown>>(
+    requestString: string,
+    options: GraphQlRequestOptions
+  ): Observable<TResponse> {
     return this.apollo
       .mutate<TResponse>({
-        mutation: gql(`mutation ${requestString}`)
+        mutation: gql(`mutation ${options?.name ?? ''} ${requestString}`)
       })
       .pipe(
         tap(response => {


### PR DESCRIPTION
#### ⚠️ Issue
Currently, we fire a lot of queries of the same type, for example: we may fire up to 10 different entity queries for different use cases. Since we have a number of queries of the same type, debugging becomes difficult for the teams as they have to look for the schema to realize which query is failing and what is the use case.

#### 💡 Solution
Added an optional attribute `name` in the Graphql options which can be used to fire a names query depending upon the use case

`Before`

```ts
query {...}
```

`After`

```ts
query abcd {...}
```