### PR TITLE
fix: export method from time range service

### DIFF
--- a/projects/common/src/time/time-range.service.ts
+++ b/projects/common/src/time/time-range.service.ts
@@ -99,7 +99,7 @@ export class TimeRangeService {
     );
   }
 
-  private timeRangeFromUrlString(timeRangeFromUrl: string): TimeRange {
+  public timeRangeFromUrlString(timeRangeFromUrl: string): TimeRange {
     const duration = this.timeDurationService.durationFromString(timeRangeFromUrl);
     if (duration) {
       return new RelativeTimeRange(duration);


### PR DESCRIPTION
exported `timeRangeFromUrlString` method