### PR TITLE
feat(file-upload): show info toast when diff file type is uploaded

### DIFF
--- a/projects/components/src/file-upload/file-upload.component.test.ts
+++ b/projects/components/src/file-upload/file-upload.component.test.ts
@@ -92,9 +92,9 @@ describe('File Upload Component', () => {
     });
     const filesAddedSpy = jest.spyOn(spectator.component.filesAdded, 'emit');
     spectator.triggerEventHandler('input', 'change', { target: { files: fileList } });
-    expect(filesAddedSpy).not.toHaveBeenCalled();
-    expect(spectator.inject(NotificationService).createFailureToast).toHaveBeenCalledWith(
-      `File type should be any of ${config.supportedFileTypes.join(', ')}`
+    expect(filesAddedSpy).toHaveBeenCalled();
+    expect(spectator.inject(NotificationService).createInfoToast).toHaveBeenCalledWith(
+      `Make sure to choose file of type ${config.supportedFileTypes.join(', ')}`
     );
   });
 

--- a/projects/components/src/file-upload/file-upload.component.ts
+++ b/projects/components/src/file-upload/file-upload.component.ts
@@ -135,16 +135,22 @@ export class FileUploadComponent {
       return false;
     }
 
-    if (!this.areFileTypesValid(fileList)) {
-      this.showFileTypeErrorToast();
-
-      return false;
-    }
-
     if (this.areFilesEmpty(fileList)) {
       this.showEmptyFilesErrorToast();
 
       return false;
+    }
+
+    /**
+     * It's not advised to rely on mime based validation as there is limitations.
+     * So we use an info toast rather than stopping the flow.
+     *
+     * @see - https://developer.mozilla.org/en-US/docs/Web/API/File/type#result
+     */
+    if (!this.areFileTypesValid(fileList)) {
+      this.showFileTypeInfoToast();
+
+      return true;
     }
 
     return true;
@@ -177,9 +183,9 @@ export class FileUploadComponent {
     this.notificationService.createFailureToast(`File should not be empty`);
   }
 
-  private showFileTypeErrorToast(): void {
-    this.notificationService.createFailureToast(
-      `File type should be any of ${this.config.supportedFileTypes.join(', ')}`
+  private showFileTypeInfoToast(): void {
+    this.notificationService.createInfoToast(
+      `Make sure to choose file of type ${this.config.supportedFileTypes.join(', ')}`
     );
   }
 


### PR DESCRIPTION
File type validation in the browser is not reliable. So instead of stopping the flow, we show an **Info** toast and let the user proceed.