### PR TITLE
Fix: Paginator positioning and alignment for full page tables isn't correct

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -89,7 +89,6 @@ import { CsvFileName } from '../download-file/service/file-download.service';
         [dataSource]="this.dataSource"
         [ngClass]="[
           this.display,
-          this.pageable && this.isTableFullPage ? 'bottom-margin' : '',
           !this.showFloatingPaginator ? 'table' : ''
         ]"
         cdkDropList
@@ -262,7 +261,7 @@ import { CsvFileName } from '../download-file/service/file-download.service';
       <div
         class="pagination-controls"
         *ngIf="this.pageable"
-        [style.position]="!this.showFloatingPaginator ? (this.isTableFullPage ? 'fixed' : 'sticky') : ''"
+        [style.position]="!this.showFloatingPaginator ? 'sticky' : ''"
       >
         <ht-paginator
           *htLetAsync="this.currentPage$ as pagination"


### PR DESCRIPTION
## Description

Pagination element for full page tables was positioned as `fixed`. Which meant if the `width` was set to `100%`, it will take the width of the viewport and not the width of the parent table.

This leads to the positioning of the element being incorrect as well as alignment being off.

Solution is to make the pagination element `position: sticky`, that way `width: 100%` takes the width of the parent table and not the viewport.

This does mean that full page tables and embedded tables are now not different in terms of pagination.

### Testing
I tested a few configurations of tables manually, as well as ran unit tests to make sure nothing is breaking with the change.
