### PR TITLE
fix: fixing attribute's subpath starting with colon

### DIFF
--- a/projects/components/src/filtering/filter/parser/parsed-filter.ts
+++ b/projects/components/src/filtering/filter/parser/parsed-filter.ts
@@ -77,7 +77,7 @@ export const tryParseStringForAttribute = (
     }
     const potentialSubpath = stringAfterAttributeName.slice(MAP_LHS_DELIMITER.length);
     // Subpaths support alphanumeric, -, - and . characters
-    const firstNonSubpathCharacterIndex = potentialSubpath.search(/[^\w\-\.]/);
+    const firstNonSubpathCharacterIndex = potentialSubpath.search(/[^\w\-\.\:]/);
     const subpath =
       firstNonSubpathCharacterIndex === -1
         ? potentialSubpath

--- a/projects/components/src/filtering/filter/parser/parsed-filter.ts
+++ b/projects/components/src/filtering/filter/parser/parsed-filter.ts
@@ -76,8 +76,8 @@ export const tryParseStringForAttribute = (
       return undefined;
     }
     const potentialSubpath = stringAfterAttributeName.slice(MAP_LHS_DELIMITER.length);
-    // Subpaths support alphanumeric, -, - and . characters
-    const firstNonSubpathCharacterIndex = potentialSubpath.search(/[^\w\-\.\:]/);
+    // Subpaths support alphanumeric, -, _ , . and : characters
+    const firstNonSubpathCharacterIndex = potentialSubpath.search(/[^\w\-\_\.\:]/);
     const subpath =
       firstNonSubpathCharacterIndex === -1
         ? potentialSubpath


### PR DESCRIPTION
## Description
Fixing Attribute's subpath when they start with colon

Example: `Request Headers.:example`

### Testing
Locally tested

### Checklist:
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
