### PR TITLE
feat: improvements to table csv download logic

### DIFF
--- a/projects/components/src/download-file/service/file-download.service.ts
+++ b/projects/components/src/download-file/service/file-download.service.ts
@@ -110,8 +110,10 @@ export class FileDownloadService {
 
 export interface CsvDownloadFileConfig extends FileDownloadBaseConfig<Dictionary<unknown>[]> {
   header?: string[];
-  fileName: `${string}.csv`; // Only csv files allowed here
+  fileName: CsvFileName; // Only csv files allowed here
 }
+
+export type CsvFileName = `${string}.csv`;
 
 export interface FileDownloadBaseConfig<T = string> {
   dataSource: Observable<T>;

--- a/projects/components/src/table/cells/csv-generators/table-cell-timestamp-csv-generator.test.ts
+++ b/projects/components/src/table/cells/csv-generators/table-cell-timestamp-csv-generator.test.ts
@@ -14,10 +14,10 @@ describe('TableCellTimestampCsvGenerator', () => {
     expect(spectator.service.generateSafeCsv(null)).toEqual('-');
 
     expect(spectator.service.generateSafeCsv(new Date('2021-05-25T15:53:27.376Z'))).toEqual(
-      displayDatePipe.transform(new Date('2021-05-25T15:53:27.376Z'), { mode: DateFormatMode.TimeWithSeconds })
+      displayDatePipe.transform(new Date('2021-05-25T15:53:27.376Z'), { mode: DateFormatMode.DateAndTimeWithSeconds })
     );
     expect(spectator.service.generateSafeCsv(1697654315)).toEqual(
-      displayDatePipe.transform(1697654315, { mode: DateFormatMode.TimeWithSeconds })
+      displayDatePipe.transform(1697654315, { mode: DateFormatMode.DateAndTimeWithSeconds })
     );
   });
 });

--- a/projects/components/src/table/cells/csv-generators/table-cell-timestamp-csv-generator.ts
+++ b/projects/components/src/table/cells/csv-generators/table-cell-timestamp-csv-generator.ts
@@ -9,6 +9,6 @@ export class TableCellTimestampCsvGenerator implements TableCellCsvGenerator<Dat
   private readonly displayDate: DisplayDatePipe = new DisplayDatePipe();
 
   public generateSafeCsv(cellData: Date | number | string | null | undefined): string {
-    return this.displayDate.transform(cellData, { mode: DateFormatMode.TimeWithSeconds });
+    return this.displayDate.transform(cellData, { mode: DateFormatMode.DateAndTimeWithSeconds });
   }
 }

--- a/projects/components/src/table/table-csv-downloader.service.test.ts
+++ b/projects/components/src/table/table-csv-downloader.service.test.ts
@@ -20,7 +20,7 @@ describe('TableCsvDownloaderService', () => {
 
   test('execute download should behave as expected for no data', fakeAsync(() => {
     const spectator = createService();
-    spectator.service.executeDownload(of({ rows: [], columnConfigs: [] }), 'table-id');
+    spectator.service.executeDownload(of({ rows: [], columnConfigs: [] }), 'table-id.csv');
 
     tick();
     expect(spectator.inject(NotificationService).createInfoToast).toHaveBeenCalledWith('No data to download');
@@ -40,7 +40,7 @@ describe('TableCsvDownloaderService', () => {
           }
         ] as TableColumnConfigExtended[]
       }),
-      'table-id'
+      'table-id.csv'
     );
     tick();
 

--- a/projects/components/src/table/table-csv-downloader.service.ts
+++ b/projects/components/src/table/table-csv-downloader.service.ts
@@ -17,6 +17,7 @@ export class TableCsvDownloaderService {
     private readonly fileDownloadService: FileDownloadService,
     private readonly notificationService: NotificationService
   ) {}
+
   public triggerDownload(tableId: string): void {
     this.csvDownloadRequestSubject.next(tableId);
   }
@@ -37,8 +38,8 @@ export class TableCsvDownloaderService {
               let rowValue: Dictionary<string | undefined> = {};
               Array.from(csvGeneratorMap.keys()).forEach(columnKey => {
                 const columnConfig: TableColumnConfigExtended = csvGeneratorMap.get(columnKey)!; // Safe to assert since all columns will have a config
-                const value = row[columnKey];
                 const csvGenerator = columnConfig.csvGenerator!; // Safe to assert here since we are processing columns with valid csv generators only
+                const value = row[columnKey];
 
                 const csvContent = csvGenerator.generateSafeCsv(value, row);
 

--- a/projects/components/src/table/table.component.test.ts
+++ b/projects/components/src/table/table.component.test.ts
@@ -762,13 +762,17 @@ describe('Table component', () => {
   test('should trigger csv download as expected if ID matches', fakeAsync(() => {
     const columns = buildColumns();
     const spectator = createHost(
-      '<ht-table id="test-table" [columnConfigs]="columnConfigs" [data]="data" [selectionMode]="selectionMode" [mode]="mode"></ht-table>',
+      '<ht-table id="test-table" [csvDownloadConfig]="csvDownloadConfig" [columnConfigs]="columnConfigs" [data]="data" [selectionMode]="selectionMode" [mode]="mode"></ht-table>',
       {
         hostProps: {
           columnConfigs: columns,
           data: buildData(),
           selectionMode: TableSelectionMode.Single,
-          mode: TableMode.Flat
+          mode: TableMode.Flat,
+          csvDownloadConfig: {
+            limit: 1000,
+            fileName: 'different-name.csv'
+          }
         }
       }
     );
@@ -776,6 +780,10 @@ describe('Table component', () => {
 
     mockDownloadSubject.next('test-table');
     expect(spectator.inject(TableCsvDownloaderService).executeDownload).toHaveBeenCalledTimes(1);
+    expect(spectator.inject(TableCsvDownloaderService).executeDownload).toHaveBeenCalledWith(
+      expect.anything(),
+      'different-name.csv'
+    );
 
     // This should not trigger a download event in this table.
     mockDownloadSubject.next('test-table-no-match');

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -1287,6 +1287,6 @@ interface TableLocalPreferences {
 type PersistedTableColumnConfig = Pick<TableColumnConfig, 'id' | 'visible'>;
 
 export interface TableCsvDownloadConfig {
-  limit: number;
-  filename: CsvFileName;
+  limit?: number;
+  filename?: CsvFileName;
 }

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -682,7 +682,7 @@ export class TableComponent
 
     this.tableCsvDownloaderService.executeDownload(
       downloadConfig$,
-      this.csvDownloadConfig?.filename ?? `table-data-${this.id}-${new Date()}.csv`
+      this.csvDownloadConfig?.fileName ?? `table-data-${this.id}-${new Date()}.csv`
     );
   }
 
@@ -1288,5 +1288,5 @@ type PersistedTableColumnConfig = Pick<TableColumnConfig, 'id' | 'visible'>;
 
 export interface TableCsvDownloadConfig {
   limit?: number;
-  filename?: CsvFileName;
+  fileName?: CsvFileName;
 }

--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -73,6 +73,7 @@ import { DOCUMENT } from '@angular/common';
 import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import { TableColumnWidthUtil } from './util/column-width.util';
 import { TableCsvDownloaderService } from './table-csv-downloader.service';
+import { CsvFileName } from '../download-file/service/file-download.service';
 
 @Component({
   selector: 'ht-table',
@@ -377,6 +378,9 @@ export class TableComponent
   @Input()
   public loadingConfig?: LoadAsyncConfig;
 
+  @Input()
+  public csvDownloadConfig?: TableCsvDownloadConfig;
+
   // TODO: Rename rowHeight to minRowHeight
   @Input()
   public rowHeight: string = '44px';
@@ -665,7 +669,7 @@ export class TableComponent
         (!isNil(this.data)
           ? this.data.getData({
               columns: columnConfigs,
-              position: { limit: 1000, startIndex: 0 },
+              position: { limit: this.csvDownloadConfig?.limit ?? 1000, startIndex: 0 },
               filters: filters ?? []
             })
           : of({ data: [], totalCount: 0 })
@@ -676,7 +680,10 @@ export class TableComponent
       )
     );
 
-    this.tableCsvDownloaderService.executeDownload(downloadConfig$, this.id);
+    this.tableCsvDownloaderService.executeDownload(
+      downloadConfig$,
+      this.csvDownloadConfig?.filename ?? `table-data-${this.id}-${new Date()}.csv`
+    );
   }
 
   private addEventListeners(): void {
@@ -1278,3 +1285,8 @@ interface TableLocalPreferences {
 }
 
 type PersistedTableColumnConfig = Pick<TableColumnConfig, 'id' | 'visible'>;
+
+export interface TableCsvDownloadConfig {
+  limit: number;
+  filename: CsvFileName;
+}

--- a/projects/components/src/table/table.service.ts
+++ b/projects/components/src/table/table.service.ts
@@ -48,7 +48,8 @@ export class TableService {
       const rendererConstructor = this.tableCellRendererLookupService.lookup(
         columnConfig.display !== undefined ? columnConfig.display : CoreTableCellRendererType.Text
       );
-      const csvGenerator = this.tableCellCsvGeneratorManagementService.findMatchingGenerator(columnConfig.display);
+      // Pick up a CSV Generator based on the resolved renderer type
+      const csvGenerator = this.tableCellCsvGeneratorManagementService.findMatchingGenerator(rendererConstructor.type);
 
       const parserConstructor = this.tableCellParserLookupService.lookup(rendererConstructor.parser);
 


### PR DESCRIPTION
## Description
Improvements to table CSV download flow.

1. Add optional input to table for CSV download configs.
2. Use limit from the above for download data query. If limit is unavailable, default to 1000.
3. Use the filename from config. If unavailable, use fallback logic using table ID.
4. For column keys, preference order is column title -> column name -> column id
5. Update timestamp csv generator.