### PR TITLE
fix: add `clickOnRowToSelect` option to table

### DIFF
--- a/projects/components/src/table/table.component.ts
+++ b/projects/components/src/table/table.component.ts
@@ -343,6 +343,9 @@ export class TableComponent
   public selectionMode?: TableSelectionMode = TableSelectionMode.Single;
 
   @Input()
+  public clickOnRowToSelect?: boolean = true;
+
+  @Input()
   public title?: string;
 
   @Input()
@@ -975,7 +978,9 @@ export class TableComponent
 
   public onDataRowClick(row: StatefulTableRow): void {
     this.rowClicked.emit(row);
-    this.toggleRowSelected(row);
+    if (this.clickOnRowToSelect) {
+      this.toggleRowSelected(row);
+    }
   }
 
   public onDataRowMouseEnter(row: StatefulTableRow): void {


### PR DESCRIPTION
## Description
With various usecases of table, it is not always required to select a row when its clicked on. There are usecases that just needs some action to be done on a row click instead of toggling its selection status.

To enable this, this PR introduces a boolean control in the table component.

### Testing
Tested manually. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules