### PR TITLE
fix: topology data source updates

### DIFF
--- a/projects/observability/src/shared/dashboard/data/graphql/topology/topology-data-source.model.test.ts
+++ b/projects/observability/src/shared/dashboard/data/graphql/topology/topology-data-source.model.test.ts
@@ -115,6 +115,7 @@ describe('topology data source model', () => {
         metricSpecifications: [
           expect.objectContaining({ metric: 'numCalls', aggregation: MetricAggregationType.Average }),
         ],
+        otherSpecifications: [],
       },
       rootNodeFilters: [],
       edgeFilters: [],
@@ -128,6 +129,7 @@ describe('topology data source model', () => {
             metricSpecifications: [
               expect.objectContaining({ metric: 'numCalls', aggregation: MetricAggregationType.Average }),
             ],
+            otherSpecifications: [],
           },
         ],
         [
@@ -137,6 +139,7 @@ describe('topology data source model', () => {
             metricSpecifications: [
               expect.objectContaining({ metric: 'numCalls', aggregation: MetricAggregationType.Average }),
             ],
+            otherSpecifications: [],
           },
         ],
       ]),
@@ -148,6 +151,7 @@ describe('topology data source model', () => {
             metricSpecifications: [
               expect.objectContaining({ metric: 'numCalls', aggregation: MetricAggregationType.Average }),
             ],
+            otherSpecifications: [],
           },
         ],
       ]),
@@ -173,6 +177,7 @@ describe('topology data source model', () => {
         metricSpecifications: [
           expect.objectContaining({ metric: 'numCalls', aggregation: MetricAggregationType.Average }),
         ],
+        otherSpecifications: [],
       },
       rootNodeFilters: [filters[0]],
       edgeFilters: [filters[1]],
@@ -186,6 +191,7 @@ describe('topology data source model', () => {
             metricSpecifications: [
               expect.objectContaining({ metric: 'numCalls', aggregation: MetricAggregationType.Average }),
             ],
+            otherSpecifications: [],
           },
         ],
       ]),


### PR DESCRIPTION
1. Provide a way to pass entity-specific edge and node specifications to the topology