### PR TITLE
Fix: Request should be cloned when caching table data

### DIFF
--- a/projects/components/src/table/data/table-cdk-data-source.ts
+++ b/projects/components/src/table/data/table-cdk-data-source.ts
@@ -1,6 +1,6 @@
 import { DataSource } from '@angular/cdk/collections';
 import { Dictionary, forkJoinSafeEmpty, isEqualIgnoreFunctions, RequireBy, sortUnknown } from '@hypertrace/common';
-import { isEqual, isNil } from 'lodash-es';
+import { cloneDeep, isEqual, isNil } from 'lodash-es';
 import { BehaviorSubject, combineLatest, NEVER, Observable, of, Subject, Subscription, throwError } from 'rxjs';
 import { catchError, debounceTime, map, mergeMap, startWith, switchMap, tap } from 'rxjs/operators';
 import { PageEvent } from '../../paginator/page.event';
@@ -92,7 +92,7 @@ export class TableCdkDataSource implements DataSource<TableRow> {
 
   private cacheNewData(total: number, rows: StatefulTableRow[], request?: TableDataRequest): void {
     this.cachedData = {
-      request: request,
+      request: cloneDeep(request),
       rows: rows.map(TableCdkRowUtil.cloneRow),
       total: total,
     };


### PR DESCRIPTION
## Description
When storing the request object in the cache for the table, only the reference was being assigned to the cache for the column config. So, the new request object and the cached request object would always have the same column config even after it is updated leading to new data not being fetch when the column config changes.

Now, made the change so a deep copy of the request is created when caching.

This fixes the issue where new data was not being fetched when sort state changes in the column config.