### PR TITLE
Fix: Added scroll strategy for overlay

### DIFF
--- a/projects/components/src/popover/popover.service.ts
+++ b/projects/components/src/popover/popover.service.ts
@@ -26,6 +26,7 @@ export class PopoverService {
       positionStrategy: initialPositionStrategy,
       hasBackdrop: this.hasBackdrop(options.backdrop),
       backdropClass: this.getBackdropClass(options.backdrop),
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
     });
 
     const popoverRef = new PopoverRef(overlayRef, this.positionBuilder, this.navigationService);

--- a/projects/observability/src/shared/dashboard/dashboard-wrapper/application-aware-dashboard.component.ts
+++ b/projects/observability/src/shared/dashboard/dashboard-wrapper/application-aware-dashboard.component.ts
@@ -11,7 +11,7 @@ import { GraphQlFilterDataSourceModel } from '../data/graphql/filter/graphql-fil
   styleUrls: ['./application-aware-dashboard.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="application-aware-dashboard" [style.padding.px]="this.padding">
+    <div class="application-aware-dashboard" [style.padding.px]="this.padding" cdk-scrollable>
       <hda-dashboard
         *ngIf="this.json"
         [json]="this.json"

--- a/projects/observability/src/shared/dashboard/dashboard-wrapper/navigable-dashboard.module.ts
+++ b/projects/observability/src/shared/dashboard/dashboard-wrapper/navigable-dashboard.module.ts
@@ -6,11 +6,12 @@ import { ModelJson } from '@hypertrace/hyperdash';
 import { DashboardCoreModule, DashboardEditorModule } from '@hypertrace/hyperdash-angular';
 import { ApplicationAwareDashboardComponent } from './application-aware-dashboard.component';
 import { NavigableDashboardComponent } from './navigable-dashboard.component';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 const DEFAULT_DASHBOARDS = new InjectionToken<DashboardDefaultConfiguration[]>('DEFAULT_DASHBOARDS');
 
 @NgModule({
-  imports: [CommonModule, DashboardCoreModule, DashboardEditorModule, LoadAsyncModule, FilterBarModule],
+  imports: [CommonModule, DashboardCoreModule, DashboardEditorModule, LoadAsyncModule, FilterBarModule, ScrollingModule],
   declarations: [ApplicationAwareDashboardComponent, NavigableDashboardComponent],
   providers: [{ provide: DEFAULT_DASHBOARDS, useValue: [], multi: true }],
   exports: [ApplicationAwareDashboardComponent, NavigableDashboardComponent],

--- a/projects/observability/src/shared/dashboard/dashboard-wrapper/navigable-dashboard.module.ts
+++ b/projects/observability/src/shared/dashboard/dashboard-wrapper/navigable-dashboard.module.ts
@@ -11,7 +11,14 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
 const DEFAULT_DASHBOARDS = new InjectionToken<DashboardDefaultConfiguration[]>('DEFAULT_DASHBOARDS');
 
 @NgModule({
-  imports: [CommonModule, DashboardCoreModule, DashboardEditorModule, LoadAsyncModule, FilterBarModule, ScrollingModule],
+  imports: [
+    CommonModule,
+    DashboardCoreModule,
+    DashboardEditorModule,
+    LoadAsyncModule,
+    FilterBarModule,
+    ScrollingModule,
+  ],
   declarations: [ApplicationAwareDashboardComponent, NavigableDashboardComponent],
   providers: [{ provide: DEFAULT_DASHBOARDS, useValue: [], multi: true }],
   exports: [ApplicationAwareDashboardComponent, NavigableDashboardComponent],


### PR DESCRIPTION
## Description
Added `scrollStrategy` to overlay to reposition the overlay while scrolling. This makes the overlay stick to the position on the page and scrolls along with the rest of the page.

This would only work if the `cdk-scrollable` directive is used on the container that is being scrolled through.

So, its not a universal solution, but `cdk-scrollable` needs to be added to any containers that have overlays that are facing this issue.
