### PR TITLE
fix(time-duration): Time Duration Most Significant adjusted to not have approax value

### DIFF
--- a/projects/common/src/time/time-duration.test.ts
+++ b/projects/common/src/time/time-duration.test.ts
@@ -80,6 +80,24 @@ describe('Time duration', () => {
     expect(new TimeDuration(0, TimeUnit.Millisecond).getMostSignificantUnitOnly()).toEqual(
       new TimeDuration(0, TimeUnit.Millisecond),
     );
+
+    expect(
+      new TimeDuration(365 * 24 * 60 * 60 * 1000, TimeUnit.Millisecond).getMostSignificantUnitOnly(
+        TimeUnit.Year,
+        false,
+      ),
+    ).toEqual(new TimeDuration(1, TimeUnit.Year));
+
+    expect(
+      new TimeDuration(364 * 24 * 60 * 60 * 1000, TimeUnit.Millisecond).getMostSignificantUnitOnly(
+        TimeUnit.Year,
+        false,
+      ),
+    ).toEqual(new TimeDuration(52, TimeUnit.Week));
+
+    expect(
+      new TimeDuration(44 * 60 * 60 * 1000, TimeUnit.Millisecond).getMostSignificantUnitOnly(TimeUnit.Hour, false),
+    ).toEqual(new TimeDuration(44, TimeUnit.Hour));
   });
 
   test('can parse ISO 8601 duration string', () => {

--- a/projects/common/src/time/time-duration.ts
+++ b/projects/common/src/time/time-duration.ts
@@ -63,12 +63,17 @@ export class TimeDuration {
     return unitStringType === UnitStringType.Short ? this.toString() : this.toLongString();
   }
 
-  public getMostSignificantUnitOnly(maxSupportedUnit?: TimeUnit): TimeDuration {
+  public getMostSignificantUnitOnly(maxSupportedUnit?: TimeUnit, allowApproxUnit: boolean = true): TimeDuration {
     let orderedUnits: ConvertibleTimeUnit[] = isNil(maxSupportedUnit)
       ? TimeDuration.TIME_UNITS
       : TimeDuration.TIME_UNITS.slice(indexOf(TimeDuration.TIME_UNITS, maxSupportedUnit));
 
-    const firstApplicableUnit = orderedUnits.find(unit => this.getAmountForUnit(unit) >= 1) || TimeUnit.Millisecond;
+    const firstApplicableUnit =
+      orderedUnits.find(unit => {
+        const selectedUnitValue = this.getAmountForUnit(unit);
+
+        return allowApproxUnit ? selectedUnitValue >= 1 : selectedUnitValue >= 1 && Number.isInteger(selectedUnitValue);
+      }) || TimeUnit.Millisecond;
     const amountForUnit = Math.floor(this.getAmountForUnit(firstApplicableUnit));
 
     return new TimeDuration(amountForUnit, firstApplicableUnit);


### PR DESCRIPTION


## Description
Problem: On Providing an input like 44H, the output is 1 day.
Fix: Added an allowApproxUnit flag which on false keeps on checking the for time unit which is not approximate.

### Checklist:
- ✅ My changes generate no new warnings
- ✅ I have added tests that prove my fix is effective or that my feature works
- ✅  Any dependent changes have been merged and published in downstream modules


