### PR TITLE
Fix: Separate collapsable and search history behaviour

### DIFF
--- a/projects/components/src/search-box/search-box.component.scss
+++ b/projects/components/src/search-box/search-box.component.scss
@@ -31,7 +31,7 @@
     }
   }
 
-  &.with-search-history {
+  &.collapsable {
     width: 48px;
 
     .input {

--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -155,26 +155,45 @@ describe('Search box Component', () => {
     flush();
   }));
 
-  test('collapsable enabled should add collapsable class', fakeAsync(() => {
+  test('collapsable enabled should add collapsable class', () => {
     spectator = createHost(
-      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="true"></ht-search-box>`,
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="collapsable"></ht-search-box>`,
       {
         hostProps: {
           placeholder: 'Test Placeholder',
           debounceTime: 200,
           searchMode: SearchBoxEmitMode.Incremental,
           enableSearchHistory: true,
+          collapsable: true,
         },
       },
     );
 
     const searchBoxELement = spectator.query('.ht-search-box')!;
     expect(searchBoxELement).toHaveClass('collapsable');
-  }));
+  });
 
-  test('collapsable disabled should not add collapsable class', fakeAsync(() => {
+  test('collapsable disabled should not add collapsable class', () => {
     spectator = createHost(
-      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="false"></ht-search-box>`,
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="collapsable"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          debounceTime: 200,
+          searchMode: SearchBoxEmitMode.Incremental,
+          enableSearchHistory: true,
+          collapsable: false,
+        },
+      },
+    );
+
+    const searchBoxELement = spectator.query('.ht-search-box')!;
+    expect(searchBoxELement).not.toHaveClass('collapsable');
+  });
+
+  test('default collapsable behaviour should not add collapsable class', () => {
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory"></ht-search-box>`,
       {
         hostProps: {
           placeholder: 'Test Placeholder',
@@ -187,5 +206,5 @@ describe('Search box Component', () => {
 
     const searchBoxELement = spectator.query('.ht-search-box')!;
     expect(searchBoxELement).not.toHaveClass('collapsable');
-  }));
+  });
 });

--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -133,7 +133,6 @@ describe('Search box Component', () => {
     );
 
     const searchBoxELement = spectator.query('.ht-search-box')!;
-    expect(searchBoxELement).toHaveClass('with-search-history');
     expect(searchBoxELement).not.toHaveClass('has-value');
     expect(searchBoxELement).not.toHaveClass('focused');
 

--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -154,4 +154,38 @@ describe('Search box Component', () => {
 
     flush();
   }));
+
+  test('collapsable enabled should add collapsable class', fakeAsync(() => {
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="true"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          debounceTime: 200,
+          searchMode: SearchBoxEmitMode.Incremental,
+          enableSearchHistory: true,
+        },
+      },
+    );
+
+    const searchBoxELement = spectator.query('.ht-search-box')!;
+    expect(searchBoxELement).toHaveClass('collapsable');
+  }));
+
+  test('collapsable disabled should not add collapsable class', fakeAsync(() => {
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="false"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          debounceTime: 200,
+          searchMode: SearchBoxEmitMode.Incremental,
+          enableSearchHistory: true,
+        },
+      },
+    );
+
+    const searchBoxELement = spectator.query('.ht-search-box')!;
+    expect(searchBoxELement).not.toHaveClass('collapsable');
+  }));
 });

--- a/projects/components/src/search-box/search-box.component.ts
+++ b/projects/components/src/search-box/search-box.component.ts
@@ -38,7 +38,6 @@ import { isEmpty, uniq } from 'lodash-es';
       class="ht-search-box"
       [ngClass]="this.displayMode"
       [class.focused]="this.isFocused"
-      [class.with-search-history]="this.enableSearchHistory"
       [class.collapsable]="this.collapsable"
       [class.has-value]="!(this.value | htIsEmpty)"
     >

--- a/projects/components/src/search-box/search-box.component.ts
+++ b/projects/components/src/search-box/search-box.component.ts
@@ -39,6 +39,7 @@ import { isEmpty, uniq } from 'lodash-es';
       [ngClass]="this.displayMode"
       [class.focused]="this.isFocused"
       [class.with-search-history]="this.enableSearchHistory"
+      [class.collapsable]="this.collapsable"
       [class.has-value]="!(this.value | htIsEmpty)"
     >
       <ht-icon
@@ -112,6 +113,9 @@ export class SearchBoxComponent implements OnInit, OnChanges {
 
   @Input()
   public enableSearchHistory: boolean = false; // Experimental
+
+  @Input()
+  public collapsable: boolean = false;
 
   @Output()
   public readonly valueChange: EventEmitter<string> = new EventEmitter();


### PR DESCRIPTION
## Description
The collapsable behaviour of the search box was tied to whether search history was enabled or not.

Now added a separate input `collapsable` which can be set to `true` to make the search box collapsable and vice versa.

Search history is now independent of this.
