### PR TITLE
Feat: Provide external loading triggers

### DIFF
--- a/projects/components/src/search-box/search-box.component.scss
+++ b/projects/components/src/search-box/search-box.component.scss
@@ -31,7 +31,7 @@
     }
   }
 
-  &.with-search-history {
+  &.collapsable {
     width: 48px;
 
     .input {

--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -155,26 +155,45 @@ describe('Search box Component', () => {
     flush();
   }));
 
-  test('collapsable enabled should add collapsable class', fakeAsync(() => {
+  test('collapsable enabled should add collapsable class', () => {
     spectator = createHost(
-      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="true"></ht-search-box>`,
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="collapsable"></ht-search-box>`,
       {
         hostProps: {
           placeholder: 'Test Placeholder',
           debounceTime: 200,
           searchMode: SearchBoxEmitMode.Incremental,
           enableSearchHistory: true,
+          collapsable: true,
         },
       },
     );
 
     const searchBoxELement = spectator.query('.ht-search-box')!;
     expect(searchBoxELement).toHaveClass('collapsable');
-  }));
+  });
 
-  test('collapsable disabled should not add collapsable class', fakeAsync(() => {
+  test('collapsable disabled should not add collapsable class', () => {
     spectator = createHost(
-      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="false"></ht-search-box>`,
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="collapsable"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          debounceTime: 200,
+          searchMode: SearchBoxEmitMode.Incremental,
+          enableSearchHistory: true,
+          collapsable: false,
+        },
+      },
+    );
+
+    const searchBoxELement = spectator.query('.ht-search-box')!;
+    expect(searchBoxELement).not.toHaveClass('collapsable');
+  });
+
+  test('default collapsable behaviour should not add collapsable class', () => {
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory"></ht-search-box>`,
       {
         hostProps: {
           placeholder: 'Test Placeholder',
@@ -187,5 +206,5 @@ describe('Search box Component', () => {
 
     const searchBoxELement = spectator.query('.ht-search-box')!;
     expect(searchBoxELement).not.toHaveClass('collapsable');
-  }));
+  });
 });

--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -133,7 +133,6 @@ describe('Search box Component', () => {
     );
 
     const searchBoxELement = spectator.query('.ht-search-box')!;
-    expect(searchBoxELement).toHaveClass('with-search-history');
     expect(searchBoxELement).not.toHaveClass('has-value');
     expect(searchBoxELement).not.toHaveClass('focused');
 

--- a/projects/components/src/search-box/search-box.component.test.ts
+++ b/projects/components/src/search-box/search-box.component.test.ts
@@ -154,4 +154,38 @@ describe('Search box Component', () => {
 
     flush();
   }));
+
+  test('collapsable enabled should add collapsable class', fakeAsync(() => {
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="true"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          debounceTime: 200,
+          searchMode: SearchBoxEmitMode.Incremental,
+          enableSearchHistory: true,
+        },
+      },
+    );
+
+    const searchBoxELement = spectator.query('.ht-search-box')!;
+    expect(searchBoxELement).toHaveClass('collapsable');
+  }));
+
+  test('collapsable disabled should not add collapsable class', fakeAsync(() => {
+    spectator = createHost(
+      `<ht-search-box [placeholder]="placeholder" [debounceTime]="debounceTime" [searchMode]="searchMode" [enableSearchHistory]="enableSearchHistory" [collapsable]="false"></ht-search-box>`,
+      {
+        hostProps: {
+          placeholder: 'Test Placeholder',
+          debounceTime: 200,
+          searchMode: SearchBoxEmitMode.Incremental,
+          enableSearchHistory: true,
+        },
+      },
+    );
+
+    const searchBoxELement = spectator.query('.ht-search-box')!;
+    expect(searchBoxELement).not.toHaveClass('collapsable');
+  }));
 });

--- a/projects/components/src/search-box/search-box.component.ts
+++ b/projects/components/src/search-box/search-box.component.ts
@@ -38,7 +38,6 @@ import { isEmpty, uniq } from 'lodash-es';
       class="ht-search-box"
       [ngClass]="this.displayMode"
       [class.focused]="this.isFocused"
-      [class.with-search-history]="this.enableSearchHistory"
       [class.collapsable]="this.collapsable"
       [class.has-value]="!(this.value | htIsEmpty)"
     >

--- a/projects/components/src/search-box/search-box.component.ts
+++ b/projects/components/src/search-box/search-box.component.ts
@@ -39,6 +39,7 @@ import { isEmpty, uniq } from 'lodash-es';
       [ngClass]="this.displayMode"
       [class.focused]="this.isFocused"
       [class.with-search-history]="this.enableSearchHistory"
+      [class.collapsable]="this.collapsable"
       [class.has-value]="!(this.value | htIsEmpty)"
     >
       <ht-icon
@@ -112,6 +113,9 @@ export class SearchBoxComponent implements OnInit, OnChanges {
 
   @Input()
   public enableSearchHistory: boolean = false; // Experimental
+
+  @Input()
+  public collapsable: boolean = false;
 
   @Output()
   public readonly valueChange: EventEmitter<string> = new EventEmitter();

--- a/projects/components/src/table/data/table-cdk-data-source.ts
+++ b/projects/components/src/table/data/table-cdk-data-source.ts
@@ -56,6 +56,10 @@ export class TableCdkDataSource implements DataSource<TableRow> {
    ****************************/
 
   public connect(): Observable<ReadonlyArray<TableRow>> {
+    const loadingTrigger = this.tableDataSourceProvider.data?.loadingTrigger;
+
+    loadingTrigger?.subscribe(() => this.loadingStateSubject.next({ loading$: NEVER }));
+
     this.changeSubscription = this.buildChangeObservable()
       .pipe(
         tap(() => this.loadingStateSubject.next({ loading$: NEVER })),

--- a/projects/components/src/table/data/table-data-source.ts
+++ b/projects/components/src/table/data/table-data-source.ts
@@ -4,6 +4,7 @@ import { TableColumnConfig, TableFilter, TableSortDirection } from '../table-api
 export interface TableDataSource<TResult, TCol extends TableColumnConfig = TableColumnConfig> {
   getData(request: TableDataRequest<TCol>): Observable<TableDataResponse<TResult>>;
   getScope?(): string | undefined;
+  loadingTrigger?: Observable<unknown>;
 }
 
 export interface TableDataRequest<TCol extends TableColumnConfig = TableColumnConfig> {


### PR DESCRIPTION
## Description

Any changes that were external to the table that would trigger a new data fetch, couldn't be accounted for when displaying the loading state in the table. Also, since the data source is external and a stream, it is not possible for the table to know when a new data fetch might have been triggered.

So, added `loadingTrigger: Observable` to the `TableDataSource` as an optional field, which can be provided by the user which should emit whenever a change happens that will trigger a new data fetch.

This will require the user to provide the trigger but I couldn't find any other way for the table to know by itself if a new data fetch is going to be triggered.
