### PR TITLE
fix: explorer builder updates

### DIFF
--- a/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
+++ b/projects/observability/src/pages/explorer/explorer-dashboard-builder.ts
@@ -60,7 +60,7 @@ export class ExplorerDashboardBuilder {
     this.requestSubject.next(request);
   }
 
-  private buildVisualizationDashboard(request: ExploreVisualizationRequest): Observable<ExplorerGeneratedDashboard> {
+  protected buildVisualizationDashboard(request: ExploreVisualizationRequest): Observable<ExplorerGeneratedDashboard> {
     return of({
       json: {
         type: 'cartesian-widget',

--- a/projects/observability/src/shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-cartesian-data-source.model.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/explorer-visualization/explorer-visualization-cartesian-data-source.model.ts
@@ -12,6 +12,7 @@ import { ExploreGraphQlQueryHandlerService } from '../../../../graphql/request/h
 import { GraphQlExploreRequest } from '../../../../graphql/request/handlers/explore/explore-query';
 import { CartesianResult } from '../../../widgets/charts/cartesian-widget/cartesian-widget.model';
 import { ExploreCartesianDataSourceModel, ExplorerData } from '../explore/explore-cartesian-data-source.model';
+
 @Model({
   type: 'explorer-visualization-cartesian-data-source'
 })
@@ -38,6 +39,10 @@ export class ExplorerVisualizationCartesianDataSourceModel extends ExploreCartes
     );
   }
 
+  protected getImplicitFilters(): GraphQlFilter[] {
+    return [];
+  }
+
   protected appendFilters(
     request: Omit<GraphQlExploreRequest, 'timeRange'>,
     filters: GraphQlFilter[],
@@ -46,7 +51,7 @@ export class ExplorerVisualizationCartesianDataSourceModel extends ExploreCartes
     return {
       ...request,
       timeRange: timeRange,
-      filters: [...(request.filters ?? []), ...filters]
+      filters: [...this.getImplicitFilters(), ...(request.filters ?? []), ...filters]
     };
   }
 


### PR DESCRIPTION
## Description
1. Changing scope of visualization build method.
2. Add a new `getImplicitFilters` method in the data source.